### PR TITLE
Adds OpenAPI JSON Schema Generator Implementation

### DIFF
--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -361,6 +361,13 @@
         name: jsonschema-rs
       license: MIT
       last-updated: "2022-08-31"
+    - name: OpenAPI JSON Schema Generator
+      notes: Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. JSON schema validation run when validating schemas.
+      url: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator
+      date-draft: [2020-12]
+      draft: [5]
+      license: Apache-2.0
+      last-updated: "2023-09-28"
 - name: Ruby
   implementations:
     - name: JSONSchemer

--- a/pages/implementations/main.md
+++ b/pages/implementations/main.md
@@ -114,6 +114,7 @@ are the only keywords that changed.
 -   Python
   -  [yacg](https://github.com/OkieOth/yacg) (MIT) - parse JSON Schema and OpenApi files to build a meta model from them. This meta model can be used in Mako templates to generate source code, other schemas or plantUml.
   -  [statham](https://github.com/jacksmith15/statham-schema) (MIT) - generate type-annotated models from JSON Schema documents.
+  -  [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator) (Apache-2.0) - Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. This project focuses on making the output 100% compliant with openapi + JSON schema specs.
 -   Rust
   -  [schemafy](https://github.com/Marwes/schemafy/) - generates Rust types and serialization code from a JSON schema. *supports Draft 4*
 -   Scala


### PR DESCRIPTION
Adds OpenAPI JSON Schema Generator Implementation
The project implements the majority of the draft 2020-12 json schema keywords per [the latest release](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/3.1.0) which runs the json schema test suite for verification