### PR TITLE
Try tweaking the permissions on the token for the autocommenter.

### DIFF
--- a/.github/workflows/new-implementation.yml
+++ b/.github/workflows/new-implementation.yml
@@ -9,12 +9,13 @@ on:
       - data/*.yml
       - pages/implementations/main.md
 
-permissions:
-  pull-requests: write
-
 jobs:
   comment:
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
This doesn't *seem* like it should matter -- in that this workflow was tested as-is on a different repository as part of building it, and ran successfully. Furthermore, the docs for the permissions property in GitHub (at https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) say:

    You can use permissions either as a top-level key, to apply to all
    jobs in the workflow, or within specific jobs. When you add the
    permissions key within a specific job, all actions and run commands
    within that job that use the GITHUB_TOKEN gain the access rights you
    specify.

so, top-level seems like it's supposed to work fine.

And yet, in the "Set up job" step of #206, the permissions for PullRequest are shown as:

    PullRequest: read

(https://github.com/json-schema-org/website/actions/runs/6762327321/job/18401399964?pr=206#step:1:18 though that link won't last forever).

Let's see at least if this changes that...

Refs: #173