### PR TITLE
Fix: Adding textarea in additional context section in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,7 +22,7 @@ body:
     description: A clear and concise description of any alternative solutions or features you've considered
   validations:
     required: false
-- type: input
+- type: textarea
   attributes:
     label: Additional context
     description: Add any other context about the problem here


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Converting the issue template additional context field into a textarea.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
-  Closes #445 
-  Related to #445 
-  Others? 


**Screenshots/videos:**
N/A

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
this fix doesn't need any doc updation but if required I will be happy to do so.  
<!--Add link to it-->

**Summary**
Converted the input field to additional context of issue template into a textarea 


<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
N/A

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
