### PR TITLE
Auto smooth scroll to the top onclick of the Search

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -164,7 +164,12 @@ const MainNavigation = () => {
         isActive={section === 'community'}
       />
       <div className='flex max-sm:ml-4 items-center gap-6 md:gap-4'>
-        <div className='flex justify-center rounded border-2 border-gray-100 ml-0 w-[120px] md:w-full'>
+        <div
+          className='flex justify-center rounded border-2 border-gray-100 ml-0 w-[120px] md:w-full'
+          onClick={() => {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          }}
+        >
           <Search />
         </div>
         {showMobileNav === false ? (


### PR DESCRIPTION
**Changes Made:**

Smoothly scroll to the top onclick of the Search button to address the issue where clicking on the search button made the scroll unresponsive on devices with a width less than 769 pixels.

**Issue Number:**

- Related to #478 <!-- Use when the PR doesn't completely resolve an issue -->

**Screenshots/videos:**

[Screencast from 09-03-24 06:43:46 PM IST.webm](https://github.com/json-schema-org/website/assets/106718914/ea17bb2a-6e64-4d61-aa7e-bb256d50a724)
<!-- Add screenshots or videos wherever possible. -->

<!-- Add link to the documentation updates -->

**Summary:**

This pull request fixes the UI bug on devices with a width less than 770 pixels. The issue was causing the scroll to become unresponsive when clicking on the search button. Refer to the linked issue for more information.