### PR TITLE
Fix some inconsistent indentation

### DIFF
--- a/pages/understanding-json-schema/structuring.md
+++ b/pages/understanding-json-schema/structuring.md
@@ -215,11 +215,10 @@ identifies the highlighted subschema in the following schema.
   "$id": "https://example.com/schemas/address",
   "type": "object",
   "properties": {
-    "street_address":
-       { "type": "string" },
-       "city": { "type": "string" },
-       "state": { "type": "string" }
-    },
+    "street_address": { "type": "string" },
+    "city": { "type": "string" },
+    "state": { "type": "string" }
+  },
   "required": ["street_address", "city", "state"]
 }
 ```
@@ -263,10 +262,7 @@ the subschema on the highlighted part of the following schema.
   "$id": "https://example.com/schemas/address",
   "type": "object",
   "properties": {
-    "street_address":
-     {
-       "$anchor": "street_address", "type": "string"
-     },
+    "street_address": { "$anchor": "street_address", "type": "string" },
     "city": { "type": "string" },
     "state": { "type": "string" }
   }, 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix (indentation correction)

**Issue Number:**

N/A

**Screenshots/videos:**

N/A

**If relevant, did you update the documentation?**

https://json-schema.org/understanding-json-schema/structuring

**Summary**

I was reading the [structuring doc](https://json-schema.org/understanding-json-schema/structuring) and found the indentation in a couple of the code examples confusing. I've adjusted it to be more like other examples of the address schema in the doc, making easier to read.

**Does this PR introduce a breaking change?**

I hope not!