### PR TITLE
handled the overflow issue while opening search bar

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -50,7 +50,7 @@ export default function Layout({
 
   const newTitle = `JSON Schema${metaTitle ? ` - ${metaTitle}` : ''}`;
   return (
-    <div className='min-h-screen relative flex flex-col justify-between '>
+    <div className='min-h-screen fixed inset-0 w-full overflow-y-scroll flex flex-col justify-between'>
       <FaviconHead />
       <Head>
         <title>{newTitle}</title>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
While opening the search bar an overflow was visible in the right direction. Now the content will be at it's position on opening and closing of the search bar.


**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #525  <!-- Replace ___ with the issue number this PR resolves -->



**Screenshots/videos:**

https://github.com/json-schema-org/website/assets/119804372/4435b439-029a-4e49-88ea-94b7e401941e


<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
No
<!--Add link to it-->


