### PR TITLE
Update implementation link to open source project repo

### DIFF
--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -20,7 +20,7 @@
       license: Apache License, Version 2.0
       last-updated: "2023-02-14"
     - name: LateApexEarlySpeed.Json.Schema
-      url: https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema.Doc
+      url: https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema
       date-draft: [2020-12]
       draft: []
       license: BSD-3-Clause


### PR DESCRIPTION
The .net implementation of json schema: LateApexEarlySpeed.Json.Schema turns to be open-source now, so I would update link from previous doc repo to current open source project repo. Thanks !