### PR TITLE
Add support for the Markdown convention for Italic text using _

### DIFF
--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -143,7 +143,10 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
             },
             italic: {
               component: ({ children }) => <i>{children}</i>
-            },            
+            },    
+            bold: {
+              component: ({ children }) => <b>{children}</b>
+            },           
             p: {
               component: ({ children }) => (
                 <p className='text-slate-600 block leading-7 pb-4'>

--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -141,6 +141,9 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
             strong: {
               component: ({ children }) => <strong className='font-semibold text-slate-800'>{children}</strong>
             },
+            italic: {
+              component: ({ children }) => <i>{children}</i>
+            },            
             p: {
               component: ({ children }) => (
                 <p className='text-slate-600 block leading-7 pb-4'>


### PR DESCRIPTION
**GitHub Issue:** # / NA

**Summary**: Currently the text using _ format text as Italic is not working. The expected behaviour of the website is to render _text_ to <i>text</i>.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No