### PR TITLE
fix: #366  Resolve the icon size bug under the "Supported by" section

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -353,10 +353,10 @@ const Home = (props: any) => {
           </div>
           <div className='flex flex-col items-center md:flex-row justify-center text-center'>
             <a href='https://www.commonroom.io'>
-              <img src='/img/logos/supported/common-room.svg' className='w-44 max-h-[58px] mb-4 md:mb-0 md:mr-8 md:ml-2' />
+              <img src='/img/logos/supported/common-room.svg' className='w-44 max-h-[58px] mb-4 md:mb-0 md:mr-8 md:ml-2 scale-150' />
             </a>
             <a href='https://json-schema.org/slack'>
-              <img src='/img/logos/supported/slack-logo.svg' className='w-44 mt-4 md:mt-0 md:ml-8 md:mr-2' />
+              <img src='/img/logos/supported/slack-logo.svg' className='w-44 mt-4 md:mt-0 md:ml-8 md:mr-2 scale-75' />
             </a>
           </div>
         </section>

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -351,12 +351,12 @@ const Home = (props: any) => {
             <h2 className='text-h3mobile md:text-h3 font-semibold mb-2'>Supported by</h2>
             <p className='px-12 mx-auto'>The following companies support us by letting us use their products.<br /><a href='mailto:info@json-schema.org' className='border-b border-black'>Email us</a> for more info!</p>
           </div>
-          <div className='flex flex-col items-center md:flex-row justify-center text-center'>
+          <div className='flex flex-col items-center md:flex-row justify-center text-center gap-x-14 gap-y-4'>
             <a href='https://www.commonroom.io'>
-              <img src='/img/logos/supported/common-room.svg' className='w-44 max-h-[58px] mb-4 md:mb-0 md:mr-8 md:ml-2 scale-100 md:scale-150' />
+              <img src='/img/logos/supported/common-room.svg' className='w-48 md:w-56' />
             </a>
             <a href='https://json-schema.org/slack'>
-              <img src='/img/logos/supported/slack-logo.svg' className='w-44 mt-4 md:mt-0 md:ml-8 md:mr-2  scale-50 md:scale-75' />
+              <img src='/img/logos/supported/slack-logo.svg' className='w-24 md:w-32' />
             </a>
           </div>
         </section>

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -353,10 +353,10 @@ const Home = (props: any) => {
           </div>
           <div className='flex flex-col items-center md:flex-row justify-center text-center'>
             <a href='https://www.commonroom.io'>
-              <img src='/img/logos/supported/common-room.svg' className='w-44 max-h-[58px] mb-4 md:mb-0 md:mr-8 md:ml-2 scale-150' />
+              <img src='/img/logos/supported/common-room.svg' className='w-44 max-h-[58px] mb-4 md:mb-0 md:mr-8 md:ml-2 scale-100 md:scale-150' />
             </a>
             <a href='https://json-schema.org/slack'>
-              <img src='/img/logos/supported/slack-logo.svg' className='w-44 mt-4 md:mt-0 md:ml-8 md:mr-2 scale-75' />
+              <img src='/img/logos/supported/slack-logo.svg' className='w-44 mt-4 md:mt-0 md:ml-8 md:mr-2  scale-50 md:scale-75' />
             </a>
           </div>
         </section>


### PR DESCRIPTION
In this issue, I addressed a bug related to icon sizes. I observed that the Slack icon had a larger height compared to the common room icon. To rectify this issue, I applied a scaling property to ensure uniform icon sizes.

This enhancement is crucial for maintaining a visually consistent and polished appearance across the platform. The "before" and "after" screenshots provide a clear visual representation of the improvement.

**GitHub Issue:**  #366 
Closes #366 

**Summary**:
before :

![Screenshot from 2024-02-26 21-37-52](https://github.com/json-schema-org/website/assets/118799941/eb2c90be-c0d8-4bb9-a215-7f616bccae83)



after :
![Screenshot from 2024-02-27 09-44-16](https://github.com/json-schema-org/website/assets/118799941/ad3bc4bf-6c87-403e-9cc1-c2fe72626178)
