### PR TITLE
changed the /tools route to /implementations in MobileNav

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -91,7 +91,7 @@ const MainNavLink = ({ uri, label, className, isActive }: { uri: string, label: 
   const router = useRouter()
   return (
     <Link href={uri} className={classnames(className, 'font-semibold p-2 md:p-4', `${router.asPath === uri ? 'text-primary hover:text-primary' : 'text-slate-600 hover:text-primary'
-    }`
+      }`
     )}
     >{label}
     </Link>
@@ -195,7 +195,7 @@ const MobileNav = () => {
       />
 
       <MainNavLink
-        uri='/tools'
+        uri='/implementations'
         label='Tools'
         isActive={section === 'tools'}
 
@@ -212,7 +212,7 @@ const MobileNav = () => {
         isActive={section === 'community'}
 
       />
-    
+
     </div>
   )
 }


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
**GitHub Issue:** #396 

**Summary**: Changed the /tools route to /implementations in MobileNav. 
Since Tools tab is addressed by /implementations route /tools route is still not found. But if required i can redirect the /tools route to /implementations so that it is does not give 404.

**Do you think resolving this issue might require an [Architectural Decision Record (ADR)](https://github.com/json-schema-org/community/blob/main/CONTRIBUTING.md#key-architectural-decisions)? (significant or noteworthy)**
No