### PR TITLE
Update the links on a few pages to point to the new website repo.

### DIFF
--- a/pages/implementations/intro.md
+++ b/pages/implementations/intro.md
@@ -6,6 +6,6 @@ Implementations below are written in different languages, and support part, or a
 
 Implementations are classified based on their functionality. When known, the license of the project is also mentioned.
 
-If you have updates to this list, make a pull request on the [GitHub repo](https://github.com/json-schema-org/json-schema-org.github.io).
+If you have updates to this list, make a pull request on the [GitHub repo](https://github.com/json-schema-org/website).
 
 Listing does not signify a recommendation or endorsement of any kind.

--- a/pages/learn/glossary.md
+++ b/pages/learn/glossary.md
@@ -10,7 +10,7 @@ This page is not meant to be [normative](#normative), nor is it meant to contain
 It is meant to aid the understanding of those less familiar with formal language used within JSON Schema, or within specifications more broadly.
 (In fact, entries below make effort to avoid terminology like "normative" itself for reasons just mentioned.)
 
-If you encounter a term you wish were defined here, please feel free to [file an issue requesting it](https://github.com/json-schema-org/json-schema-org.github.io/issues/new?title=Add%20a%20glossary%20entry%20for%20).
+If you encounter a term you wish were defined here, please feel free to [file an issue requesting it](https://github.com/json-schema-org/website/issues/new?title=Add%20a%20glossary%20entry%20for%20).
 
 The entries on this page can be linked to via anchor links (e.g. `https://json-schema.org/learn/glossary.html#vocabulary`) when sharing a definition with others.
 

--- a/pages/obsolete-implementations/intro.md
+++ b/pages/obsolete-implementations/intro.md
@@ -6,4 +6,4 @@ Implementations below are written in different languages, and support part, or a
 
 Implementations are classified based on their functionality. When known, the license of the project is also mentioned.
 
-If you have updates to this list, make a pull request on the [GitHub repo](https://github.com/json-schema-org/json-schema-org.github.io).
+If you have updates to this list, make a pull request on the [GitHub repo](https://github.com/json-schema-org/website).


### PR DESCRIPTION
Fixes a few 404s, specifically on the Glossary page.

This does not update the pages/blog/posts/website-analytics-snapshot-2023.md 2023 blog post (which directly links to the json-schema-org.github.io source repository and references behavior that isn't the case for the new website). json-schema-org/community#514 is relevant here, and should likely consider what to do with this link and blog text as part of that PR.

This also does not touch files in the _include directory, which are submodules included from the spec repo and will have their own PR there.