### PR TITLE
Change copy code button to an icon

### DIFF
--- a/components/JsonEditor.tsx
+++ b/components/JsonEditor.tsx
@@ -184,7 +184,7 @@ export default function JsonEditor ({ initialCode }: { initialCode: string }) {
   ) : null
   const caption: null | string = meta?.caption || null
 
-  // fullCodeText variable is for future use in copy pasting the code for the user
+  // fullCodeText variable is for use in copy pasting the code for the user
   const fullCodeText = React.useMemo(() => {
     let text = ''
     if (value) { 
@@ -212,11 +212,23 @@ export default function JsonEditor ({ initialCode }: { initialCode: string }) {
       <div className={classnames('relative font-mono bg-slate-800 border rounded-xl mt-1 overflow-hidden shadow-lg', {
         'ml-10': meta?.indent
       })}>
-        <div className='flex flex-row items-center absolute right-0 text-white h-6 font-sans bg-white/20 text-xs px-3 rounded-bl-lg font-semibold'>
-          {isJsonSchema
-            ? <><img src='/logo-white.svg' className='h-4 mr-1.5' /> schema</>
-            : <>data</>
-          }
+        <div className='flex flex-row absolute right-0 z-10'>
+          { /* Copy code button */ }
+          <div className='flex mr-1.5 cursor-pointer group'
+            onClick={() => {
+              navigator.clipboard.writeText(fullCodeText)
+              setCopied(true)
+              setTimeout(() => setCopied(false), 2000)
+            }}>
+              <img src='/icons/copy.svg' title='Copy to clipboard' className={`opacity-50 hover:opacity-90 duration-150 ${copied ? 'hidden' : ''}`}></img>
+              <img src='/icons/copied.svg' title='Copied!' className={copied ? '' : 'hidden'}></img>
+          </div>
+          <div className='flex flex-row items-center text-white h-6 font-sans bg-white/20 text-xs px-3 rounded-bl-lg font-semibold'>
+            {isJsonSchema
+              ? <><img src='/logo-white.svg' className='h-4 mr-1.5' /> schema</>
+              : <>data</>
+            }
+          </div>
         </div>
         <Editable
           onCopy={(e) => {
@@ -295,21 +307,6 @@ export default function JsonEditor ({ initialCode }: { initialCode: string }) {
             throw new Error(`unknown element.type [${element.type}] in render function`)
           }}
         />
-
-        {/* Copy Code button */}
-        <div 
-          className='absolute right-0 bottom-0 text-white bg-slate-800/50 text-xs px-3 py-1 cursor-pointer
-           hover:bg-slate-500 rounded'
-          onClick={() => {
-            navigator.clipboard.writeText(fullCodeText)
-            setCopied(true)
-            setTimeout(() => setCopied(false), 2500)
-          }}
-        >
-          {
-            copied ? 'Copied' : 'Copy'
-          }
-        </div>
 
         {validation === 'invalid' && (
           <div className='text-white px-4 py-3 font-sans flex flex-row justify-end items-center bg-red-500/30 text-sm'>

--- a/public/icons/copied.svg
+++ b/public/icons/copied.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#00DD00" class="bi bi-check2" viewBox="0 0 16 16">
+  <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0"/>
+</svg>

--- a/public/icons/copy.svg
+++ b/public/icons/copy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#ffffff" class="bi bi-copy" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M4 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2zm2-1a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1zM2 5a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1h1v1a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h1v1z"/>
+</svg>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** Resolves https://github.com/json-schema-org/website/issues/344

**Summary**:
The previous copy code button covered the validity indicator. This PR changes it to a copy icon next to the data type label.

**Before:**
![image](https://github.com/json-schema-org/website/assets/46278840/9670b96c-ba79-4577-899d-c3bf1f335048)

**After:**
![image](https://github.com/json-schema-org/website/assets/46278840/9ada4577-0925-4c77-9a3a-acb553937b46)

**New click animation:**

https://github.com/json-schema-org/website/assets/46278840/740b895f-8e5c-49f7-beca-75b6d3db9485

<hr>

**Implementation notes:**
Both the icons are always rendered with one always being invisible. I tried to use a ternary operator, but the hover animation caused the copy icon to flash after coming back, and I didn't like the way that looked:

https://github.com/json-schema-org/website/assets/46278840/c37d11ed-a33c-47bb-9493-51bedea88a84


**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**:
No, this is a minor visual change.