### PR TITLE
chore: fix broken link to "$id" keyword

### DIFF
--- a/pages/understanding-json-schema/basics.md
+++ b/pages/understanding-json-schema/basics.md
@@ -139,7 +139,7 @@ you control, for example:
 { "$id": "http://yourdomain.com/schemas/myschema.json" }
 ```
 
-The details of `$id` become more apparent when you start [structuring a complex schema](../../understanding-json-schema/structuring#dollarid).
+The details of `$id` become more apparent when you start [structuring a complex schema](../../understanding-json-schema/structuring#id).
 
 <Infobox label="Draft-specific info">
 In Draft 4, `$id` is just `id` (without the dollar-sign).

--- a/pages/understanding-json-schema/structuring.md
+++ b/pages/understanding-json-schema/structuring.md
@@ -8,7 +8,7 @@ section: docs
 * [Schema Identification](#schema-identification)
 * [Base URI](#base-uri)
 * [$ref](#dollarref)
-* [$id](#dollarid)
+* [$id](#id)
 * [$defs](#defs)
 * [Recursion](#recursion)
 * [Extending Recursive Schemas](#extending-recursive-schemas)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fix broken link to `"$id"` keyword.

**Screenshots/videos:**
- [https://json-schema.org/understanding-json-schema/basics#declaring-a-unique-identifier](https://json-schema.org/understanding-json-schema/basics#declaring-a-unique-identifier):
![basics](https://github.com/json-schema-org/website/assets/87906913/34adec64-defc-48df-a5af-9697a5a6b032)

- [https://json-schema.org/understanding-json-schema/structuring#structuring-a-complex-schema](https://json-schema.org/understanding-json-schema/structuring#structuring-a-complex-schema):
![id-link](https://github.com/json-schema-org/website/assets/87906913/71e837a7-6642-485e-843d-aee1813fae08)

- [https://json-schema.org/understanding-json-schema/structuring#id]( https://json-schema.org/understanding-json-schema/structuring#id):
![id-section](https://github.com/json-schema-org/website/assets/87906913/3509a719-399a-47a9-8e27-15adf49f5ea1)

**Summary**
Stumbled upon it while reading.
