### PR TITLE
Fix: Sidebar borders fix in dark theme

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -52,9 +52,10 @@ const DocLinkBlank = ({
   return (
     <Link
       href={uri}
-      className={classnames('text-sm block border-l-2 py-1 pl-2', {
+      className={classnames('text-sm block  py-1 pl-2', {
         '  font-medium': !isActive,
-        'text-primary text-bold border-l-primary font-semibold': isActive,
+        'text-primary text-bold border-l-primary border-l-2 font-semibold':
+          isActive,
       })}
       target='_blank'
       rel='noopener noreferrer'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Fixed the sidebar borders of docs page in dark mode 

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #570 


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

## Before

![image](https://github.com/json-schema-org/website/assets/124715224/4939d466-7858-4c26-b2d3-2e5e4b4ede79)

## After

![image](https://github.com/json-schema-org/website/assets/124715224/452bc6b3-715e-4a69-abb4-d283f8be20f5)






**Summary**
Fixing the sidebar borders in dark theme.

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
