### PR TITLE
Rename implementations section to tools

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -122,8 +122,8 @@ const MainNavigation = () => {
       <MainNavLink
         className='hidden lg:block hover:underline'
         uri='/implementations'
-        label='Implementations'
-        isActive={section === 'implementations'}
+        label='Tools'
+        isActive={section === 'tools'}
 
       />
       <MainNavLink
@@ -185,9 +185,9 @@ const MobileNav = () => {
       />
 
       <MainNavLink
-        uri='/implementations'
-        label='Implementations'
-        isActive={section === 'implementations'}
+        uri='/tools'
+        label='Tools'
+        isActive={section === 'tools'}
 
       />
       <MainNavLink

--- a/context.ts
+++ b/context.ts
@@ -6,6 +6,6 @@ export enum BlockContextValue {
   Details
 }
 
-export const SectionContext = React.createContext<null | 'learn' | 'docs' | 'implementers' | 'implementations' | 'blog' | 'community' | 'specification'| 'overview' | 'getting-started' | 'reference'>(null)
+export const SectionContext = React.createContext<null | 'learn' | 'docs' | 'implementers' | 'tools' | 'blog' | 'community' | 'specification'| 'overview' | 'getting-started' | 'reference'>(null)
 export const BlockContext = React.createContext<BlockContextValue | null>(null)
 export const FullMarkdownContext = React.createContext<string | null>(null)

--- a/pages/implementations/index.page.tsx
+++ b/pages/implementations/index.page.tsx
@@ -38,9 +38,9 @@ type ImplementationByLanguage = { name: string }
 
 export default function ImplementationsPages ({ blocks, validators, hyperLibaries }: { blocks: any, validators: ImplementationByLanguage[], hyperLibaries: ImplementationByLanguage[] }) {
   return (
-    <SectionContext.Provider value='implementations'>
+    <SectionContext.Provider value='tools'>
       <div className='w-5/6 mx-auto mt-12'>
-        <Headline1>Implementations</Headline1>
+        <Headline1>Tools</Headline1>
         <StyledMarkdown markdown={blocks.intro} />
         <Headline2>Validators</Headline2>
         <ImplementationTable implementationsByLanguage={validators} prefix='validators-' />

--- a/pages/obsolete-implementations/index.page.tsx
+++ b/pages/obsolete-implementations/index.page.tsx
@@ -41,7 +41,7 @@ type ImplementationByLanguage = { name: string }
 
 export default function ImplementationsPages ({ blocks, validators, hyperLibaries }: { blocks: any, validators: ImplementationByLanguage[], hyperLibaries: ImplementationByLanguage[] }) {
   return (
-    <SectionContext.Provider value='implementations'>
+    <SectionContext.Provider value='tools'>
       <Headline1>Obsolete Implementations</Headline1>
       <StyledMarkdown markdown={blocks.intro} />
 

--- a/pages/obsolete-implementations/index.page.tsx
+++ b/pages/obsolete-implementations/index.page.tsx
@@ -42,7 +42,7 @@ type ImplementationByLanguage = { name: string }
 export default function ImplementationsPages ({ blocks, validators, hyperLibaries }: { blocks: any, validators: ImplementationByLanguage[], hyperLibaries: ImplementationByLanguage[] }) {
   return (
     <SectionContext.Provider value='tools'>
-      <Headline1>Obsolete Implementations</Headline1>
+      <Headline1>Obsolete Tools</Headline1>
       <StyledMarkdown markdown={blocks.intro} />
 
       <Headline2>Validators</Headline2>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #320 
Resolves: #320

**Summary**: This PR renames the Implementations section in favour of Tools

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No