### PR TITLE
Update networknt/json schema validator to indicate support for 2020-12 and 2019-09

### DIFF
--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -152,14 +152,14 @@
     - name: networknt/json-schema-validator
       url: https://github.com/networknt/json-schema-validator
       notes: Support OpenAPI 3.0 with Jackson parser
-      date-draft: []
+      date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4]
       license: Apache License 2.0
       compliance:
         config:
             docs: https://github.com/networknt/json-schema-validator/blob/master/doc/config.md
             instructions: "set `handleNullableField` to `false`"
-      last-updated: "2022-08-31"
+      last-updated: "2024-02-05"
     - name: erosb/json-sKema
       url: https://github.com/erosb/json-sKema
       notes: Successor of the everit-org/json-schema library


### PR DESCRIPTION
As of 1.3.1 the networknt/json-schema-validator supports 2020-12 and 2019-09.

- https://www.creekservice.org/json-schema-validation-comparison/functional#summary-results-table