### PR TITLE
Fix to include compliance notes of the validators

### DIFF
--- a/pages/implementations/index.page.tsx
+++ b/pages/implementations/index.page.tsx
@@ -111,7 +111,7 @@ function ImplementationTable ({ implementationsByLanguage, prefix }: { implement
                       mixedNotes = implementation.notes
                     }
                     if (implementation.compliance) {
-                      if (implementation.notes){
+                      if (implementation.notes) {
                         mixedNotes += '<br/><em>Compliance:</em>'
                       } else {
                         mixedNotes = '<em>Compliance:</em>'

--- a/pages/implementations/index.page.tsx
+++ b/pages/implementations/index.page.tsx
@@ -106,6 +106,23 @@ function ImplementationTable ({ implementationsByLanguage, prefix }: { implement
                     </td>
                   </tr>
                   {implementationByLanguage.implementations.map((implementation: any, index: number) => {
+                    let mixedNotes = ''
+                    if (implementation.notes){
+                      mixedNotes = implementation.notes
+                    }
+                    if (implementation.compliance){
+                      if (implementation.notes){
+                        mixedNotes += '<br/><em>Compliance:</em>'
+                      } else {
+                        mixedNotes = '<em>Compliance:</em>'
+                      }
+                      if (implementation.compliance.config.docs){
+                        mixedNotes += ' This implementation <a href="' + implementation.compliance.config.docs + '">documents</a> that you must '
+                      }
+                      if (implementation.compliance.config.instructions){
+                        mixedNotes += '<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'
+                      }
+                    }                 
                     const allDrafts = [
                       ...(implementation['date-draft'] || []),
                       ...(implementation['draft'] || [])
@@ -118,26 +135,7 @@ function ImplementationTable ({ implementationsByLanguage, prefix }: { implement
                           <a className='text-blue-500' href={implementation.url}>{implementation.name}</a>
                         </td>
                         <td className='pl-6 hidden sm:table-cell'>
-                          {implementation.notes && (
-                            <React.Fragment>
-                              <StyledMarkdown markdown={'Notes: ' + implementation.notes} />
-                            </React.Fragment>
-                          )}
-                          {implementation.compliance && (
-                            <React.Fragment>
-                              Compliance:
-                              {implementation.compliance.config.docs && (
-                                <React.Fragment>
-                                  This implementation <a href={implementation.compliance.config.docs}>documents</a> that you must
-                                </React.Fragment>
-                              )}
-                              {implementation.compliance.config.instructions && (
-                                <React.Fragment>
-                                  <StyledMarkdown markdown={'<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'} />
-                                </React.Fragment>
-                              )}
-                            </React.Fragment>
-                          )}
+                          <StyledMarkdown markdown={mixedNotes} />
                         </td>
                         <td className='pl-6 pb-2 pt-2'>
                           {allDrafts

--- a/pages/implementations/index.page.tsx
+++ b/pages/implementations/index.page.tsx
@@ -123,12 +123,12 @@ function ImplementationTable ({ implementationsByLanguage, prefix }: { implement
                           )}
                           {implementation.compliance && (
                             <>Compliance:
-                            {implementation.compliance.config.docs && (
-                              <> This implementation <a href={implementation.compliance.config.docs}>documents</a> that you must</>
-                            )}
-                            {implementation.compliance.config.instructions && (
-                              <> <StyledMarkdown markdown={'<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'} /></>
-                            )}
+                              {implementation.compliance.config.docs && (
+                                <> This implementation <a href={implementation.compliance.config.docs}>documents</a> that you must</>
+                              )}
+                              {implementation.compliance.config.instructions && (
+                                <> <StyledMarkdown markdown={'<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'} /></>
+                              )}
                             </>
                           )}
                         </td>

--- a/pages/implementations/index.page.tsx
+++ b/pages/implementations/index.page.tsx
@@ -119,17 +119,24 @@ function ImplementationTable ({ implementationsByLanguage, prefix }: { implement
                         </td>
                         <td className='pl-6 hidden sm:table-cell'>
                           {implementation.notes && (
-                            <> <StyledMarkdown markdown={'Notes: ' + implementation.notes} /></>
+                            <React.Fragment>
+                              <StyledMarkdown markdown={'Notes: ' + implementation.notes} />
+                            </React.Fragment>
                           )}
                           {implementation.compliance && (
-                            <>Compliance:
+                            <React.Fragment>
+                              Compliance:
                               {implementation.compliance.config.docs && (
-                                <> This implementation <a href={implementation.compliance.config.docs}>documents</a> that you must</>
+                                <React.Fragment>
+                                  This implementation <a href={implementation.compliance.config.docs}>documents</a> that you must
+                                </React.Fragment>
                               )}
                               {implementation.compliance.config.instructions && (
-                                <> <StyledMarkdown markdown={'<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'} /></>
+                                <React.Fragment>
+                                  <StyledMarkdown markdown={'<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'} />
+                                </React.Fragment>
                               )}
-                            </>
+                            </React.Fragment>
                           )}
                         </td>
                         <td className='pl-6 pb-2 pt-2'>

--- a/pages/implementations/index.page.tsx
+++ b/pages/implementations/index.page.tsx
@@ -107,19 +107,19 @@ function ImplementationTable ({ implementationsByLanguage, prefix }: { implement
                   </tr>
                   {implementationByLanguage.implementations.map((implementation: any, index: number) => {
                     let mixedNotes = ''
-                    if (implementation.notes){
+                    if (implementation.notes) {
                       mixedNotes = implementation.notes
                     }
-                    if (implementation.compliance){
+                    if (implementation.compliance) {
                       if (implementation.notes){
                         mixedNotes += '<br/><em>Compliance:</em>'
                       } else {
                         mixedNotes = '<em>Compliance:</em>'
                       }
-                      if (implementation.compliance.config.docs){
+                      if (implementation.compliance.config.docs) {
                         mixedNotes += ' This implementation <a href="' + implementation.compliance.config.docs + '">documents</a> that you must '
                       }
-                      if (implementation.compliance.config.instructions){
+                      if (implementation.compliance.config.instructions) {
                         mixedNotes += '<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'
                       }
                     }                 

--- a/pages/implementations/index.page.tsx
+++ b/pages/implementations/index.page.tsx
@@ -118,7 +118,19 @@ function ImplementationTable ({ implementationsByLanguage, prefix }: { implement
                           <a className='text-blue-500' href={implementation.url}>{implementation.name}</a>
                         </td>
                         <td className='pl-6 hidden sm:table-cell'>
-                          <StyledMarkdown markdown={implementation.notes} />
+                          {implementation.notes && (
+                            <> <StyledMarkdown markdown={'Notes: ' + implementation.notes} /></>
+                          )}
+                          {implementation.compliance && (
+                            <>Compliance:
+                            {implementation.compliance.config.docs && (
+                              <> This implementation <a href={implementation.compliance.config.docs}>documents</a> that you must</>
+                            )}
+                            {implementation.compliance.config.instructions && (
+                              <> <StyledMarkdown markdown={'<strong>' + implementation.compliance.config.instructions + '</strong> to produce specification-compliant behavior.'} /></>
+                            )}
+                            </>
+                          )}
                         </td>
                         <td className='pl-6 pb-2 pt-2'>
                           {allDrafts


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #270 

**Summary**: Fix to include the missing compliance notes of the validators in the implementations page.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No