### PR TITLE
Add eslint-plugin-json-schema-validator to "Linter plugins" implementations

### DIFF
--- a/pages/implementations/main.md
+++ b/pages/implementations/main.md
@@ -253,5 +253,6 @@ the utility, and decided on a case-by-case basis.
 ## Linter plugins
 
 - [remark-lint-frontmatter-schema](https://github.com/JulianCataldo/remark-lint-frontmatter-schema) - Validate **Markdown** frontmatter **YAML** against an associated **JSON schema** with this **remark-lint** rule plugin.
+- [eslint-plugin-json-schema-validator](https://github.com/ota-meshi/eslint-plugin-json-schema-validator) - ESLint plugin that validates code using JSON schema and reports violations.
 
 ## Hyper-Schema


### PR DESCRIPTION



<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** NA

**Summary**:

This PR adds [eslint-plugin-json-schema-validator] to the list of **Linter plugins**.

[eslint-plugin-json-schema-validator] is an ESLint plugin that validates code using JSON schema and reports violations.

[eslint-plugin-json-schema-validator]: https://github.com/ota-meshi/eslint-plugin-json-schema-validator/

---

close https://github.com/ota-meshi/eslint-plugin-json-schema-validator/issues/281