### PR TITLE
Apply for adding new json schema validator implementation for .Net: LateApexEarlySpeed.Json.Schema

### DIFF
--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -19,6 +19,12 @@
       draft: [7, 6]
       license: Apache License, Version 2.0
       last-updated: "2023-02-14"
+    - name: LateApexEarlySpeed.Json.Schema
+      url: https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema.Doc
+      date-draft: [2020-12]
+      draft: []
+      license: BSD-3-Clause
+      last-updated: "2023-12-13"
 - name: C++
   implementations:
     - name: f5-json-schema


### PR DESCRIPTION
Hello, recently I created my personal project about json schema implementation for .net. It is based on draft 2020-12, has known limitation currently listed in project doc but it also has some features and advantages. Currently it is a free close source project and may be transferred to be open source in future.

I am not sure if it is proper to be added to this website's implementation list. The description of implementation: https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema.Doc

Intention of writing this implementation:
Several years ago, I touched and learned json schema concept during work, and feel json schema is interesting concept because it can describe any data well, and I used some excellent json schema libraries for work. Years later, I would like to implement json schema myself and meantime try to find some difficulties so to improve my develop skills during design and coding, performance optimization and CICD experience for this project. Now I would also hope more people can use it.

Thanks !