### PR TITLE
Removing carbon ads accordingly when changing screen orientation

### DIFF
--- a/components/CarbonsAds.tsx
+++ b/components/CarbonsAds.tsx
@@ -1,17 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 
-declare global {
-  interface Window {
-    _carbonads: {
-      refresh: () => void;
-      reload: (where: string, force_serve: boolean) => void;
-      remove: (el: HTMLElement) => void;
-      srv: () => void;
-    };
-  }
-}
-
 type Props = {
   className?: string;
   variant?: 'sidebar';
@@ -22,43 +11,30 @@ function CarbonAds({ className, variant = 'sidebar' }: Props) {
   const router = useRouter();
 
   useEffect(() => {
-    const mobileMediaQuery = window.matchMedia('(max-width: 1023px)');
-    if (!mobileMediaQuery.matches) {
-      const hasCarbonAds = document.querySelector('#carbonads');
-      // Check if another ad is present to refresh
-      if (hasCarbonAds) {
-        window._carbonads.refresh();
-        return;
-      } else {
-        // Check if the script is present (ad is not yet present) so that duplicate requests are not made to carbon ads
-        const hasCarbonAdsScript = document.querySelector('#_carbonads_js');
-        if (!hasCarbonAdsScript) {
-          const carbonAdsScript = document.createElement('script');
-          carbonAdsScript.id = '_carbonads_js';
-          carbonAdsScript.type = 'text/javascript';
-          carbonAdsScript.async = true;
-          document
-            .querySelector('#carbonads-container')
-            ?.appendChild(carbonAdsScript);
-          carbonAdsScript.src = `//cdn.carbonads.com/carbon.js?serve=CE7I627Y&placement=json-schemaorg&rnd=${Math.random()}`;
-        }
-      }
-
-      const existingStyleSheet = document.querySelector('#_carbonads_css');
-      if (existingStyleSheet) {
-        existingStyleSheet.innerHTML = CarbonAds.stylesheet[variant];
-      } else {
-        const carbonAdsStyleSheet = document.createElement('style');
-        carbonAdsStyleSheet.id = '_carbonads_css';
-        carbonAdsStyleSheet.innerHTML = CarbonAds.stylesheet[variant];
-        document
-          .querySelector('#carbonads-container')
-          ?.appendChild(carbonAdsStyleSheet);
-      }
-    } else {
-      (carbonRef.current as HTMLElement).style.display = 'none';
+    const hasCarbonAdsScript = document.querySelector('#_carbonads_js');
+    if (!hasCarbonAdsScript) {
+      const carbonAdsScript = document.createElement('script');
+      carbonAdsScript.id = '_carbonads_js';
+      carbonAdsScript.type = 'text/javascript';
+      carbonAdsScript.async = true;
+      document
+        .querySelector('#carbonads-container')
+        ?.appendChild(carbonAdsScript);
+      carbonAdsScript.src = `//cdn.carbonads.com/carbon.js?serve=CE7I627Y&placement=json-schemaorg&rnd=${Math.random()}`;
     }
-  }, [router.asPath]);
+
+    const existingStyleSheet = document.querySelector('#_carbonads_css');
+    if (existingStyleSheet) {
+      existingStyleSheet.innerHTML = CarbonAds.stylesheet[variant];
+    } else {
+      const carbonAdsStyleSheet = document.createElement('style');
+      carbonAdsStyleSheet.id = '_carbonads_css';
+      carbonAdsStyleSheet.innerHTML = CarbonAds.stylesheet[variant];
+      document
+        .querySelector('#carbonads-container')
+        ?.appendChild(carbonAdsStyleSheet);
+    }
+  }, [variant]);
 
   return (
     <aside
@@ -114,6 +90,12 @@ CarbonAds.stylesheet = {
       font-size: 12px;
       margin-top: 4px;
       color: rgb(100 116 139);
+    }
+
+    @media (max-width: 1023px) {
+      #carbonads-container {
+        display: none;
+      }
     }
   `,
 };

--- a/components/Headlines.tsx
+++ b/components/Headlines.tsx
@@ -42,12 +42,15 @@ const Headline = ({
   const router = useRouter();
   const asPath = router.asPath;
   const slug = slugifyMarkdownHeadline(children as any[]);
-
+  const id= propAttributes?.slug || slug
+  const isActive = id===asPath.split('#')[1];
   const attributes = {
     ...propAttributes,
     id: propAttributes?.slug || slug,
+    
     className: classnames(
-      'group cursor-pointer hover:underline',
+      'group cursor-pointer',
+      isActive ? 'hover, text-blue-500' : 'hover:underline',
       propAttributes?.className,
     ),
     onClick: () => {
@@ -60,6 +63,7 @@ const Headline = ({
       window.location.href = urlString;
     },
   };
+
   const childredWithoutFragment = filterFragment(children);
   return (
     <Tag attributes={attributes}>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Removes a bug related to carbon ads.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #457  <!-- Replace ___ with the issue number this PR resolves -->


**If relevant, did you update the documentation?**
no
<!--Add link to it-->

**Summary**
Before: Once the ad is loaded , changes in screen orientation would result in uneven placing of the carbon ad.
![image](https://github.com/json-schema-org/website/assets/95571773/bc82acc6-1c52-430d-8d90-80f2ed4eec2b)

After: When the screen orientation changes, the ad is removed even after being loaded and not resulting into uneven ad placing. 
![image](https://github.com/json-schema-org/website/assets/95571773/c3c21e9a-6084-461d-a893-e38bf85e0e2b)

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
