### PR TITLE
Fix Inconsistent code rendering in documentation examples

### DIFF
--- a/pages/learn/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step.md
@@ -139,6 +139,7 @@ With the new `properties` validation keyword, the overall schema looks like this
   "description": "A product from Acme's catalog",
   "type": "object",
   "properties": {
+    ...
     "productId": {
       "description": "The unique identifier for a product",
       "type": "integer"
@@ -157,6 +158,7 @@ The following example adds another required key, `productName`. This value is a 
   "description": "A product from Acme's catalog",
   "type": "object",
   "properties": {
+    ...
     "productId": {
       "description": "The unique identifier for a product",
       "type": "integer"
@@ -195,6 +197,7 @@ To define a required property:
 
 ```json
 {
+  ...
   "price": {
     "description": "The price of the product",
     "type": "number",
@@ -207,6 +210,7 @@ To define a required property:
 
 ```json
 {
+  ...
   "price": {
     "description": "The price of the product",
     "type": "number",
@@ -228,6 +232,7 @@ With the new `required` keyword and `price` key, the overall schema looks like t
   "description": "A product from Acme's catalog",
   "type": "object",
   "properties": {
+    ...
     "productId": {
       "description": "The unique identifier for a product",
       "type": "integer"
@@ -277,6 +282,7 @@ To define an optional property:
 
 ```json
 {
+  ...
   "tags": {
     "description": "Tags for the product",
     "type": "array",
@@ -291,6 +297,7 @@ To define an optional property:
 
 ```json
 {
+  ...
   "tags": {
     "description": "Tags for the product",
     "type": "array",
@@ -306,6 +313,7 @@ To define an optional property:
 
 ```json
 {
+  ...
   "tags": {
     "description": "Tags for the product",
     "type": "array",
@@ -328,6 +336,7 @@ With the new `tags` keyword, the overall schema looks like this:
   "description": "A product from Acme's catalog",
   "type": "object",
   "properties": {
+    ...
     "productId": {
       "description": "The unique identifier for a product",
       "type": "integer"
@@ -394,6 +403,7 @@ To create a nested data structure:
   "dimensions": {
     "type": "object",
     "properties": {
+      ...
       "length": {
         "type": "number"
       },
@@ -415,6 +425,7 @@ To create a nested data structure:
   "dimensions": {
     "type": "object",
     "properties": {
+      ...
       "length": {
         "type": "number"
       },
@@ -440,6 +451,7 @@ Using the new nested data structures, the overall schema looks like this:
   "description": "A product from Acme's catalog",
   "type": "object",
   "properties": {
+    ...
     "productId": {
       "description": "The unique identifier for a product",
       "type": "integer"
@@ -501,6 +513,7 @@ The following schema validates a geographical location:
   "required": ["latitude", "longitude"],
   "type": "object",
   "properties": {
+    ...
     "latitude": {
       "type": "number",
       "minimum": -90,
@@ -550,6 +563,7 @@ With the external schema reference, the overall schema looks like this:
   "description": "A product from Acme's catalog",
   "type": "object",
   "properties": {
+    ...
     "productId": {
       "description": "The unique identifier for a product",
       "type": "integer"
@@ -625,4 +639,5 @@ This example JSON data matches the product catalog schema:
 To validate this JSON data against the product catalog JSON Schema, you can use any validator of your choice. In addition to command-line and browser tools, validation tools are available in a wide range of languages, including Java, Python, .NET, and many others. To find a validator that’s right for your project, see [Implementations](https://json-schema.org/implementations).
 
 Use the example JSON data as the input data and the product catalog JSON Schema as the schema. Your validation tool compares the data against the schema, and if the data meets all the requirements defined in the schema, validation is successful.
+
 

--- a/pages/learn/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step.md
@@ -5,11 +5,11 @@ section: docs
 
 JSON Schema is a vocabulary that you can use to annotate and validate JSON documents. This tutorial guides you through the process of creating a JSON Schema document, including:
 
-* [Creating a schema definition](#create)
-* [Defining properties](#define)
-* [Nesting data structures](#nest-data)
-* [Adding outside references](#external)
-* [Validating JSON data against the schema](#validate)
+- [Creating a schema definition](#create)
+- [Defining properties](#define)
+- [Nesting data structures](#nest-data)
+- [Adding outside references](#external)
+- [Validating JSON data against the schema](#validate)
 
 After you create the JSON Schema document, you can validate the example data against your schema using a validator in a language of your choice. See [Implementations](https://json-schema.org/implementations) for a current list of supported validators.
 
@@ -25,17 +25,17 @@ The example we use in this guide is a product catalog that stores its data using
 {
   "productId": 1,
   "productName": "A green door",
-  "price": 12.50,
-  "tags": [ "home", "green" ]
+  "price": 12.5,
+  "tags": ["home", "green"]
 }
 ```
 
 Each product in the catalog has:
 
-* `productId`: an identifier for the product
-* `productName`: the product name
-* `price`: the cost to the consumer
-* `tags`: an optional array of identifying tags
+- `productId`: an identifier for the product
+- `productName`: the product name
+- `price`: the cost to the consumer
+- `tags`: an optional array of identifying tags
 
 The JSON object is human-readable, but it doesn’t include any context or metadata. There’s no way to tell from looking at the object what the keys mean or what the possible inputs are. JSON Schema is a standard for providing answers to these questions. In this guide, you will create a JSON Schema document that describes the structure, constraints, and data types for a set of JSON data.
 
@@ -65,10 +65,10 @@ JSON Schema is hypermedia-ready and ideal for annotating your existing JSON-base
 
 To create a basic schema definition, define the following keywords:
 
-* `$schema`: specifies which draft of the JSON Schema standard the schema adheres to.
-* `$id`: sets a URI for the schema. You can use this unique URI to refer to elements of the schema from inside the same document or from external JSON documents.
-* `title` and `description`: state the intent of the schema. These keywords don’t add any constraints to the data being validated.
-* `type`: defines the first constraint on the JSON data. In the product catalog example below, this keyword specifies that the data must be a JSON object.
+- `$schema`: specifies which draft of the JSON Schema standard the schema adheres to.
+- `$id`: sets a URI for the schema. You can use this unique URI to refer to elements of the schema from inside the same document or from external JSON documents.
+- `title` and `description`: state the intent of the schema. These keywords don’t add any constraints to the data being validated.
+- `type`: defines the first constraint on the JSON data. In the product catalog example below, this keyword specifies that the data must be a JSON object.
 
 For example:
 
@@ -99,28 +99,32 @@ Using the product catalog example, `productId` is a numeric value that uniquely 
 To add the `properties` object to the schema:
 
 1. Add the `properties` validation keyword to the end of the schema:
-    
+
 ```json
-...
-"title": "Product",
-"description": "A product from Acme's catalog",
-"type": "object",
-"properties": {
-  "productId": {
+{
+  ...
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "productId": {
+    }
   }
 }
 ```
 
 2. Add the `productId` keyword, along with the following schema annotations:
-    * `description`: describes what `productId` is. In this case, it’s the product’s unique identifier.
-    * `type`: defines what kind of data is expected. For this example, since the product identifier is a numeric value, use `integer`.
-    
+   - `description`: describes what `productId` is. In this case, it’s the product’s unique identifier.
+   - `type`: defines what kind of data is expected. For this example, since the product identifier is a numeric value, use `integer`.
+
 ```json
-...
-"properties": {
-  "productId": {
-    "description": "The unique identifier for a product",
-    "type": "integer"
+{
+  ...
+  "properties": {
+    "productId": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    }
   }
 }
 ```
@@ -174,36 +178,44 @@ This section describes how to specify that certain properties are required. This
 To define a required property:
 
 1. Inside the `properties` object, add the `price` key. Include the usual schema annotations `description` and `type`, where `type` is a number:
-    
+
 ```json
-"properties": {
-...
-  "price": {
-    "description": "The price of the product",
-    "type": "number"
+{
+  "properties": {
+  ...
+    "price": {
+      "description": "The price of the product",
+      "type": "number"
+    }
   }
+}
 ```
 
 2. Add the `exclusiveMinimum` validation keyword and set the value to zero:
-    
+
 ```json
-"price": {
-  "description": "The price of the product",
-  "type": "number",
-  "exclusiveMinimum": 0
+{
+  "price": {
+    "description": "The price of the product",
+    "type": "number",
+    "exclusiveMinimum": 0
+  }
 }
 ```
 
 3. Add the `required` validation keyword to the end of the schema, after the `properties` object. Add `productID`, `productName`, and the new `price` key to the array:
-    
+
 ```json
-"price": {
-  "description": "The price of the product",
+{
+  "price": {
+    "description": "The price of the product",
     "type": "number",
     "exclusiveMinimum": 0
+  },
+  {
+    "required": [ "productId", "productName", "price" ]
   }
-},
-"required": [ "productId", "productName", "price" ]
+}
 ```
 
 With the new `required` keyword and `price` key, the overall schema looks like this:
@@ -230,7 +242,7 @@ With the new `required` keyword and `price` key, the overall schema looks like t
       "exclusiveMinimum": 0
     }
   },
-  "required": [ "productId", "productName", "price" ]
+  "required": ["productId", "productName", "price"]
 }
 ```
 
@@ -240,61 +252,69 @@ The `exclusiveMinimum` validation keyword is set to zero, which means that only 
 
 This section describes how to define an optional property. For this example, define a keyword named `tags` using the following criteria:
 
-* The `tags` keyword is optional.
-* If `tags` is included, it must contain at least one item.
-* All tags must be unique.
-* All tags must be text.
+- The `tags` keyword is optional.
+- If `tags` is included, it must contain at least one item.
+- All tags must be unique.
+- All tags must be text.
 
 To define an optional property:
 
 1. Inside the `properties` object, add the `tags` keyword. Include the usual schema annotations `description` and `type`, and define `type` as an array:
-    
+
 ```json
-"properties": {
-...
-  "tags": {
-    "description": "Tags for the product",
-    "type": "array"
+{
+  "properties": {
+  ...
+    "tags": {
+      "description": "Tags for the product",
+      "type": "array"
+    }
   }
 }
 ```
 
 2. Add a new validation keyword for `items` to define what appears in the array. For example, `string`:
-    
+
 ```json
-"tags": {
-  "description": "Tags for the product",
-  "type": "array",
-  "items": {
-    "type": "string"
+{
+  "tags": {
+    "description": "Tags for the product",
+    "type": "array",
+    "items": {
+      "type": "string"
+    }
   }
 }
 ```
 
 3. To make sure there is at least one item in the array, use the `minItems` validation keyword:
-    
+
 ```json
-"tags": {
-  "description": "Tags for the product",
-  "type": "array",
-  "items": {
-    "type": "string"
-  },
-  "minItems": 1
+{
+  "tags": {
+    "description": "Tags for the product",
+    "type": "array",
+    "items": {
+      "type": "string"
+    },
+    "minItems": 1
+  }
 }
 ```
 
 4. To make sure that every item in the array is unique, use the `uniqueItems` validation keyword and set it to `true`:
-    
+
 ```json
-"tags": {
-  "description": "Tags for the product",
-  "type": "array",
-  "items": {
-    "type": "string"
-  },
-  "minItems": 1,
-  "uniqueItems": true
+{
+  "tags": {
+    "description": "Tags for the product",
+    "type": "array",
+    "items": {
+      "type": "string"
+    },
+    "minItems": 1,
+    "uniqueItems": true
+  }
 }
 ```
 
@@ -331,7 +351,7 @@ With the new `tags` keyword, the overall schema looks like this:
       "uniqueItems": true
     }
   },
-  "required": [ "productId", "productName", "price" ]
+  "required": ["productId", "productName", "price"]
 }
 ```
 
@@ -346,59 +366,67 @@ The earlier examples describe a flat schema with only one level. This section de
 To create a nested data structure:
 
 1. Inside the `properties` object, create a new key called `dimensions`:
-    
+
 ```json
-"properties": {
-...
-  "dimensions": {
+{
+  "properties": {
+  ...
+    "dimensions": {
+    }
   }
 }
 ```
 
 2. Define the `type` validation keyword as `object`:
-    
+
 ```json
-"dimensions": {
-  "type": "object",
+{
+  "dimensions": {
+    "type": "object"
+  }
 }
 ```
 
 3. Add the `properties` validation keyword to contain the nested data structure. Inside the new `properties` keyword, add keywords for `length`, `width`, and `height` that all use the `number` type:
-    
+
 ```json
-"dimensions": {
-  "type": "object",
-  "properties": {
-    "length": {
-      "type": "number"
-    },
-    "width": {
-      "type": "number"
-    },
-    "height": {
-      "type": "number"
+{
+  "dimensions": {
+    "type": "object",
+    "properties": {
+      "length": {
+        "type": "number"
+      },
+      "width": {
+        "type": "number"
+      },
+      "height": {
+        "type": "number"
+      }
     }
   }
 }
 ```
 
 4. To make each of these properties required, add a `required` validation keyword inside the `dimensions` object:
-    
+
 ```json
-"dimensions": {
-  "type": "object",
-  "properties": {
-    "length": {
-      "type": "number"
+{
+  "dimensions": {
+    "type": "object",
+    "properties": {
+      "length": {
+        "type": "number"
+      },
+      "width": {
+        "type": "number"
+      },
+      "height": {
+        "type": "number"
+      }
     },
-    "width": {
-      "type": "number"
-    },
-    "height": {
-      "type": "number"
-    }
-  },
-  "required": [ "length", "width", "height" ]
+    "required": ["length", "width", "height"]
+  }
 }
 ```
 
@@ -447,10 +475,10 @@ Using the new nested data structures, the overall schema looks like this:
           "type": "number"
         }
       },
-      "required": [ "length", "width", "height" ]
+      "required": ["length", "width", "height"]
     }
   },
-  "required": [ "productId", "productName", "price" ]
+  "required": ["productId", "productName", "price"]
 }
 ```
 
@@ -470,7 +498,7 @@ The following schema validates a geographical location:
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Longitude and Latitude",
   "description": "A geographical coordinate on a planet (most commonly Earth).",
-  "required": [ "latitude", "longitude" ],
+  "required": ["latitude", "longitude"],
   "type": "object",
   "properties": {
     "latitude": {
@@ -490,21 +518,25 @@ The following schema validates a geographical location:
 To reference this schema in the product catalog schema:
 
 1. Inside the `properties` object, add a key named `warehouseLocation`:
-    
+
 ```json
-"properties": {
-...
-  "warehouseLocation": {
+{
+  "properties": {
+  ...
+    "warehouseLocation": {
+    }
   }
 }
 ```
 
 2. To link to the external geographical location schema, add the `$ref` schema keyword and the schema URL:
-    
+
 ```json
-"warehouseLocation": {
-  "description": "Coordinates of the warehouse where the product is located.",
-  "$ref": "https://example.com/geographical-location.schema.json"
+{
+  "warehouseLocation": {
+    "description": "Coordinates of the warehouse where the product is located.",
+    "$ref": "https://example.com/geographical-location.schema.json"
+  }
 }
 ```
 
@@ -553,14 +585,14 @@ With the external schema reference, the overall schema looks like this:
           "type": "number"
         }
       },
-      "required": [ "length", "width", "height" ]
+      "required": ["length", "width", "height"]
     },
     "warehouseLocation": {
       "description": "Coordinates of the warehouse where the product is located.",
       "$ref": "https://example.com/geographical-location.schema.json"
     }
   },
-  "required": [ "productId", "productName", "price" ]
+  "required": ["productId", "productName", "price"]
 }
 ```
 
@@ -576,8 +608,8 @@ This example JSON data matches the product catalog schema:
 {
   "productId": 1,
   "productName": "An ice sculpture",
-  "price": 12.50,
-  "tags": [ "cold", "ice" ],
+  "price": 12.5,
+  "tags": ["cold", "ice"],
   "dimensions": {
     "length": 7.0,
     "width": 12.0,

--- a/pages/learn/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step.md
@@ -5,11 +5,11 @@ section: docs
 
 JSON Schema is a vocabulary that you can use to annotate and validate JSON documents. This tutorial guides you through the process of creating a JSON Schema document, including:
 
-- [Creating a schema definition](#create)
-- [Defining properties](#define)
-- [Nesting data structures](#nest-data)
-- [Adding outside references](#external)
-- [Validating JSON data against the schema](#validate)
+* [Creating a schema definition](#create)
+* [Defining properties](#define)
+* [Nesting data structures](#nest-data)
+* [Adding outside references](#external)
+* [Validating JSON data against the schema](#validate)
 
 After you create the JSON Schema document, you can validate the example data against your schema using a validator in a language of your choice. See [Implementations](https://json-schema.org/implementations) for a current list of supported validators.
 
@@ -25,17 +25,17 @@ The example we use in this guide is a product catalog that stores its data using
 {
   "productId": 1,
   "productName": "A green door",
-  "price": 12.5,
+  "price": 12.50,
   "tags": ["home", "green"]
 }
 ```
 
 Each product in the catalog has:
 
-- `productId`: an identifier for the product
-- `productName`: the product name
-- `price`: the cost to the consumer
-- `tags`: an optional array of identifying tags
+* `productId`: an identifier for the product
+* `productName`: the product name
+* `price`: the cost to the consumer
+* `tags`: an optional array of identifying tags
 
 The JSON object is human-readable, but it doesn’t include any context or metadata. There’s no way to tell from looking at the object what the keys mean or what the possible inputs are. JSON Schema is a standard for providing answers to these questions. In this guide, you will create a JSON Schema document that describes the structure, constraints, and data types for a set of JSON data.
 
@@ -65,10 +65,10 @@ JSON Schema is hypermedia-ready and ideal for annotating your existing JSON-base
 
 To create a basic schema definition, define the following keywords:
 
-- `$schema`: specifies which draft of the JSON Schema standard the schema adheres to.
-- `$id`: sets a URI for the schema. You can use this unique URI to refer to elements of the schema from inside the same document or from external JSON documents.
-- `title` and `description`: state the intent of the schema. These keywords don’t add any constraints to the data being validated.
-- `type`: defines the first constraint on the JSON data. In the product catalog example below, this keyword specifies that the data must be a JSON object.
+* `$schema`: specifies which draft of the JSON Schema standard the schema adheres to.
+* `$id`: sets a URI for the schema. You can use this unique URI to refer to elements of the schema from inside the same document or from external JSON documents.
+* `title` and `description`: state the intent of the schema. These keywords don’t add any constraints to the data being validated.
+* `type`: defines the first constraint on the JSON data. In the product catalog example below, this keyword specifies that the data must be a JSON object.
 
 For example:
 
@@ -114,8 +114,8 @@ To add the `properties` object to the schema:
 ```
 
 2. Add the `productId` keyword, along with the following schema annotations:
-   - `description`: describes what `productId` is. In this case, it’s the product’s unique identifier.
-   - `type`: defines what kind of data is expected. For this example, since the product identifier is a numeric value, use `integer`.
+   * `description`: describes what `productId` is. In this case, it’s the product’s unique identifier.
+   * `type`: defines what kind of data is expected. For this example, since the product identifier is a numeric value, use `integer`.
 
 ```json
 {
@@ -252,10 +252,10 @@ The `exclusiveMinimum` validation keyword is set to zero, which means that only 
 
 This section describes how to define an optional property. For this example, define a keyword named `tags` using the following criteria:
 
-- The `tags` keyword is optional.
-- If `tags` is included, it must contain at least one item.
-- All tags must be unique.
-- All tags must be text.
+* The `tags` keyword is optional.
+* If `tags` is included, it must contain at least one item.
+* All tags must be unique.
+* All tags must be text.
 
 To define an optional property:
 
@@ -608,7 +608,7 @@ This example JSON data matches the product catalog schema:
 {
   "productId": 1,
   "productName": "An ice sculpture",
-  "price": 12.5,
+  "price": 12.50,
   "tags": ["cold", "ice"],
   "dimensions": {
     "length": 7.0,
@@ -625,3 +625,4 @@ This example JSON data matches the product catalog schema:
 To validate this JSON data against the product catalog JSON Schema, you can use any validator of your choice. In addition to command-line and browser tools, validation tools are available in a wide range of languages, including Java, Python, .NET, and many others. To find a validator that’s right for your project, see [Implementations](https://json-schema.org/implementations).
 
 Use the example JSON data as the input data and the product catalog JSON Schema as the schema. Your validation tool compares the data against the schema, and if the data meets all the requirements defined in the schema, validation is successful.
+


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #349 

**Summary**:
The documentation inconsistent code rendering examples have been fixed.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**

No

