### PR TITLE
Add an automatic commenter for new tooling PRs.

### DIFF
--- a/.github/workflows/new-implementation.yml
+++ b/.github/workflows/new-implementation.yml
@@ -1,0 +1,47 @@
+name: New Implementation Commenter
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+    paths:
+      - data/*.yml
+      - pages/implementations/main.md
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: process.env.NEW_TOOL_MESSAGE,
+            })
+        env:
+          NEW_TOOL_MESSAGE: |
+            Hey there 👋!
+
+            Are you an implementer of a new JSON Schema related tool, or an interested user submitting a tool you like?
+            If so, thanks for considering adding your tool to our collection -- and if not, sorry, I'm just a bot looking at which pages you're modifying!
+
+            Someone will review your pull request shortly.
+
+            In the interim, if you haven't already, there's a few things you might be interested in reviewing or confirming:
+
+              1. [ ] **Short description**: Tell us a small bit about your tool! We love staying up to date on what's out there, and what your intentions are in writing it.
+              2. [ ] **Common Interfaces**: We maintain a page with some "commonly useful programming interfaces" that tooling may want to implement and present to your users.
+                      You can find that page [here in our documentation](https://json-schema.org/implementers/interfaces).
+                      Have a read through and consider whether you implement or should implement any of what's there.
+              3. [ ] **Bowtie Harness**: [Bowtie](https://github.com/bowtie-json-schema/bowtie) is a tool which gives JSON Schema users access to a huge number of different implementations across many languages, and [reports on](https://bowtie.report/) the compliance of those implementations with the JSON Schema specifications.
+                      If it makes sense for your kind of tool, consider writing a *harness* which connects it to Bowtie. Instructions for doing so can be found in the tutorial in [Bowtie's documentation](https://docs.bowtie.report/).
+
+            If you have any questions, any feedback, or need help with the submission process, don't hesitate to reach out.
+            Thanks a bunch for your awesome contribution!

--- a/.github/workflows/new-implementation.yml
+++ b/.github/workflows/new-implementation.yml
@@ -37,10 +37,12 @@ jobs:
             In the interim, if you haven't already, there's a few things you might be interested in reviewing or confirming:
 
               1. [ ] **Short description**: Tell us a small bit about your tool! We love staying up to date on what's out there, and what your intentions are in writing it.
-              2. [ ] **Common Interfaces**: We maintain a page with some "commonly useful programming interfaces" that tooling may want to implement and present to your users.
+              2. [ ] **Come Join Our Slack!**: We have an `#implementers` channel for anyone interested in or building JSON Schema tooling!
+                      An invite can be found [here](https://json-schema.org/slack) or on our homepage!
+              3. [ ] **Common Interfaces**: We maintain a page with some "commonly useful programming interfaces" that tooling may want to implement and present to your users.
                       You can find that page [here in our documentation](https://json-schema.org/implementers/interfaces).
                       Have a read through and consider whether you implement or should implement any of what's there.
-              3. [ ] **Bowtie Harness**: [Bowtie](https://github.com/bowtie-json-schema/bowtie) is a tool which gives JSON Schema users access to a huge number of different implementations across many languages, and [reports on](https://bowtie.report/) the compliance of those implementations with the JSON Schema specifications.
+              4. [ ] **Bowtie Harness**: [Bowtie](https://github.com/bowtie-json-schema/bowtie) is a tool which gives JSON Schema users access to a huge number of different implementations across many languages, and [reports on](https://bowtie.report/) the compliance of those implementations with the JSON Schema specifications.
                       If it makes sense for your kind of tool, consider writing a *harness* which connects it to Bowtie. Instructions for doing so can be found in the tutorial in [Bowtie's documentation](https://docs.bowtie.report/).
 
             If you have any questions, any feedback, or need help with the submission process, don't hesitate to reach out.


### PR DESCRIPTION
This workflow will comment on PRs that add new tools / implementations to the website. It will do so only on PR open (i.e. once), not whenever the PR is modified.

The goal is to direct implementers (or users submitting on their behalf) to review some resources that might be applicable to them.

We can of course grow or shrink this list as needed, if we wish to point to additional resources.

Right now, the way it detects which PRs are tool additions is by considering any PR which touches:

    * the YAML files in the data directory
    * the pages/implementations/main.md page

to be possible candidates.

Additional tweaks could be made to add or remove these triggers if the commenter is too noisy, or not noisy enough.

For PRs which touch these pages, this looks like:

![Screenshot 2023-10-23 at 1 01 49 PM](https://github.com/json-schema-org/website/assets/329822/bd32c08e-35fb-45fd-b3ed-503c30d1d969)

PRs which do not meet the above detection are ignored.

Some further context on the immediate motivator of this is [here](https://github.com/json-schema-org/community/issues/408#issuecomment-1775343633).