### PR TITLE
Add a link to new JVM validator benchmark

### DIFF
--- a/pages/implementations/main.md
+++ b/pages/implementations/main.md
@@ -9,6 +9,9 @@ Benchmarks that compare at least two implementations supporting draft-06+ may be
 -   PHP
   -   [php-json-schema-bench](https://github.com/swaggest/php-json-schema-bench) - comparative benchmark for JSON-schema PHP validators using JSON-Schema Test Suite and z-schema/JSCK (MIT)
 
+-   JVM (Java, Kotlin, Scala)
+  -   [json-schema-validation-comparison](https://www.creekservice.org/json-schema-validation-comparison/) - an independent functional and performance comparison of JVM-based validator implementations using JSON-Schema Test Suite and more (MIT)
+
 ### API documentation
 
 -   JavaScript


### PR DESCRIPTION
Hey, it was suggested on [Slack](https://json-schema.slack.com/archives/C5CF75URH/p1697889828358549), that I raise a PR to add a link to the implementations page for a new performance benchmark & functionality comparison microsite we've created while trying to decide which JVM based validator implementation to use.

Site: https://www.creekservice.org/json-schema-validation-comparison/
Repo: https://github.com/creek-service/json-schema-validation-comparison

The site is designed to be auto-updating, via GitHub dependabot, as new versions of implementations are released. Contribution from implementation developers is encouraged.