### PR TITLE
fix typo: type -> $ref

### DIFF
--- a/pages/draft/2020-12/release-notes.md
+++ b/pages/draft/2020-12/release-notes.md
@@ -366,8 +366,8 @@ external references that we want to bundle.
   "properties": {
     "address": { "type": "string" },
     "city": { "type": "string" },
-    "postalCode": { "type": "/schema/common#/$defs/usaPostalCode" },
-    "state": { "type": "/$defs/states" }
+    "postalCode": { "$ref": "/schema/common#/$defs/usaPostalCode" },
+    "state": { "$ref": "/$defs/states" }
   },
 
   "$defs": {
@@ -423,8 +423,8 @@ embedded schemas using `$defs`. Here's what the bundled schema would look like.
       "properties": {
         "address": { "type": "string" },
         "city": { "type": "string" },
-        "postalCode": { "type": "/schema/common#/$defs/usaPostalCode" },
-        "state": { "type": "#/$defs/states" }
+        "postalCode": { "$ref": "/schema/common#/$defs/usaPostalCode" },
+        "state": { "$ref": "#/$defs/states" }
       },
 
       "$defs": {


### PR DESCRIPTION
**GitHub Issue:** #360  

**Summary**: Replaced the usage of the `"type"` keyword by `"$ref"` in 4 places where the value of `"type"` was clearly describing a reference.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
no