### PR TITLE
Add an initial version of a page on common interfaces.

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -255,6 +255,7 @@ export const DocsNav = () => {
             </div>
             <DocLink uri='/understanding-json-schema/structuring' label='Structuring a complex schema' />
           </div>
+          <DocLink uri='/learn/interfaces' label='Common Interfaces Across Implementations' />
         </div>
       </div>
       {/* Specification */}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -67,8 +67,7 @@ const getReferencePath = [
   '/understanding-json-schema/reference/type',
   '/understanding-json-schema/reference/generic',  
   '/understanding-json-schema/reference',
-  '/learn/glossary',
-  '/learn/interfaces'
+  '/learn/glossary'
 ]
 const getSpecificationPath = [
   '/draft/2020-12/release-notes',
@@ -81,6 +80,11 @@ const getSpecificationPath = [
   '/specification-links',
   '/specification'
 ]
+
+const getImplementersPath = [
+  '/implementers/interfaces'
+]
+
 export const SidebarLayout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter()
   const [open, setOpen] = useState(false)
@@ -135,6 +139,7 @@ export const DocsNav = () => {
     getDocs: false,
     getStarted: false,
     getReference: false,
+    getImplementers: false,
     getSpecification: false,
   })
   useEffect(() => {
@@ -146,6 +151,8 @@ export const DocsNav = () => {
       setActive({ ...active, getReference: true })
     } else if (getSpecificationPath.includes(router.asPath)) {
       setActive({ ...active, getSpecification: true })
+    } else if (getImplementersPath.includes(router.asPath)) {
+      setActive({ ...active, getImplementers: true })
     }
   }, [router.asPath])
 
@@ -161,6 +168,10 @@ export const DocsNav = () => {
     setActive({ ...active, getReference: !active.getReference })
   }
 
+  const handleClickImplementers = () => {
+    setActive({ ...active, getImplementers: !active.getImplementers })
+  }
+
   const handleClickSpec = () => {
     setActive({ ...active, getSpecification: !active.getSpecification })
   }
@@ -168,6 +179,7 @@ export const DocsNav = () => {
   const rotate = active.getDocs ? 'rotate(180deg)' : 'rotate(0)'
   const rotateG = active.getStarted ? 'rotate(180deg)' : 'rotate(0)'
   const rotateR = active.getReference ? 'rotate(180deg)' : 'rotate(0)'
+  const rotateI = active.getImplementers ? 'rotate(180deg)' : 'rotate(0)'
   const rotateSpec = active.getSpecification ? 'rotate(180deg)' : 'rotate(0)'
 
   return (
@@ -256,10 +268,21 @@ export const DocsNav = () => {
             </div>
             <DocLink uri='/understanding-json-schema/structuring' label='Structuring a complex schema' />
           </div>
-          <SegmentSubtitle label='Implementations' />
-          <div className='pl-4 pb-1 pt-1'>
-            <DocLink uri='/learn/interfaces' label='Common Interfaces Across Implementations' />
+        </div>
+      </div>
+      <div className='mb-2 bg-slate-200 p-2 rounded'>
+        <div className='flex justify-between w-full items-center' onClick={handleClickImplementers} >
+          <div className='flex  items-center align-middle'>
+            <img src='/icons/book.svg' alt='eye icon' className='mr-2' />
+            <SegmentHeadline label='Implementers' />
           </div>
+          <svg style={{ transform: rotateI, transition: 'all 0.2s linear' }} id='arrow' xmlns='http://www.w3.org/2000/svg' fill='none' height='32' viewBox='0 0 24 24' width='24'><path clipRule='evenodd' d='m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z' fill='#707070' fillRule='evenodd' /></svg>
+        </div>
+        <div
+          className={classnames( 'ml-6', { 'hidden': !active.getImplementers })}
+          id='implementers'
+        >
+          <DocLink uri='/implementers/interfaces' label='Common Interfaces Across Implementations' />
         </div>
       </div>
       {/* Specification */}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -67,7 +67,8 @@ const getReferencePath = [
   '/understanding-json-schema/reference/type',
   '/understanding-json-schema/reference/generic',  
   '/understanding-json-schema/reference',
-  '/learn/glossary'
+  '/learn/glossary',
+  '/learn/interfaces'
 ]
 const getSpecificationPath = [
   '/draft/2020-12/release-notes',
@@ -255,7 +256,10 @@ export const DocsNav = () => {
             </div>
             <DocLink uri='/understanding-json-schema/structuring' label='Structuring a complex schema' />
           </div>
-          <DocLink uri='/learn/interfaces' label='Common Interfaces Across Implementations' />
+          <SegmentSubtitle label='Implementations' />
+          <div className='pl-4 pb-1 pt-1'>
+            <DocLink uri='/learn/interfaces' label='Common Interfaces Across Implementations' />
+          </div>
         </div>
       </div>
       {/* Specification */}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -67,7 +67,8 @@ const getReferencePath = [
   '/understanding-json-schema/reference/type',
   '/understanding-json-schema/reference/generic',  
   '/understanding-json-schema/reference',
-  '/learn/glossary'
+  '/learn/glossary',
+  '/implementers/interfaces'
 ]
 const getSpecificationPath = [
   '/draft/2020-12/release-notes',
@@ -80,11 +81,6 @@ const getSpecificationPath = [
   '/specification-links',
   '/specification'
 ]
-
-const getImplementersPath = [
-  '/implementers/interfaces'
-]
-
 export const SidebarLayout = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter()
   const [open, setOpen] = useState(false)
@@ -139,7 +135,6 @@ export const DocsNav = () => {
     getDocs: false,
     getStarted: false,
     getReference: false,
-    getImplementers: false,
     getSpecification: false,
   })
   useEffect(() => {
@@ -151,8 +146,6 @@ export const DocsNav = () => {
       setActive({ ...active, getReference: true })
     } else if (getSpecificationPath.includes(router.asPath)) {
       setActive({ ...active, getSpecification: true })
-    } else if (getImplementersPath.includes(router.asPath)) {
-      setActive({ ...active, getImplementers: true })
     }
   }, [router.asPath])
 
@@ -168,10 +161,6 @@ export const DocsNav = () => {
     setActive({ ...active, getReference: !active.getReference })
   }
 
-  const handleClickImplementers = () => {
-    setActive({ ...active, getImplementers: !active.getImplementers })
-  }
-
   const handleClickSpec = () => {
     setActive({ ...active, getSpecification: !active.getSpecification })
   }
@@ -179,7 +168,6 @@ export const DocsNav = () => {
   const rotate = active.getDocs ? 'rotate(180deg)' : 'rotate(0)'
   const rotateG = active.getStarted ? 'rotate(180deg)' : 'rotate(0)'
   const rotateR = active.getReference ? 'rotate(180deg)' : 'rotate(0)'
-  const rotateI = active.getImplementers ? 'rotate(180deg)' : 'rotate(0)'
   const rotateSpec = active.getSpecification ? 'rotate(180deg)' : 'rotate(0)'
 
   return (
@@ -268,21 +256,10 @@ export const DocsNav = () => {
             </div>
             <DocLink uri='/understanding-json-schema/structuring' label='Structuring a complex schema' />
           </div>
-        </div>
-      </div>
-      <div className='mb-2 bg-slate-200 p-2 rounded'>
-        <div className='flex justify-between w-full items-center' onClick={handleClickImplementers} >
-          <div className='flex  items-center align-middle'>
-            <img src='/icons/book.svg' alt='eye icon' className='mr-2' />
-            <SegmentHeadline label='Implementers' />
+          <SegmentSubtitle label='For implementers' />
+          <div className='pl-4 pb-1 pt-1'>
+            <DocLink uri='/implementers/interfaces' label='Common Interfaces across Implementations' />
           </div>
-          <svg style={{ transform: rotateI, transition: 'all 0.2s linear' }} id='arrow' xmlns='http://www.w3.org/2000/svg' fill='none' height='32' viewBox='0 0 24 24' width='24'><path clipRule='evenodd' d='m16.5303 8.96967c.2929.29289.2929.76777 0 1.06063l-4 4c-.2929.2929-.7677.2929-1.0606 0l-4.00003-4c-.29289-.29286-.29289-.76774 0-1.06063s.76777-.29289 1.06066 0l3.46967 3.46963 3.4697-3.46963c.2929-.29289.7677-.29289 1.0606 0z' fill='#707070' fillRule='evenodd' /></svg>
-        </div>
-        <div
-          className={classnames( 'ml-6', { 'hidden': !active.getImplementers })}
-          id='implementers'
-        >
-          <DocLink uri='/implementers/interfaces' label='Common Interfaces Across Implementations' />
         </div>
       </div>
       {/* Specification */}

--- a/context.ts
+++ b/context.ts
@@ -6,6 +6,6 @@ export enum BlockContextValue {
   Details
 }
 
-export const SectionContext = React.createContext<null | 'learn' | 'docs' | 'implementations' | 'blog' | 'community' | 'specification'| 'overview' | 'getting-started' | 'reference'>(null)
+export const SectionContext = React.createContext<null | 'learn' | 'docs' | 'implementers' | 'implementations' | 'blog' | 'community' | 'specification'| 'overview' | 'getting-started' | 'reference'>(null)
 export const BlockContext = React.createContext<BlockContextValue | null>(null)
 export const FullMarkdownContext = React.createContext<string | null>(null)

--- a/pages/implementers/[slug].page.tsx
+++ b/pages/implementers/[slug].page.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import Head from 'next/head'
+import StyledMarkdown from '~/components/StyledMarkdown'
+import { getLayout } from '~/components/Sidebar'
+import getStaticMarkdownPaths from '~/lib/getStaticMarkdownPaths'
+import getStaticMarkdownProps from '~/lib/getStaticMarkdownProps'
+import { Headline1 } from '~/components/Headlines'
+import { SectionContext } from '~/context'
+
+export async function getStaticPaths() { return getStaticMarkdownPaths('pages/implementers') }
+export async function getStaticProps(args: any) { return getStaticMarkdownProps(args, 'pages/implementers') }
+
+export default function StaticMarkdownPage ({ frontmatter, content }: { frontmatter: any, content: any }) {
+  return (
+    <SectionContext.Provider value={frontmatter.section || null}>
+      <Head>
+        <title>JSON Schema - {frontmatter.title}</title>
+      </Head>
+      <Headline1>{frontmatter.title}</Headline1>
+      <StyledMarkdown markdown={content} />
+    </SectionContext.Provider>
+  )
+}
+StaticMarkdownPage.getLayout = getLayout

--- a/pages/implementers/interfaces.md
+++ b/pages/implementers/interfaces.md
@@ -25,7 +25,7 @@ In addition to placeholder types like `String`, `Number`, `Boolean`, `Mapping`, 
 `Schema`
 
 > The type of JSON Schemas, which may also differ across dialects of JSON Schema.
-> For common or modern versions of JSON Schema this type is essentially `Map<String, Any> | Boolean`.
+> For common or modern versions of JSON Schema this type must essentially be able to represent both arbitrary JSON objects as well as booleans.
 
 `Instance`
 

--- a/pages/implementers/interfaces.md
+++ b/pages/implementers/interfaces.md
@@ -5,11 +5,11 @@ section: implementers
 
 JSON Schema is extremely widely used and nearly equally widely implemented.
 There are implementations of JSON Schema validation for [over 20 languages](https://json-schema.org/implementations.html) or environments.
-This prevalence is fantastic for user choice \-- as someone wishing to use JSON Schema you can be almost certain you\'ll find an implementation suitable for your target environment.
+This prevalence is fantastic for user choice -- as someone wishing to use JSON Schema you can be almost certain you'll find an implementation suitable for your target environment.
 
 But when it comes to community support, it can be challenging to know how to perform various JSON Schema operations in a particular library or implementation, as each may have slightly differing (or more than slightly differing) APIs.
 This can become particularly challenging when considering behavior not necessarily prescribed or required by the specification itself, but which is nonetheless common, useful, or even required behavior *in practice* in order to use JSON Schema.
-This page serves to document a number of these *common operations*, documenting the interfaces offered by many such implementations and inspired in part by the interfaces required for Bowtie\'s own operation.
+This page serves to document a number of these *common operations*, documenting the interfaces offered by many implementations across the existing JSON Schema ecosystem.
 
 For each, we first name and describe the operation using terminology from the specification where available, or otherwise using terminology that is aimed to be succinct but precise.
 The intention of this page is partially to be a reference of important JSON Schema operations as well as a way of tailoring help for a particular language and implementation.
@@ -30,7 +30,7 @@ In addition to placeholder types like `String`, `Number`, `Boolean`, `Mapping`, 
 `Instance`
 
 > The type of JSON instances.
-> This type should essentially be `Any` or a type capable of representing all JSON values, given JSON Schema\'s applicability to any representable JSON.
+> This type should essentially be `Any` or a type capable of representing all JSON values, given JSON Schema's applicability to any representable JSON.
 
 `Dialect`
 
@@ -39,13 +39,13 @@ In addition to placeholder types like `String`, `Number`, `Boolean`, `Mapping`, 
 
 `EvaluationContext`
 
-:   The type of \"fully ready\" schemas and instances *along* with any additional implementation-specific customizable behavior.
+:   The type of "fully ready" schemas and instances *along* with any additional implementation-specific customizable behavior.
     At minimum, this type is either `Schema → Instance` or `Schema × Instance` (depending on whether the implementation takes both schema and instance together or compiles schemas and then produces a separate function taking the instance to validate).
     It is highly likely to be richer in at least some of the following ways:
 
     > -   Given likely support for some form of schema registry in order to support referencing external schemas, this type will likely include a registry of some sort, i.e. `Mapping<URI, Schema> → Schema → ...`
     > -   If an implementation supports customizing which JSON types match to which language types (such as [discussed below](#type-customization)) then this type likely includes some representation of this mapping, i.e. `Mapping<String, Callable[...]> → Schema → ...` encapsulating what each type is mapped to during this evaluation.
-    > -   Similarly, if there is a specific API for [format assertion enablement](#format-assertion-enablement), some representation of the `format` keyword\'s behavior is present in the context
+    > -   Similarly, if there is a specific API for [format assertion enablement](#format-assertion-enablement), some representation of the `format` keyword's behavior is present in the context
     > -   If the implementation supports the [creation or customization of dialects](#dialect-creation), and especially if schemas can contain subschemas across different dialects, then the context will contain some representation of dialects, e.g. `Dialect → Schema → ...`
 
 `Result`
@@ -66,7 +66,7 @@ In addition to placeholder types like `String`, `Number`, `Boolean`, `Mapping`, 
 
 Because this page deals with concerns which cross language barriers, and different programming languages have different capabilities particularly around how they represent out of band errors (via exceptions, option types, wrapper return types, sentinel values or some other mechanism), this page also introduces[^1] specific notation for representing the types of functions which include explicit representation for their out-of-band errors.
 Interpreting these types will depend on the programming language.
-It\'s easier to explain the above with an example:
+It's easier to explain the above with an example:
 
 [^1]: The authors of this page are not aware of a suitable existing and/or pervasive notation which serves this purpose already.
       If you are aware of one, a pull request or pointer would be welcome.
@@ -77,15 +77,15 @@ We will write the type of this function as `Float → Float → Float <!> Divide
 
 The specific manifestation of `DivideByZeroError` will depend on the programming language.
 In a language with exceptions, this function may raise a `DivideByZeroError`-equivalent as an exception, which must or may be handled by the caller. 
-In a language with option types, the \"correct\" type signature may really be wrapped in an `Option` type which represents the division by zero case (so the \"true\" signature in such a language would be `Option[Float → Float → Float]`).
+In a language with option types, the "correct" type signature may really be wrapped in an `Option` type which represents the division by zero case (so the "true" signature in such a language would be `Option[Float → Float → Float]`).
 In a language with wrapper return types, the true type signature may be `Result<Float, DivideByZeroError>` where the returned value must be inspected to ensure it contains a successful result, and where the divide by zero error is instead a possible error value.
-In a language with a convention to return \"junk\" values, the true type may be precisely `Float → Float → Float` where some arbitrary float value is
+In a language with a convention to return "junk" values, the true type may be precisely `Float → Float → Float` where some arbitrary float value is
 returned when dividing by zero, with no further indication.
 
 In all cases above, when an exception (corresp. error or junk value) is raised (corresp. returned), we by convention assume that any normal return value is either completely not present by the mechanisms of the programming language, or else is considered meaningless.
 
 In addition, this page will not, in general, consider or mention the possibility that an error might be raised for reasons other than those discussed in a particular section.
-For example, the division example mentioned above may raise other kinds of errors if provided with strings, in a dynamically typed language where such possibilities exist at runtime, such that the \"real\" division function may look more like `Float → Float → Float <!> DivideByZeroError | TypeError` or even further error possibilities.
+For example, the division example mentioned above may raise other kinds of errors if provided with strings, in a dynamically typed language where such possibilities exist at runtime, such that the "real" division function may look more like `Float → Float → Float <!> DivideByZeroError | TypeError` or even further error possibilities.
 In the case of JSON Schema, this may mean every interface mentioned below has a type containing `<!> InvalidSchema | NotValidJSON | ...` representing cases where they are provided with schemas that are not valid according to the specification, or which do not fit the JSON data model, etc., but we consider these to be implicit and will not mention them explicitly unless directly relevant to the interface being discussed.
 
 ## Instance Validation
@@ -114,7 +114,7 @@ If it succeeds, this API may return a result with further detail, or may simply 
 `EvaluationContext` → Boolean
 :::
 
-An API which produces a simple boolean result indicating an instance\'s validity under a schema.
+An API which produces a simple boolean result indicating an instance's validity under a schema.
 
 ### Two-Argument Validation
 
@@ -192,7 +192,7 @@ An API which allows (re-)configuring which language-level types correspond to wh
 `String` → `String` → `Result`
 :::
 
-An API which directly validates instances using schemas where both are represented as strings \-- serialized JSON \-- as opposed to deserialized JSON.
+An API which directly validates instances using schemas where both are represented as strings -- serialized JSON -- as opposed to deserialized JSON.
 
 ## Language Object Validation
 
@@ -222,7 +222,7 @@ An API which allows associating URIs with a schema where the URI is internally i
 
 ### Schema Discovery
 
-An API which (recursively) crawls a root schema or schemas, discovering any subresources (subschemas) which are present and identifiable, and making those subresources\' URIs available for further referencing.
+An API which (recursively) crawls a root schema or schemas, discovering any subresources (subschemas) which are present and identifiable, and making those subresources' URIs available for further referencing.
 
 ### Dynamic URI Resolution
 
@@ -230,7 +230,7 @@ An API which allows for arbitrary dynamic lookup behavior for any reference not 
 
 ## Output Format Selection / Generation
 
-An API which configures which of JSON Schema\'s output format(s) are used when producing results, or which allows generating a particular output format given a `Result`.
+An API which configures which of JSON Schema's output format(s) are used when producing results, or which allows generating a particular output format given a `Result`.
 
 ## Vocabulary Registration
 

--- a/pages/implementers/interfaces.md
+++ b/pages/implementers/interfaces.md
@@ -21,55 +21,54 @@ Contributions and corrections from implementers are particularly welcome, as are
 For purposes of making some sections of this page more precise, we assume the existence of a set of *abstract types* all of which may be referenced below, and which will have specific concrete types within a given programming language or implementation.
 In addition to placeholder types like `String`, `Number`, `Boolean`, `Mapping`, `Callable` and the like, the JSON Schema-related types include:
 
-::: glossary
-`Schema`
+#### `Schema`
 
-> The type of JSON Schemas, which may also differ across dialects of JSON Schema.
-> For common or modern versions of JSON Schema this type must essentially be able to represent both arbitrary JSON objects as well as booleans.
+The type of JSON Schemas, which may also differ across dialects of JSON Schema.
+For common or modern versions of JSON Schema this type must essentially be able to represent both arbitrary JSON objects as well as booleans.
 
-`Instance`
+#### `Instance`
 
-> The type of JSON instances.
-> This type should essentially be `Any` or a type capable of representing all JSON values, given JSON Schema's applicability to any representable JSON.
+The type of JSON instances.
+This type should essentially be `Any` or a type capable of representing all JSON values, given JSON Schema's applicability to any representable JSON.
 
-`Dialect`
+#### `Dialect`
 
-> The type of JSON dialects or dialect identifiers.
-> This type may simply be `String` if the dialect is represented within the implementation by its URI or by some short name.
+The type of JSON dialects or dialect identifiers.
+This type may simply be `String` if the dialect is represented within the implementation by its URI or by some short name.
 
-`EvaluationOptions`
+#### `EvaluationOptions`
 
-:   The type of "fully ready" schemas and instances *along* with any additional implementation-specific customizable behavior.
-    At minimum, this type is either `Schema → Instance` or `Schema × Instance` (depending on whether the implementation takes both schema and instance together or compiles schemas and then produces a separate function taking the instance to validate).
-    It is highly likely to be richer in at least some of the following ways:
+The type of "fully ready" schemas and instances *along* with any additional implementation-specific customizable behavior.
+At minimum, this type is either `Schema → Instance` or `Schema × Instance` (depending on whether the implementation takes both schema and instance together or compiles schemas and then produces a separate function taking the instance to validate).
+It is highly likely to be richer in at least some of the following ways:
 
-    > -   Given likely support for some form of schema registry in order to support referencing external schemas, this type will likely include a registry of some sort, i.e. `Mapping<URI, Schema> → Schema → ...`
-    > -   If an implementation supports customizing which JSON types match to which language types (such as [discussed below](#type-customization)) then this type likely includes some representation of this mapping, i.e. `Mapping<String, Callable[...]> → Schema → ...` encapsulating what each type is mapped to during this evaluation.
-    > -   Similarly, if there is a specific API for [format assertion enablement](#format-assertion-enablement), some representation of the `format` keyword's behavior is present in the context
-    > -   If the implementation supports the [creation or customization of dialects](#dialect-creation), and especially if schemas can contain subschemas across different dialects, then the context will contain some representation of dialects, e.g. `Dialect → Schema → ...`
+  * Given likely support for some form of schema registry in order to support referencing external schemas, this type will likely include a registry of some sort, i.e. `Mapping<URI, Schema> → Schema → ...`
+  *   If an implementation supports customizing which JSON types match to which language types (such as [discussed below](#type-customization)) then this type likely includes some representation of this mapping, i.e. `Mapping<String, Callable[...]> → Schema → ...` encapsulating what each type is mapped to during this evaluation.
+  *   Similarly, if there is a specific API for [format assertion enablement](#format-assertion-enablement), some representation of the `format` keyword's behavior is present in the context
+  *   If the implementation supports the [creation or customization of dialects](#dialect-creation), and especially if schemas can contain subschemas across different dialects, then the context will contain some representation of dialects, e.g. `Dialect → Schema → ...`
 
-`Result`
+#### `Result`
 
-> The type of JSON Schema validation results, i.e. an object which encapsulates the validity of a given `Instance` under a `Schema`.
-> This type may simply be `Boolean` in some implementations or languages.
+The type of JSON Schema validation results, i.e. an object which encapsulates the validity of a given `Instance` under a `Schema`.
+This type may simply be `Boolean` in some implementations or languages.
 
 `ResultWithAnnotations`
 
 > The type of JSON Schema validation results that *include* JSON Schema annotations collected during validation.
 
-`URI`
+#### `URI`
 
-> The type of RFC 3986 compliant URIs.
-> This type should not generally be the same as `String`, as URIs have multiple possible string representations and require normalization to
-> have correct semantics.
-:::
+The type of RFC 3986 compliant URIs.
+This type should not generally be the same as `String`, as URIs have multiple possible string representations and require normalization to
+have correct semantics.
+
+---
 
 Because this page deals with concerns which cross language barriers, and different programming languages have different capabilities particularly around how they represent out of band errors (via exceptions, option types, wrapper return types, sentinel values or some other mechanism), this page also introduces[^1] specific notation for representing the types of functions which include explicit representation for their out-of-band errors.
 Interpreting these types will depend on the programming language.
 It's easier to explain the above with an example:
 
-[^1]: The authors of this page are not aware of a suitable existing and/or pervasive notation which serves this purpose already.
-      If you are aware of one, a pull request or pointer would be welcome.
+[^1]: The authors of this page are not aware of a suitable existing and/or pervasive notation which serves this purpose already. If you are aware of one, a pull request or pointer would be welcome.
 
 Consider a division function on floats, represented as `x / y`.
 
@@ -96,33 +95,20 @@ Implementations may offer one or more of the specific interfaces below in order 
 
 ### Exception-Driven Validation
 
-::: topic
-**Type**
-
-`EvaluationOptions → None <!> ValidationError` or
-`EvaluationOptions → Result <!> ValidationError`
-:::
+**Type**: `EvaluationOptions → None <!> ValidationError` or `EvaluationOptions → Result <!> ValidationError`
 
 A validation API which causes a language-specific failure or exception when validation itself fails.
 If it succeeds, this API may return a result with further detail, or may simply continue execution silently.
 
 ### Boolean Validation
 
-::: topic
-**Type**
-
-`EvaluationOptions` → Boolean
-:::
+**Type**: `EvaluationOptions` → Boolean
 
 An API which produces a simple boolean result indicating an instance's validity under a schema.
 
 ### Two-Argument Validation
 
-::: topic
-**Type**
-
-`Schema` × `Instance` → `Result`
-:::
+**Type**: `Schema` × `Instance` → `Result`
 
 An API which takes a schema and instance simultaneously and produces a result indicating whether the instance is valid under the given schema.
 
@@ -130,53 +116,33 @@ In some sense, two argument validation is the simplest possible API for JSON Sch
 
 ### Repeated Validation / Schema Compilation
 
-::: topic
-**Type**
-
-`Schema` → `Instance` → `Result`
-:::
+**Type**: `Schema` → `Instance` → `Result`
 
 An API which attempts to prepare a schema for repeated use.
 It may (and likely will) perform some form of preoptimization, performing some set of work ahead of time such that it will not be necessary to repeat when validating many instances.
 
 ## Annotation Collection
 
-::: topic
-**Type**
-
-`EvaluationOptions` → `ResultWithAnnotations`
-:::
+**Type**: `EvaluationOptions` → `ResultWithAnnotations`
 
 An API which collects annotations produced when processing a given schema and instance.
 
 ## Schema Validation
 
-::: topic
-**Type**
-
-`Schema` → `Result`
-:::
+**Type**: `Schema` → `Result`
 
 An API which validates a schema itself under the dialect it is written for.
 This API likely makes use of a corresponding metaschema (or metaschemas) for the dialect, but generally must do additional work to ensure the schema is not invalid even under conditions not checked for within the metaschema.
 
 ## Explicit Version Selection
 
-::: topic
-**Type**
-
-`Dialect` → `EvaluationOptions` → `Result`
-:::
+**Type**: `Dialect` → `EvaluationOptions` → `Result`
 
 An API which controls which dialect the implementation will assume when given a schema which does not otherwise indicate its dialect (i.e. which does not declare a `$schema` property).
 
 ## Version Detection
 
-::: topic
-**Type**
-
-`Schema` → `Dialect`
-:::
+**Type**: `Schema` → `Dialect`
 
 An API which identifies which dialect a given schema is written for, returning either the dialect itself or otherwise a dialect-specific validation function.
 
@@ -186,21 +152,13 @@ An API which allows (re-)configuring which language-level types correspond to wh
 
 ## String Validation
 
-::: topic
-**Type**
-
-`String` → `String` → `Result`
-:::
+**Type**: `String` → `String` → `Result`
 
 An API which directly validates instances using schemas where both are represented as strings -- serialized JSON -- as opposed to deserialized JSON.
 
 ## Language Object Validation
 
-::: topic
-**Type**
-
-`EvaluationOptions` → `Result`
-:::
+**Type**: `EvaluationOptions` → `Result`
 
 An API which validates instances using schemas where both have been deserialized into language-level objects, or potentially built up programmatically directly as language-level objects.
 

--- a/pages/implementers/interfaces.md
+++ b/pages/implementers/interfaces.md
@@ -37,7 +37,7 @@ In addition to placeholder types like `String`, `Number`, `Boolean`, `Mapping`, 
 > The type of JSON dialects or dialect identifiers.
 > This type may simply be `String` if the dialect is represented within the implementation by its URI or by some short name.
 
-`EvaluationContext`
+`EvaluationOptions`
 
 :   The type of "fully ready" schemas and instances *along* with any additional implementation-specific customizable behavior.
     At minimum, this type is either `Schema → Instance` or `Schema × Instance` (depending on whether the implementation takes both schema and instance together or compiles schemas and then produces a separate function taking the instance to validate).
@@ -99,8 +99,8 @@ Implementations may offer one or more of the specific interfaces below in order 
 ::: topic
 **Type**
 
-`EvaluationContext → None <!> ValidationError` or
-`EvaluationContext → Result <!> ValidationError`
+`EvaluationOptions → None <!> ValidationError` or
+`EvaluationOptions → Result <!> ValidationError`
 :::
 
 A validation API which causes a language-specific failure or exception when validation itself fails.
@@ -111,7 +111,7 @@ If it succeeds, this API may return a result with further detail, or may simply 
 ::: topic
 **Type**
 
-`EvaluationContext` → Boolean
+`EvaluationOptions` → Boolean
 :::
 
 An API which produces a simple boolean result indicating an instance's validity under a schema.
@@ -144,7 +144,7 @@ It may (and likely will) perform some form of preoptimization, performing some s
 ::: topic
 **Type**
 
-`EvaluationContext` → `ResultWithAnnotations`
+`EvaluationOptions` → `ResultWithAnnotations`
 :::
 
 An API which collects annotations produced when processing a given schema and instance.
@@ -165,7 +165,7 @@ This API likely makes use of a corresponding metaschema (or metaschemas) for the
 ::: topic
 **Type**
 
-`Dialect` → `EvaluationContext` → `Result`
+`Dialect` → `EvaluationOptions` → `Result`
 :::
 
 An API which controls which dialect the implementation will assume when given a schema which does not otherwise indicate its dialect (i.e. which does not declare a `$schema` property).
@@ -199,7 +199,7 @@ An API which directly validates instances using schemas where both are represent
 ::: topic
 **Type**
 
-`EvaluationContext` → `Result`
+`EvaluationOptions` → `Result`
 :::
 
 An API which validates instances using schemas where both have been deserialized into language-level objects, or potentially built up programmatically directly as language-level objects.

--- a/pages/implementers/interfaces.md
+++ b/pages/implementers/interfaces.md
@@ -8,7 +8,7 @@ There are implementations of JSON Schema validation for [over 20 languages](http
 This prevalence is fantastic for user choice \-- as someone wishing to use JSON Schema you can be almost certain you\'ll find an implementation suitable for your target environment.
 
 But when it comes to community support, it can be challenging to know how to perform various JSON Schema operations in a particular library or implementation, as each may have slightly differing (or more than slightly differing) APIs.
-This can become particularly challenging when considering behavior not necessarily proscribed or required by the specification itself, but which is nonetheless common, useful or even required behavior *in practice* in order to use JSON Schema.
+This can become particularly challenging when considering behavior not necessarily prescribed or required by the specification itself, but which is nonetheless common, useful, or even required behavior *in practice* in order to use JSON Schema.
 This page serves to document a number of these *common operations*, documenting the interfaces offered by many such implementations and inspired in part by the interfaces required for Bowtie\'s own operation.
 
 For each, we first name and describe the operation using terminology from the specification where available, or otherwise using terminology that is aimed to be succinct but precise.

--- a/pages/implementers/interfaces.md
+++ b/pages/implementers/interfaces.md
@@ -1,6 +1,6 @@
 ---
-title: Common Interfaces Across JSON Schema Implementations
-section: docs
+title: Common Interfaces across JSON Schema Implementations
+section: implementers
 ---
 
 JSON Schema is extremely widely used and nearly equally widely implemented.

--- a/pages/learn/interfaces.md
+++ b/pages/learn/interfaces.md
@@ -1,4 +1,7 @@
-# Common Interfaces Across JSON Schema Implementations
+---
+title: Common Interfaces Across JSON Schema Implementations
+section: docs
+---
 
 JSON Schema is extremely widely used and nearly equally widely implemented.
 There are implementations of JSON Schema validation for [over 20 languages](https://json-schema.org/implementations.html) or environments.

--- a/pages/learn/interfaces.md
+++ b/pages/learn/interfaces.md
@@ -1,0 +1,242 @@
+# Common Interfaces Across JSON Schema Implementations
+
+JSON Schema is extremely widely used and nearly equally widely implemented.
+There are implementations of JSON Schema validation for [over 20 languages](https://json-schema.org/implementations.html) or environments.
+This prevalence is fantastic for user choice \-- as someone wishing to use JSON Schema you can be almost certain you\'ll find an implementation suitable for your target environment.
+
+But when it comes to community support, it can be challenging to know how to perform various JSON Schema operations in a particular library or implementation, as each may have slightly differing (or more than slightly differing) APIs.
+This can become particularly challenging when considering behavior not necessarily proscribed or required by the specification itself, but which is nonetheless common, useful or even required behavior *in practice* in order to use JSON Schema.
+This page serves to document a number of these *common operations*, documenting the interfaces offered by many such implementations and inspired in part by the interfaces required for Bowtie\'s own operation.
+
+For each, we first name and describe the operation using terminology from the specification where available, or otherwise using terminology that is aimed to be succinct but precise.
+The intention of this page is partially to be a reference of important JSON Schema operations as well as a way of tailoring help for a particular language and implementation.
+We therefore include examples of each interface or piece of functionality across implementations, when known.
+The ordering of sections on this page is not necessarily indicative of their importance relative to each other.
+Omission of functionality (i.e. if you do not find the way to do something below with a given implementation) is *not* necessarily a sign that the implementation does not support the functionality, though it might mean it could not be easily found by the page authors.
+Contributions and corrections from implementers are particularly welcome, as are documentation links!
+
+For purposes of making some sections of this page more precise, we assume the existence of a set of *abstract types* all of which may be referenced below, and which will have specific concrete types within a given programming language or implementation.
+In addition to placeholder types like `String`, `Number`, `Boolean`, `Mapping`, `Callable` and the like, the JSON Schema-related types include:
+
+::: glossary
+`Schema`
+
+> The type of JSON Schemas, which may also differ across dialects of JSON Schema.
+> For common or modern versions of JSON Schema this type is essentially `Map<String, Any> | Boolean`.
+
+`Instance`
+
+> The type of JSON instances.
+> This type should essentially be `Any` or a type capable of representing all JSON values, given JSON Schema\'s applicability to any representable JSON.
+
+`Dialect`
+
+> The type of JSON dialects or dialect identifiers.
+> This type may simply be `String` if the dialect is represented within the implementation by its URI or by some short name.
+
+`EvaluationContext`
+
+:   The type of \"fully ready\" schemas and instances *along* with any additional implementation-specific customizable behavior.
+    At minimum, this type is either `Schema → Instance` or `Schema × Instance` (depending on whether the implementation takes both schema and instance together or compiles schemas and then produces a separate function taking the instance to validate).
+    It is highly likely to be richer in at least some of the following ways:
+
+    > -   Given likely support for some form of schema registry in order to support referencing external schemas, this type will likely include a registry of some sort, i.e. `Mapping<URI, Schema> → Schema → ...`
+    > -   If an implementation supports customizing which JSON types match to which language types (such as [discussed below](#type-customization)) then this type likely includes some representation of this mapping, i.e. `Mapping<String, Callable[...]> → Schema → ...` encapsulating what each type is mapped to during this evaluation.
+    > -   Similarly, if there is a specific API for [format assertion enablement](#format-assertion-enablement), some representation of the `format` keyword\'s behavior is present in the context
+    > -   If the implementation supports the [creation or customization of dialects](#dialect-creation), and especially if schemas can contain subschemas across different dialects, then the context will contain some representation of dialects, e.g. `Dialect → Schema → ...`
+
+`Result`
+
+> The type of JSON Schema validation results, i.e. an object which encapsulates the validity of a given `Instance` under a `Schema`.
+> This type may simply be `Boolean` in some implementations or languages.
+
+`ResultWithAnnotations`
+
+> The type of JSON Schema validation results that *include* JSON Schema annotations collected during validation.
+
+`URI`
+
+> The type of RFC 3986 compliant URIs.
+> This type should not generally be the same as `String`, as URIs have multiple possible string representations and require normalization to
+> have correct semantics.
+:::
+
+Because this page deals with concerns which cross language barriers, and different programming languages have different capabilities particularly around how they represent out of band errors (via exceptions, option types, wrapper return types, sentinel values or some other mechanism), this page also introduces[^1] specific notation for representing the types of functions which include explicit representation for their out-of-band errors.
+Interpreting these types will depend on the programming language.
+It\'s easier to explain the above with an example:
+
+[^1]: The authors of this page are not aware of a suitable existing and/or pervasive notation which serves this purpose already.
+      If you are aware of one, a pull request or pointer would be welcome.
+
+Consider a division function on floats, represented as `x / y`.
+
+We will write the type of this function as `Float → Float → Float <!> DivideByZeroError`, where the interpretation of this signature is that the function takes 2 floats and returns a float, but the `<!>` signals it may also propagate a `DivideByZeroError` (in this case when the function is asked to divide by zero).
+
+The specific manifestation of `DivideByZeroError` will depend on the programming language.
+In a language with exceptions, this function may raise a `DivideByZeroError`-equivalent as an exception, which must or may be handled by the caller. 
+In a language with option types, the \"correct\" type signature may really be wrapped in an `Option` type which represents the division by zero case (so the \"true\" signature in such a language would be `Option[Float → Float → Float]`).
+In a language with wrapper return types, the true type signature may be `Result<Float, DivideByZeroError>` where the returned value must be inspected to ensure it contains a successful result, and where the divide by zero error is instead a possible error value.
+In a language with a convention to return \"junk\" values, the true type may be precisely `Float → Float → Float` where some arbitrary float value is
+returned when dividing by zero, with no further indication.
+
+In all cases above, when an exception (corresp. error or junk value) is raised (corresp. returned), we by convention assume that any normal return value is either completely not present by the mechanisms of the programming language, or else is considered meaningless.
+
+In addition, this page will not, in general, consider or mention the possibility that an error might be raised for reasons other than those discussed in a particular section.
+For example, the division example mentioned above may raise other kinds of errors if provided with strings, in a dynamically typed language where such possibilities exist at runtime, such that the \"real\" division function may look more like `Float → Float → Float <!> DivideByZeroError | TypeError` or even further error possibilities.
+In the case of JSON Schema, this may mean every interface mentioned below has a type containing `<!> InvalidSchema | NotValidJSON | ...` representing cases where they are provided with schemas that are not valid according to the specification, or which do not fit the JSON data model, etc., but we consider these to be implicit and will not mention them explicitly unless directly relevant to the interface being discussed.
+
+## Instance Validation
+
+Instance validation is one of the key capabilities of JSON Schema.
+It is the process in which a given piece of data is deemed valid or invalid under a specific schema.
+Implementations may offer one or more of the specific interfaces below in order to perform this validation.
+
+### Exception-Driven Validation
+
+::: topic
+**Type**
+
+`EvaluationContext → None <!> ValidationError` or
+`EvaluationContext → Result <!> ValidationError`
+:::
+
+A validation API which causes a language-specific failure or exception when validation itself fails.
+If it succeeds, this API may return a result with further detail, or may simply continue execution silently.
+
+### Boolean Validation
+
+::: topic
+**Type**
+
+`EvaluationContext` → Boolean
+:::
+
+An API which produces a simple boolean result indicating an instance\'s validity under a schema.
+
+### Two-Argument Validation
+
+::: topic
+**Type**
+
+`Schema` × `Instance` → `Result`
+:::
+
+An API which takes a schema and instance simultaneously and produces a result indicating whether the instance is valid under the given schema.
+
+In some sense, two argument validation is the simplest possible API for JSON Schema validation; it asks simply whether a given instance is valid under a given schema with no presumptions of repeated use (of the schema) or additional calculation.
+
+### Repeated Validation / Schema Compilation
+
+::: topic
+**Type**
+
+`Schema` → `Instance` → `Result`
+:::
+
+An API which attempts to prepare a schema for repeated use.
+It may (and likely will) perform some form of preoptimization, performing some set of work ahead of time such that it will not be necessary to repeat when validating many instances.
+
+## Annotation Collection
+
+::: topic
+**Type**
+
+`EvaluationContext` → `ResultWithAnnotations`
+:::
+
+An API which collects annotations produced when processing a given schema and instance.
+
+## Schema Validation
+
+::: topic
+**Type**
+
+`Schema` → `Result`
+:::
+
+An API which validates a schema itself under the dialect it is written for.
+This API likely makes use of a corresponding metaschema (or metaschemas) for the dialect, but generally must do additional work to ensure the schema is not invalid even under conditions not checked for within the metaschema.
+
+## Explicit Version Selection
+
+::: topic
+**Type**
+
+`Dialect` → `EvaluationContext` → `Result`
+:::
+
+An API which controls which dialect the implementation will assume when given a schema which does not otherwise indicate its dialect (i.e. which does not declare a `$schema` property).
+
+## Version Detection
+
+::: topic
+**Type**
+
+`Schema` → `Dialect`
+:::
+
+An API which identifies which dialect a given schema is written for, returning either the dialect itself or otherwise a dialect-specific validation function.
+
+## Type Customization
+
+An API which allows (re-)configuring which language-level types correspond to which JSON Schema types, and additionally potentially allowing for the definition of new types.
+
+## String Validation
+
+::: topic
+**Type**
+
+`String` → `String` → `Result`
+:::
+
+An API which directly validates instances using schemas where both are represented as strings \-- serialized JSON \-- as opposed to deserialized JSON.
+
+## Language Object Validation
+
+::: topic
+**Type**
+
+`EvaluationContext` → `Result`
+:::
+
+An API which validates instances using schemas where both have been deserialized into language-level objects, or potentially built up programmatically directly as language-level objects.
+
+## Format Assertion Enablement
+
+An API which configures the behavior of the `format` keyword, in dialects where this behavior is not solely controlled by JSON Schema vocabulary enablement.
+
+## Schema Registry Population
+
+An API which configures the bundle of schemas available for referencing during the validation process.
+
+### Externally Identified Schemas
+
+An API which allows associating one or more URIs with a schema where the URIs are not internally indicated by an `$id` keyword (or a dialect-specific equivalent).
+
+### Internally Identified Schemas
+
+An API which allows associating URIs with a schema where the URI is internally indicated by the presence of an `$id` keyword (or a dialect-specific equivalent) in the schema.
+
+### Schema Discovery
+
+An API which (recursively) crawls a root schema or schemas, discovering any subresources (subschemas) which are present and identifiable, and making those subresources\' URIs available for further referencing.
+
+### Dynamic URI Resolution
+
+An API which allows for arbitrary dynamic lookup behavior for any reference not prepopulated in the registry.
+
+## Output Format Selection / Generation
+
+An API which configures which of JSON Schema\'s output format(s) are used when producing results, or which allows generating a particular output format given a `Result`.
+
+## Vocabulary Registration
+
+An API which facilitates the creation of new JSON Schema vocabularies, typically for use when later [building new dialects](#dialect-creation).
+
+## Dialect Creation
+
+An API which facilitates the creation of new JSON Schema dialects, typically registering them in some way such that they can be further used inside the implementation.
+
+## Failure Details
+
+An API which allows for programmatic introspection of the causes of a particular validation failure, at minimum containing the failing keyword(s), value(s) and individual message(s) which led to the failure.


### PR DESCRIPTION
This page doesn't yet compile even, failing with some obscure Javascript error in a headline.

It was however ported from a reST page, so I'm still figuring out what flavor of markdown is needed to work with the site.

Marking it as [WIP] at least until I figure out what needs tweaking -- which certainly seems likely to be at least the `topic` and `glossary` bits, as Markdown doesn't really have equivalents of these, so I assume some Javascripting is necessary to implement something similar to the Bowtie page.

But the content is ready for immediate review.