### PR TITLE
Fix broken links to header anchors

### DIFF
--- a/pages/understanding-json-schema/reference/object.md
+++ b/pages/understanding-json-schema/reference/object.md
@@ -96,8 +96,8 @@ key is the name of a property and each value is a schema used to
 validate that property. Any property that doesn\'t match any of the
 property names in the `properties` keyword is ignored by this keyword.
 
-> See [Additional Properties](#additional-properties) and
-[Unevaluated Properties](#unevaluated-properties) for how to disallow properties that
+> See [Additional Properties](#additionalproperties) and
+[Unevaluated Properties](#unevaluatedproperties) for how to disallow properties that
 don\'t match any of the property names in `properties`.
 
 For example, let\'s say we want to define a simple schema for an address


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR fixes two broken relative links:

* The link definitions used hyphenated anchors (like `"additional-properties"`)
* The target headers define non-hyphenated IDs (like `"additionalproperties"`)

You can see the current problem by visiting:

https://json-schema.org/understanding-json-schema/reference/object#properties

and attempting to click on the "Additional Properties" and "Unevaluated Properties" link in the call-out text.

![image](https://github.com/json-schema-org/website/assets/39996/e72fd082-e864-4705-8068-1879bd14a8c7)

`git blame` showed that the hyphenated anchor lines were modified a few months ago, while the target lines were last modified ~2 years ago, so I removed the hyphens to align with the long-standing target lines.

