### PR TITLE
Updates openapi json schema generator

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,16 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/community" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-00" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-01" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-02" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-03" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-04" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-05" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-06" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft-07" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft/2019-09" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/_includes/draft/2020-12" vcs="Git" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,16 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/community" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-00" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-01" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-02" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-03" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-04" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-05" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-06" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft-07" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft/2019-09" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/_includes/draft/2020-12" vcs="Git" />
   </component>
 </project>

--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -197,6 +197,13 @@
       date-draft: [ 2020-12 ]
       license: Apache 2.0
       last-updated: "2023-09-04"
+    - name: OpenAPI JSON Schema Generator
+      notes: Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. JSON schema validation run when validating schemas.
+      url: https://github.com/openapi-json-schema-tools/openapi-json-schema-generator
+      date-draft: [2020-12]
+      draft: [5]
+      license: Apache-2.0
+      last-updated: "2024-01-21"
 - name: JavaScript
   implementations:
     - name: Hyperjump JSV
@@ -373,7 +380,7 @@
       date-draft: [2020-12]
       draft: [5]
       license: Apache-2.0
-      last-updated: "2023-09-28"
+      last-updated: "2024-01-21"
 - name: Ruby
   implementations:
     - name: JSONSchemer

--- a/pages/implementations/main.md
+++ b/pages/implementations/main.md
@@ -115,7 +115,8 @@ are the only keywords that changed.
   -  [jsonschema2pojo](https://github.com/joelittlejohn/jsonschema2pojo) (Apache 2.0) - generates Java types from JSON Schema (or example JSON) and can annotate those types for data-binding with Jackson 2.x or Gson. *draft-07*
   -  [jsonschematypes](https://github.com/jimblackler/jsonschematypes) (Apache 2.0) - Java library to generate Java or TypeScript classes from standard JSON Schemas. *JSON Schema 2019-09, draft-07, -06, -04, -03*
   -  [jsongenerator](https://github.com/jimblackler/jsonschematypes/tree/master/codegen) *JSON Schema 2019-09, draft-07, -06, -04, -03* (Apache-2.0)
--   Kotlin
+  -  [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator) (Apache-2.0) - Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. This project focuses on making the output 100% compliant with openapi + JSON schema specs. JSON Schema 2020-12, draft-05
+- Kotlin
   -  [json-kotlin-schema-codegen](https://github.com/pwall567/json-kotlin-schema-codegen) (MIT) - Generates Kotlin data classes, Java classes or TypeScript interfaces from JSON Schema.
 -   Online (web tool)
   -  [quicktype.io](https://app.quicktype.io/#l=schema) - infer JSON Schema from samples, and generate TypeScript, C++, go, Java, C#, Swift, etc. types from JSON Schema
@@ -124,7 +125,7 @@ are the only keywords that changed.
 -   Python
   -  [yacg](https://github.com/OkieOth/yacg) (MIT) - parse JSON Schema and OpenApi files to build a meta model from them. This meta model can be used in Mako templates to generate source code, other schemas or plantUml.
   -  [statham](https://github.com/jacksmith15/statham-schema) (MIT) - generate type-annotated models from JSON Schema documents.
-  -  [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator) (Apache-2.0) - Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. This project focuses on making the output 100% compliant with openapi + JSON schema specs.
+  -  [OpenAPI JSON Schema Generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator) (Apache-2.0) - Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. This project focuses on making the output 100% compliant with openapi + JSON schema specs. JSON Schema 2020-12, draft-05
 -   Rust
   -  [schemafy](https://github.com/Marwes/schemafy/) - generates Rust types and serialization code from a JSON schema. *supports Draft 4*
 -   Scala


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** # / NA

**Summary**:

Updates openapi json schema generator
- lists the project in java + python for validation
- lists the project in java and python for code generation, adds json schema drafts

I am updating these sections because I am the maintainer of that project and I [recently added draft 2020-12 schema validation to the java code generator](https://github.com/openapi-json-schema-tools/openapi-json-schema-generator/releases/tag/4.1.0).

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

Yes/No
[JUSTIFICATION]