### PR TITLE
added highlight to active fragments

### DIFF
--- a/components/Headlines.tsx
+++ b/components/Headlines.tsx
@@ -42,12 +42,15 @@ const Headline = ({
   const router = useRouter();
   const asPath = router.asPath;
   const slug = slugifyMarkdownHeadline(children as any[]);
-
+  const id= propAttributes?.slug || slug
+  const isActive = id===asPath.split('#')[1];
   const attributes = {
     ...propAttributes,
     id: propAttributes?.slug || slug,
+    
     className: classnames(
-      'group cursor-pointer hover:underline',
+      'group cursor-pointer',
+      isActive ? 'hover, text-blue-500' : 'hover:underline',
       propAttributes?.className,
     ),
     onClick: () => {
@@ -60,6 +63,7 @@ const Headline = ({
       window.location.href = urlString;
     },
   };
+
   const childredWithoutFragment = filterFragment(children);
   return (
     <Tag attributes={attributes}>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
feature
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
-  Closes #303  <!-- Replace  with the issue number this PR resolves -->
-  Related to #302  <!-- Use when the PR doesn't completely resolve an issue -->



**Screenshots/videos:**
![image](https://github.com/json-schema-org/website/assets/95571773/e41610b3-eb16-4245-a1d4-385a934df7d8)

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
no
<!--Add link to it-->

**Summary**
Added blue as highlight colour for the active fragment when they are directly visited via link.
<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
