### PR TITLE
WIP: add warning about the use of oneof with recursive references

### DIFF
--- a/pages/understanding-json-schema/reference/combining.md
+++ b/pages/understanding-json-schema/reference/combining.md
@@ -135,6 +135,9 @@ Multiple of *both* 5 and 3 is rejected.
 15
 ```
 
+.. warning::
+   Careful consideration should be taken when using `oneOf` entries as the nature of it requires verification of all sub-schemas so doing anything recursive can have a severe performance impact.
+
 <Keywords label="single: not single: schema composition; not" />
 
 ## not


### PR DESCRIPTION
add warning about the use of `oneof` with recursive references so people don't panic when processing times increase 10x from a seemingly small change


<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** https://github.com/json-schema-org/community/issues/520 & https://github.com/json-schema-org/understanding-json-schema/pull/131

**Summary**:

Using `oneOf` entries with recursive references or simply a high number of references results in long processing times which is actually expected given the nature of `oneOf` (i.e. it has to check *every* referenced schema). However, this is not immediately obvious during development.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

No, because it's just a tiny warning added to the docs.