### PR TITLE
Remove rel=alternate links that 404

### DIFF
--- a/public/draft/2020-12/draft-bhutton-json-schema-01.html
+++ b/public/draft/2020-12/draft-bhutton-json-schema-01.html
@@ -45,7 +45,6 @@
     setuptools 49.2.1
     six 1.15.0
 -->
-<link href="jsonschema-core.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 

--- a/public/draft/2020-12/draft-bhutton-json-schema-validation-01.html
+++ b/public/draft/2020-12/draft-bhutton-json-schema-validation-01.html
@@ -40,7 +40,6 @@
     setuptools 49.2.1
     six 1.15.0
 -->
-<link href="jsonschema-validation.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
 <style type="text/css">/*
 

--- a/public/draft/2020-12/relative-json-pointer.html
+++ b/public/draft/2020-12/relative-json-pointer.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0;url=/draft/2020-12/draft-bhutton-relative-json-pointer-00.html">
+draft-bhutton-relative-json-pointer-00.html


### PR DESCRIPTION
Alternately (pun intended), I could create links to the actual XML documents. This is easier and I think it's sufficient.