### PR TITLE
added dates to specification link

### DIFF
--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -302,6 +302,7 @@ For links to the somewhat more readably formatted versions on this web site, and
     - Core: [draft-bhutton-json-schema-01](../../draft/2020-12/draft-bhutton-json-schema-01.html) ([changes](../../draft/2020-12/draft-bhutton-json-schema-01.html#appendix-G))
     - Validation: [draft-bhutton-json-schema-validation-01](../../draft/2020-12/draft-bhutton-json-schema-validation-01.html) ([changes](/draft/2020-12/draft-bhutton-json-schema-validation-01.html#appendix-C))
     - Relative JSON Pointer: [draft-bhutton-relative-json-pointer-00](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00) ([changes](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00#appendix-A))
+    - Published: 16-June-2022
 - General use meta-schemas
     - [JSON Schema meta-schema](../../draft/2020-12/schema)
     - [JSON Hyper-Schema meta-schema](../../draft/2020-12/hyper-schema) (2019-09 Hyper-Schema with 2020-12 Validation)
@@ -338,6 +339,7 @@ _**NOTE:** All meta-schema URIs now use `https://`.  While currently also availa
     - Validation: [draft-handrews-json-schema-validation-02](../../draft/2019-09/draft-handrews-json-schema-validation-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-validation-02.html#rfc.appendix.C))
     - Hyper-Schema: [draft-handrews-json-schema-hyperschema-02](../../draft/2019-09/draft-handrews-json-schema-hyperschema-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-hyperschema-02.html#rfc.appendix.B))
     - Relative JSON Pointer: [draft-handrews-relative-json-pointer-02](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02) ([changes](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02#appendix-A))
+    - Published: 17-September-2019
 - General use meta-schemas
     - [JSON Schema meta-schema](../../draft/2019-09/schema)
     - [JSON Hyper-Schema meta-schema](../../draft/2019-09/hyper-schema)
@@ -366,6 +368,7 @@ _**NOTE:** All meta-schema URIs now use `https://`.  While currently also availa
 - [JSON Hyper-Schema Link Description Object meta-schema](../../draft-07/links)
 - [JSON Hyper-Schema recommended output schema](../../draft-07/hyper-schema-output)
 - Relative JSON Pointer: [draft-handrews-relative-json-pointer-01](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-01) ([changes](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-01#appendix-B))
+- Published: 19-March-2018
 
 #### Obsolete Draft 7 Documents
 
@@ -383,6 +386,7 @@ _These were updated without changing functionality or meta-schemas due to a few 
 - Hyper-Schema: [draft-wright-json-schema-hyperschema-01](../../draft-06/draft-wright-json-schema-hyperschema-01.html) ([changes](../../draft-06/draft-wright-json-schema-hyperschema-01.html#rfc.appendix.B)) ([hyper-schema migration FAQ](draft-06/json-hyper-schema-release-notes))
 - [JSON Schema meta-schema](../../draft-06/schema)
 - [JSON Hyper-Schema meta-schema](../../draft-06/hyper-schema)
+- Published: 21-April-2017
 
 ### Draft 5
 
@@ -390,6 +394,7 @@ _These were updated without changing functionality or meta-schemas due to a few 
  - Validation: [draft-wright-json-schema-validation-00](../../draft-05/draft-wright-json-schema-validation-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-validation-00.pdf#appendix-B))
  - Hyper-Schema: [draft-wright-json-schema-hyperschema-00](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf#appendix-B))
  - Draft 5 was primarily a cleanup of Draft 4 and continued to use the Draft 4 meta-schemas.
+ - Published: 13-October-2016
 
 ### Draft 4
 
@@ -399,24 +404,28 @@ _These were updated without changing functionality or meta-schemas due to a few 
  - JSON Reference: [draft-pbryan-zyp-json-ref-03](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) ([changes](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#appendix-A))
  * [JSON Schema meta-schema](../../draft-04/schema)
  * [JSON Hyper-Schema meta-schema](../../draft-04/hyper-schema)
+ - Published: 2013
 
 ### Draft 3
 
  - Complete Specification: [draft-zyp-json-schema-03](../../draft-03/draft-zyp-json-schema-03.pdf) ([changes](../../draft-03/draft-zyp-json-schema-03.pdf#anchor54))
 * [JSON Schema meta-schema](../../draft-03/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-03/hyper-schema)
+- Published: 22-November-2010
 
 ### Draft 2
 
  - Complete Specification: [draft-zyp-json-schema-02](../../draft-02/draft-zyp-json-schema-02.txt) (changes: Appendix-A)
 * [JSON Schema meta-schema](../../draft-02/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-02/hyper-schema)
+- Published: 23-March-2010
 
 ### Draft 1
 
  - Complete Specification: [draft-zyp-json-schema-01](../../draft-01/draft-zyp-json-schema-01.html) ([changes](../../draft-01/draft-zyp-json-schema-01.html#anchor54))
 * [JSON Schema meta-schema](../../draft-01/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-01/hyper-schema)
+- Published: 05-December-2009
 
 ### Draft 0
 
@@ -425,6 +434,7 @@ _Note that Draft 0 erroneously claimed to update another RFC, and was replaced t
  - Specification: [draft-zyp-json-schema-00](../../draft-00/draft-zyp-json-schema-00.txt) (changes: Appendix-A))
 * [JSON Schema meta-schema](../../draft-00/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-00/hyper-schema)
+- Published: 05-December-2009
 
 ## Latest Snapshot (work in progress)
 

--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -404,7 +404,7 @@ _These were updated without changing functionality or meta-schemas due to a few 
  - JSON Reference: [draft-pbryan-zyp-json-ref-03](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) ([changes](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#appendix-A))
  * [JSON Schema meta-schema](../../draft-04/schema)
  * [JSON Hyper-Schema meta-schema](../../draft-04/hyper-schema)
- - Published: 2013
+ - Published: 31-January-2013
 
 ### Draft 3
 


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #123
Resolves #123 

**Summary**:
- added published/release dates for each versions (e.g. draft 6, draft 7) 

**Files Changes**
- `pages/specification-links.md`

**Before**
Can see on website [here](https://json-schema.org/specification-links#2020-12)

**After**
[screen-recording.webm](https://github.com/json-schema-org/website/assets/84331681/c15e08ce-aa80-4540-871b-a9e39b397801)

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
<!-- If the issue has the `adr-required`, this PR must include an ADR. -->
<!-- If you do not want to include an ADR, or are not sure how to make one, make sure you allow edits to this PR by maintainers. -->

Yes/No
No