### PR TITLE
Use dark style for code blocks

### DIFF
--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -5,7 +5,7 @@ import slugifyMarkdownHeadline from '~/lib/slugifyMarkdownHeadline'
 import JsonEditor from '~/components/JsonEditor'
 import getFindResultsByGlobalRegExp from '~/lib/getFindResultsByGlobalRegExp'
 import Highlight from 'react-syntax-highlighter'
-import { atomOneLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs'
+import { atomOneDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs'
 import { BlockContext, BlockContextValue } from '~/context'
 import Code from '~/components/Code'
 import { FullMarkdownContext } from '~/context'
@@ -226,7 +226,7 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
                     lineNumberStyle={{
                       marginRight: 10
                     }}
-                    style={atomOneLight}
+                    style={atomOneDark}
                     showLineNumbers
                     startingLineNumber={1}
                     lineProps={() => {


### PR DESCRIPTION
Use dark style for code blocks for consistency with json blocks.