### PR TITLE
Correct Q&A discussion link in DocsHelp.tsx

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -9,7 +9,7 @@ export const DocsHelp = () => {
         </svg> Need help?
       </h3>
       <div className='mt-2 mb-2'>
-        Learning JSON Schema is often confusing, but don't worry, we are here to help! You can start a thread on <a target='_blank' className='underline' rel='noreferrer' href='https://github.com/json-schema-org/community/discussions/new?category=q-a'>GitHub Discussions</a>, connect with us on <a target='_blank' rel='noreferrer' className='underline' href='https://json-schema.org/slack'>Slack</a>, or join our live <a target='_blank' rel='noreferrer' className='underline' href='https://github.com/json-schema-org/community/discussions/34'>Office Hours</a>.
+        Learning JSON Schema is often confusing, but don't worry, we are here to help! You can start a thread on <a target='_blank' className='underline' rel='noreferrer' href='https://github.com/orgs/json-schema-org/discussions/new?category=q-a'>GitHub Discussions</a>, connect with us on <a target='_blank' rel='noreferrer' className='underline' href='https://json-schema.org/slack'>Slack</a>, or join our live <a target='_blank' rel='noreferrer' className='underline' href='https://github.com/json-schema-org/community/discussions/34'>Office Hours</a>.
       </div>
       <div className='mt-1 mb-2'>
         We'd love to help!! ❤️


### PR DESCRIPTION
Correct link to start a new Q&A discussion


<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** NA

**Summary**:
Fixing a slightly broken link in the docs. Most of the redirects from `github.com/json-schema-org/community/` to `github.com/orgs/json-schema-org` work correctly (eg - [https://github.com/_**json-schema-org/community**_/discussions/34](https://github.com/json-schema-org/community/discussions/34) correctly redirects to [https://github.com/_**orgs/json-schema-org**_/discussions/34](https://github.com/orgs/json-schema-org/discussions/34)), but this link to start a new Q&A discussion doesn't.

<img width="330" alt="image" src="https://github.com/eddyashton/json_schema_website/assets/6000239/6a223217-5a31-4ef3-8c38-1550103238df">

When clicked, it takes you to https://github.com/orgs/json-schema-org/discussions/new/choose with the following error banner:
<img width="461" alt="image" src="https://github.com/eddyashton/json_schema_website/assets/6000239/af407a0d-e81a-4467-8987-28460d57570c">

This PR updates that link in the help popup, to point directly to `orgs/json-schema-org`.


**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No