### PR TITLE
Invert the order of the links table, add publication date column and rearrange columns 

### DIFF
--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -22,32 +22,41 @@ For links to the somewhat more readably formatted versions on this web site, and
 <table>
   <tbody>
     <tr>
-      <th>IETF identifiers</th>
-      <th>meta-schema identifiers</th>
       <th>common name</th>
-      <th>notes</th>
       <th>published</th>
+      <th>meta-schema identifiers</th>
+      <th>IETF identifiers</th>
+      <th>notes</th>
     </tr>
 	<tr>
-      <td>
-        <small><i>(TBD)</i></small>
-      </td>
-      <td>
-        <small><i>(TBD)</i></small>
-      </td>
       <td>
         Draft 2021-NN
       </td>
       <td>
-        <small>Milestone:
-        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/7">Draft 2021-NN</a>
-        </small>
+        <small><i>(TBD)</i></small>
       </td>
 	  <td>
         <small><i>(TBD)</i></small>
       </td>
+	  <td>
+        <small><i>(TBD)</i></small>
+      </td>
+	   <td>
+        <small>Milestone:
+        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/7">Draft 2021-NN</a>
+        </small>
+      </td>
     </tr>
     <tr>
+	<td rowspan="3">
+        Draft 2020-12
+      </td>
+	   <td rowspan="3">
+         <small>16-June-2022</small>
+      </td>
+      <td rowspan="3">
+        <tt><small>2020-12</small></tt>
+      </td>
       <td>
         <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-00.html">
           draft-bhutton-json-schema-00
@@ -60,21 +69,12 @@ For links to the somewhat more readably formatted versions on this web site, and
         </a></small></tt><br>
       </td>
       <td rowspan="3">
-        <tt><small>2020-12</small></tt>
-      </td>
-      <td rowspan="3">
-        Draft 2020-12
-      </td>
-      <td rowspan="3">
         <small>
         Milestone:
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/8">draft-08-patch-1</a>
         <br/>
         Changes and fixes as a result of discussion with the OpenAPI community. (Includes breaking changes.)
         </small>
-      </td>
-      <td rowspan="3">
-         <small>16-June-2022</small>
       </td>
     </tr>
     <tr><td><!-- This empty row keeps the row colors aligned properly for the two "2020-12" versions --></td></tr>
@@ -90,6 +90,17 @@ For links to the somewhat more readably formatted versions on this web site, and
       </td>
     </tr>
     <tr>
+	    <td>
+        Draft 2019-09
+      </td>
+		<td>
+	  <small>
+        17-September-2019
+		</small>
+      </td>
+      <td>
+        <small>2019-09</small>
+      </td>
       <td>
         <small><a href="../draft/2019-09/draft-handrews-json-schema-02.html">
           draft-handrews-json-schema-02
@@ -105,23 +116,23 @@ For links to the somewhat more readably formatted versions on this web site, and
         </a></small><br>
       </td>
       <td>
-        <small>2019-09</small>
-      </td>
-      <td>
-        Draft 2019-09
-      </td>
-      <td>
         <small>Milestone:
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/6">draft-08</a>
         </small>
       </td>
-      <td>
-	  <small>
-        17-September-2019
-		</small>
-      </td>
     </tr>
     <tr>
+	  <td rowspan="3">
+        Draft 7
+      </td>
+	  <td rowspan="3">
+	    <small>
+          19-March-2018
+		</small>
+      </td>
+      <td rowspan="3">
+        <small>draft-07</small>
+      </td>
       <td>
         <small><a href="../draft-07/draft-handrews-json-schema-00.pdf">
           draft-handrews-json-schema-00
@@ -137,12 +148,6 @@ For links to the somewhat more readably formatted versions on this web site, and
         </a></small><br>
       </td>
       <td rowspan="3">
-        <small>draft-07</small>
-      </td>
-      <td rowspan="3">
-        Draft 7
-      </td>
-      <td rowspan="3">
         <small>
         the&nbsp;<small>draft-handrews-*-01</small> drafts were
         bugfixes and/or clarifications without meta-schema or functional changes
@@ -150,11 +155,6 @@ For links to the somewhat more readably formatted versions on this web site, and
         Milestone:
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/5">draft-07</a>
         </small>
-      </td>
-      <td rowspan="3">
-	  <small>
-        19-March-2018
-		</small>
       </td>
     </tr>
     <tr><td><!-- This empty row keeps the row colors aligned properly for the two "draft-07" versions --></td></tr>
@@ -176,6 +176,17 @@ For links to the somewhat more readably formatted versions on this web site, and
     </tr>
     <tr>
       <td>
+        Draft 6
+      </td>
+      <td>
+	  <small>
+        21-April-2017
+		</small>
+      </td>
+      <td>
+        <small>draft-06</small>
+      </td>
+      <td>
         <small><a href="../draft-06/draft-wright-json-schema-01.html">
           draft-wright-json-schema-01
         </a></small><br><br>
@@ -187,24 +198,24 @@ For links to the somewhat more readably formatted versions on this web site, and
         </a></small><br>
       </td>
       <td>
-        <small>draft-06</small>
-      </td>
-      <td>
-        Draft 6
-      </td>
-      <td>
         <small>Milestones:
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/2">draft-6</a>,
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/4">Meta-schema draft-06</a>
         </small>
       </td>
-      <td>
-	  <small>
-        21-April-2017
-		</small>
-      </td>
     </tr>
     <tr>
+      <td>
+        Draft 5
+      </td>
+	  <td>
+		<small>
+        13-October-2016
+		</small>
+      </td>
+	   <td rowspan="2">
+        <small>draft-04</small>
+      </td>
       <td>
         <small><a href="../draft-05/draft-wright-json-schema-00.pdf">
           draft-wright-json-schema-00
@@ -216,12 +227,6 @@ For links to the somewhat more readably formatted versions on this web site, and
           draft-wright-json-schema-hyperschema-00
         </a></small><br>
       </td>
-      <td rowspan="2">
-        <small>draft-04</small>
-      </td>
-      <td>
-        Draft 5
-      </td>
       <td>
         <small>meta-schemas not changed, so
         "<small>draft-05</small>" is really
@@ -229,13 +234,16 @@ For links to the somewhat more readably formatted versions on this web site, and
         <br />
         Milestone: <a href="https://github.com/json-schema-org/json-schema-spec/milestone/1">draft-5 (2016-10-13)</a></small>
       </td>
-      <td>
-		<small>
-        13-October-2016
-		</small>
-      </td>
     </tr>
     <tr>
+      <td>
+        Draft 4
+      </td>
+	  <td>
+	  <small>
+        31-January-2013
+		</small>
+      </td>
       <td>
         <small><a href="../draft-04/draft-zyp-json-schema-04.html">
           draft-zyp-json-schema-04
@@ -251,9 +259,6 @@ For links to the somewhat more readably formatted versions on this web site, and
         </a></small><br>
       </td>
       <td>
-        Draft 4
-      </td>
-      <td>
         <small>
         <small>json-ref</small> drafts
         <small>00-02</small> were all published between
@@ -261,86 +266,82 @@ For links to the somewhat more readably formatted versions on this web site, and
         <small>json-schema-04</small>
         </small>
       </td>
-      <td>
-	  <small>
-        31-January-2013
-		</small>
-      </td>
     </tr>
     <tr>
       <td>
-        <small><a href="../draft-03/draft-zyp-json-schema-03.pdf">
-          draft-zyp-json-schema-03
-        </a></small>
-      </td>
-      <td>
-        <small>draft-03</small>
-      </td>
-      <td>
         Draft 3
       </td>
-      <td></td>
       <td>
 	  <small>
         22-November-2010
 		</small>
       </td>
+      <td>
+        <small>draft-03</small>
+      </td>
+      <td>
+        <small><a href="../draft-03/draft-zyp-json-schema-03.pdf">
+          draft-zyp-json-schema-03
+        </a></small>
+      </td>
+      <td></td>
     </tr>
     <tr>
       <td>
-        <small><a href="../draft-02/draft-zyp-json-schema-02.txt">
-          draft-zyp-json-schema-02
-        </a></small></td>
-      <td>
-        <small>draft-02</small>
-      </td>
-      <td>
         Draft 2
       </td>
-      <td></td>
       <td>
 	  <small>
         23-March-2010
 		</small>
       </td>
+      <td>
+        <small>draft-02</small>
+      </td>
+      <td>
+        <small><a href="../draft-02/draft-zyp-json-schema-02.txt">
+          draft-zyp-json-schema-02
+        </a></small></td>
+      <td></td>
     </tr>
     <tr>
       <td>
-        <small><a href="../draft-01/draft-zyp-json-schema-01.html">
-          draft-zyp-json-schema-01
-        </a></small></td>
-      <td>
-        <small>draft-01</small>
-      </td>
-      <td>
         Draft 1
       </td>
-      <td></td>
       <td>
 	  <small>
         05-December-2009
 		</small>
       </td>
+      <td>
+        <small>draft-01</small>
+      </td>
+      <td>
+        <small><a href="../draft-01/draft-zyp-json-schema-01.html">
+          draft-zyp-json-schema-01
+        </a></small>
+		</td>
+      <td></td>
     </tr>
     <tr>
+      <td>
+        Draft 0
+      </td>
+      <td>
+        <small>
+		05-December-2009
+		</small>
+      </td>
+      <td>
+        <small>draft-00</small></td>
       <td>
         <small><a href="../draft-00/draft-zyp-json-schema-00.txt">
           draft-zyp-json-schema-00
         </a></small>
       </td>
       <td>
-        <small>draft-00</small></td>
-      <td>
-        Draft 0
-      </td>
-      <td>
         <small>due to a markup error, this draft was replaced by
         <small>draft-01</small> on the same day</small>
-      </td>
-      <td>
-        <small>
-		05-December-2009
-		</small>
       </td>
     </tr>
 

--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -5,15 +5,15 @@ section: docs
 
 <!-- Links on this page should be immutable - none of them should go to `/latest`, etc. -->
 
-You can find the latest released draft on the [Specification](../../specification) page. The complex numbering and naming system for drafts and meta-schemas is fully explained here as well.
+You can find the latest released draft on the [Specification](../../specification) page.  The complex numbering and naming system for drafts and meta-schemas is fully explained here as well.
 
 <TableOfContent depth={4} />
 
 ## Understanding draft names and numbers
 
-IETF Internet-Drafts (I-Ds) are named with the editor's name and a sequential number which resets with each new editor. Meta-schemas were more-or-less numbered sequentially up through Draft 7, but the increasingly confusing mismatch between "draft-nn" versions on the meta-schemas and the IETF documents has made that unsustainable. The practice of fixing meta-schema bugs in place to preserve the sequential numbering has also been controversial.
+IETF Internet-Drafts (I-Ds) are named with the editor's name and a sequential number which resets with each new editor.  Meta-schemas were more-or-less numbered sequentially up through Draft 7, but the increasingly confusing mismatch between "draft-nn" versions on the meta-schemas and the IETF documents has made that unsustainable.  The practice of fixing meta-schema bugs in place to preserve the sequential numbering has also been controversial.
 
-Starting with what had been called "Draft 8" while it was being written, meta-schemas are identified by the year and month of publication. This allows for bug fixes to be published with new URIs (as long as it is not more than once a month).
+Starting with what had been called "Draft 8" while it was being written, meta-schemas are identified by the year and month of publication.  This allows for bug fixes to be published with new URIs (as long as it is not more than once a month).
 
 ### Table of All Versions of Everything
 
@@ -28,7 +28,7 @@ For links to the somewhat more readably formatted versions on this web site, and
       <th>IETF identifiers</th>
       <th>notes</th>
     </tr>
-	<tr>
+    <tr>
       <td>
         Draft 2021-NN
       </td>
@@ -43,15 +43,17 @@ For links to the somewhat more readably formatted versions on this web site, and
       </td>
 	   <td>
         <small>Milestone:
-        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/7">Draft 2021-NN</a>
+        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/7">
+          Draft 2021-NN
+        </a>
         </small>
       </td>
     </tr>
     <tr>
-	<td rowspan="3">
+	    <td rowspan="3">
         Draft 2020-12
       </td>
-	   <td rowspan="3">
+	    <td rowspan="3">
          <small>16-June-2022</small>
       </td>
       <td rowspan="3">
@@ -93,10 +95,10 @@ For links to the somewhat more readably formatted versions on this web site, and
 	    <td>
         Draft 2019-09
       </td>
-		<td>
-	  <small>
+		  <td>
+	    <small>
         17-September-2019
-		</small>
+		  </small>
       </td>
       <td>
         <small>2019-09</small>
@@ -125,10 +127,10 @@ For links to the somewhat more readably formatted versions on this web site, and
 	  <td rowspan="3">
         Draft 7
       </td>
-	  <td rowspan="3">
-	    <small>
+	    <td rowspan="3">
+	      <small>
           19-March-2018
-		</small>
+		    </small>
       </td>
       <td rowspan="3">
         <small>draft-07</small>
@@ -179,9 +181,9 @@ For links to the somewhat more readably formatted versions on this web site, and
         Draft 6
       </td>
       <td>
-	  <small>
-        21-April-2017
-		</small>
+	      <small>
+          21-April-2017
+		    </small>
       </td>
       <td>
         <small>draft-06</small>
@@ -208,10 +210,10 @@ For links to the somewhat more readably formatted versions on this web site, and
       <td>
         Draft 5
       </td>
-	  <td>
-		<small>
-        13-October-2016
-		</small>
+	    <td>
+		    <small>
+          13-October-2016
+		    </small>
       </td>
 	   <td rowspan="2">
         <small>draft-04</small>
@@ -239,10 +241,10 @@ For links to the somewhat more readably formatted versions on this web site, and
       <td>
         Draft 4
       </td>
-	  <td>
-	  <small>
-        31-January-2013
-		</small>
+	    <td>
+	      <small>
+          31-January-2013
+	  	  </small>
       </td>
       <td>
         <small><a href="../draft-04/draft-zyp-json-schema-04.html">
@@ -272,9 +274,9 @@ For links to the somewhat more readably formatted versions on this web site, and
         Draft 3
       </td>
       <td>
-	  <small>
-        22-November-2010
-		</small>
+	      <small>
+          22-November-2010
+		    </small>
       </td>
       <td>
         <small>draft-03</small>
@@ -291,9 +293,9 @@ For links to the somewhat more readably formatted versions on this web site, and
         Draft 2
       </td>
       <td>
-	  <small>
-        23-March-2010
-		</small>
+	      <small>
+          23-March-2010
+		    </small>
       </td>
       <td>
         <small>draft-02</small>
@@ -309,9 +311,9 @@ For links to the somewhat more readably formatted versions on this web site, and
         Draft 1
       </td>
       <td>
-	  <small>
-        05-December-2009
-		</small>
+	      <small>
+          05-December-2009
+		    </small>
       </td>
       <td>
         <small>draft-01</small>
@@ -329,8 +331,8 @@ For links to the somewhat more readably formatted versions on this web site, and
       </td>
       <td>
         <small>
-		05-December-2009
-		</small>
+		      05-December-2009
+		    </small>
       </td>
       <td>
         <small>draft-00</small></td>
@@ -353,14 +355,14 @@ For links to the somewhat more readably formatted versions on this web site, and
 ### 2020-12
 
 - Specifications
-  - Core: [draft-bhutton-json-schema-01](../../draft/2020-12/draft-bhutton-json-schema-01.html) ([changes](../../draft/2020-12/draft-bhutton-json-schema-01.html#appendix-G))
-  - Validation: [draft-bhutton-json-schema-validation-01](../../draft/2020-12/draft-bhutton-json-schema-validation-01.html) ([changes](/draft/2020-12/draft-bhutton-json-schema-validation-01.html#appendix-C))
-  - Relative JSON Pointer: [draft-bhutton-relative-json-pointer-00](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00) ([changes](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00#appendix-A))
-  - Published: 16-June-2022
+    - Core: [draft-bhutton-json-schema-01](../../draft/2020-12/draft-bhutton-json-schema-01.html) ([changes](../../draft/2020-12/draft-bhutton-json-schema-01.html#appendix-G))
+    - Validation: [draft-bhutton-json-schema-validation-01](../../draft/2020-12/draft-bhutton-json-schema-validation-01.html) ([changes](/draft/2020-12/draft-bhutton-json-schema-validation-01.html#appendix-C))
+    - Relative JSON Pointer: [draft-bhutton-relative-json-pointer-00](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00) ([changes](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00#appendix-A))
+    - Published: 16-June-2022
 - General use meta-schemas
-  - [JSON Schema meta-schema](../../draft/2020-12/schema)
-  - [JSON Hyper-Schema meta-schema](../../draft/2020-12/hyper-schema) (2019-09 Hyper-Schema with 2020-12 Validation)
-  - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2020-12/links)
+    - [JSON Schema meta-schema](../../draft/2020-12/schema)
+    - [JSON Hyper-Schema meta-schema](../../draft/2020-12/hyper-schema) (2019-09 Hyper-Schema with 2020-12 Validation)
+    - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2020-12/links)
 - Individual vocabulary meta-schemas
   - [Core Vocabulary meta-schema](../../draft/2020-12/meta/core)
   - [Applicator Vocabulary meta-schema](../../draft/2020-12/meta/applicator)
@@ -371,9 +373,9 @@ For links to the somewhat more readably formatted versions on this web site, and
   - [Content Vocabulary meta-schema](../../draft/2020-12/meta/content)
   - [Meta-Data Vocabulary meta-schema](../../draft/2020-12/meta/meta-data)
 - Output schemas
-  - [JSON Schema recommended output schema](../../draft/2020-12/output/schema)
+    - [JSON Schema recommended output schema](../../draft/2020-12/output/schema)
 - Output examples
-  - [JSON Schema verbose output example](../../draft/2020-12/output/verbose-example)
+    - [JSON Schema verbose output example](../../draft/2020-12/output/verbose-example)
 
 #### Obsolete Draft 2020-12 Documents
 
@@ -386,31 +388,31 @@ _These were updated without changing functionality or meta-schemas due to a few 
 
 ### Draft 2019-09 (formerly known as Draft 8)
 
-_**NOTE:** All meta-schema URIs now use `https://`. While currently also available over plain HTTP due to the limitations of GitHub pages and the need to keep prior drafts available over HTTP, only the HTTPS URIs should be used._
+_**NOTE:** All meta-schema URIs now use `https://`.  While currently also available over plain HTTP due to the limitations of GitHub pages and the need to keep prior drafts available over HTTP, only the HTTPS URIs should be used._
 
 - Specifications
-  - Core: [draft-handrews-json-schema-02](../../draft/2019-09/draft-handrews-json-schema-02.html) ([changes](draft/2019-09/draft-handrews-json-schema-02.html#rfc.appendix.G))
-  - Validation: [draft-handrews-json-schema-validation-02](../../draft/2019-09/draft-handrews-json-schema-validation-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-validation-02.html#rfc.appendix.C))
-  - Hyper-Schema: [draft-handrews-json-schema-hyperschema-02](../../draft/2019-09/draft-handrews-json-schema-hyperschema-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-hyperschema-02.html#rfc.appendix.B))
-  - Relative JSON Pointer: [draft-handrews-relative-json-pointer-02](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02) ([changes](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02#appendix-A))
-  - Published: 17-September-2019
+    - Core: [draft-handrews-json-schema-02](../../draft/2019-09/draft-handrews-json-schema-02.html) ([changes](draft/2019-09/draft-handrews-json-schema-02.html#rfc.appendix.G))
+    - Validation: [draft-handrews-json-schema-validation-02](../../draft/2019-09/draft-handrews-json-schema-validation-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-validation-02.html#rfc.appendix.C))
+    - Hyper-Schema: [draft-handrews-json-schema-hyperschema-02](../../draft/2019-09/draft-handrews-json-schema-hyperschema-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-hyperschema-02.html#rfc.appendix.B))
+    - Relative JSON Pointer: [draft-handrews-relative-json-pointer-02](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02) ([changes](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02#appendix-A))
+    - Published: 17-September-2019
 - General use meta-schemas
-  - [JSON Schema meta-schema](../../draft/2019-09/schema)
-  - [JSON Hyper-Schema meta-schema](../../draft/2019-09/hyper-schema)
-  - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2019-09/links)
+    - [JSON Schema meta-schema](../../draft/2019-09/schema)
+    - [JSON Hyper-Schema meta-schema](../../draft/2019-09/hyper-schema)
+    - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2019-09/links)
 - Individual vocabulary meta-schemas
-  - [Core Vocabulary meta-schema](../../draft/2019-09/meta/core)
-  - [Applicator Vocabulary meta-schema](../../draft/2019-09/meta/applicator)
-  - [Validation Vocabulary meta-schema](../../draft/2019-09/meta/validation)
-  - [Format Vocabulary meta-schema](../../draft/2019-09/meta/format)
-  - [Content Vocabulary meta-schema](../../draft/2019-09/meta/content)
-  - [Meta-Data Vocabulary meta-schema](../../draft/2019-09/meta/meta-data)
-  - [Hyper-Schema Vocabulary meta-schema](../../draft/2019-09/meta/hyper-schema)
+    - [Core Vocabulary meta-schema](../../draft/2019-09/meta/core)
+    - [Applicator Vocabulary meta-schema](../../draft/2019-09/meta/applicator)
+    - [Validation Vocabulary meta-schema](../../draft/2019-09/meta/validation)
+    - [Format Vocabulary meta-schema](../../draft/2019-09/meta/format)
+    - [Content Vocabulary meta-schema](../../draft/2019-09/meta/content)
+    - [Meta-Data Vocabulary meta-schema](../../draft/2019-09/meta/meta-data)
+    - [Hyper-Schema Vocabulary meta-schema](../../draft/2019-09/meta/hyper-schema)
 - Output schemas
-  - [JSON Schema recommended output schema](../../draft/2019-09/output/schema)
-  - [JSON Hyper-Schema recommended output schema](../../draft/2019-09/output/hyper-schema)
+    - [JSON Schema recommended output schema](../../draft/2019-09/output/schema)
+    - [JSON Hyper-Schema recommended output schema](../../draft/2019-09/output/hyper-schema)
 - Output examples
-  - [JSON Schema verbose output example](../../draft/2019-09/output/verbose-example)
+    - [JSON Schema verbose output example](../../draft/2019-09/output/verbose-example)
 
 ### Draft 7
 
@@ -444,71 +446,61 @@ _These were updated without changing functionality or meta-schemas due to a few 
 
 ### Draft 5
 
-- Core: [draft-wright-json-schema-00](../../draft-05/draft-wright-json-schema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-00.pdf#appendix-B))
-- Validation: [draft-wright-json-schema-validation-00](../../draft-05/draft-wright-json-schema-validation-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-validation-00.pdf#appendix-B))
-- Hyper-Schema: [draft-wright-json-schema-hyperschema-00](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf#appendix-B))
-- Draft 5 was primarily a cleanup of Draft 4 and continued to use the Draft 4 meta-schemas.
-- Published: 13-October-2016
+ - Core: [draft-wright-json-schema-00](../../draft-05/draft-wright-json-schema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-00.pdf#appendix-B))
+ - Validation: [draft-wright-json-schema-validation-00](../../draft-05/draft-wright-json-schema-validation-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-validation-00.pdf#appendix-B))
+ - Hyper-Schema: [draft-wright-json-schema-hyperschema-00](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf#appendix-B))
+ - Draft 5 was primarily a cleanup of Draft 4 and continued to use the Draft 4 meta-schemas.
+ - Published: 13-October-2016
 
 ### Draft 4
 
-- Core: [draft-zyp-json-schema-04](../../draft-04/draft-zyp-json-schema-04.html) ([changes](../../draft-04/draft-zyp-json-schema-04.html#rfc.appendix.A))
-- Validation: [draft-fge-json-schema-validation-00](../../draft-04/draft-fge-json-schema-validation-00.html) ([changes](../../draft-04/draft-fge-json-schema-validation-00.html#rfc.appendix.A))
-- Hyper-Schema: [draft-luff-json-hyper-schema-00](../../draft-04/draft-luff-json-hyper-schema-00.html) ([changes](../../draft-04/draft-luff-json-hyper-schema-00.html#rfc.appendix.A))
-- JSON Reference: [draft-pbryan-zyp-json-ref-03](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) ([changes](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#appendix-A))
-
-* [JSON Schema meta-schema](../../draft-04/schema)
-* [JSON Hyper-Schema meta-schema](../../draft-04/hyper-schema)
-
-- Published: 31-January-2013
+ - Core: [draft-zyp-json-schema-04](../../draft-04/draft-zyp-json-schema-04.html) ([changes](../../draft-04/draft-zyp-json-schema-04.html#rfc.appendix.A))
+ - Validation: [draft-fge-json-schema-validation-00](../../draft-04/draft-fge-json-schema-validation-00.html) ([changes](../../draft-04/draft-fge-json-schema-validation-00.html#rfc.appendix.A))
+ - Hyper-Schema: [draft-luff-json-hyper-schema-00](../../draft-04/draft-luff-json-hyper-schema-00.html) ([changes](../../draft-04/draft-luff-json-hyper-schema-00.html#rfc.appendix.A))
+ - JSON Reference: [draft-pbryan-zyp-json-ref-03](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) ([changes](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#appendix-A))
+ * [JSON Schema meta-schema](../../draft-04/schema)
+ * [JSON Hyper-Schema meta-schema](../../draft-04/hyper-schema)
+ - Published: 31-January-2013
 
 ### Draft 3
 
-- Complete Specification: [draft-zyp-json-schema-03](../../draft-03/draft-zyp-json-schema-03.pdf) ([changes](../../draft-03/draft-zyp-json-schema-03.pdf#anchor54))
-
+ - Complete Specification: [draft-zyp-json-schema-03](../../draft-03/draft-zyp-json-schema-03.pdf) ([changes](../../draft-03/draft-zyp-json-schema-03.pdf#anchor54))
 * [JSON Schema meta-schema](../../draft-03/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-03/hyper-schema)
-
 - Published: 22-November-2010
 
 ### Draft 2
 
-- Complete Specification: [draft-zyp-json-schema-02](../../draft-02/draft-zyp-json-schema-02.txt) (changes: Appendix-A)
-
+ - Complete Specification: [draft-zyp-json-schema-02](../../draft-02/draft-zyp-json-schema-02.txt) (changes: Appendix-A)
 * [JSON Schema meta-schema](../../draft-02/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-02/hyper-schema)
-
 - Published: 23-March-2010
 
 ### Draft 1
 
-- Complete Specification: [draft-zyp-json-schema-01](../../draft-01/draft-zyp-json-schema-01.html) ([changes](../../draft-01/draft-zyp-json-schema-01.html#anchor54))
-
+ - Complete Specification: [draft-zyp-json-schema-01](../../draft-01/draft-zyp-json-schema-01.html) ([changes](../../draft-01/draft-zyp-json-schema-01.html#anchor54))
 * [JSON Schema meta-schema](../../draft-01/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-01/hyper-schema)
-
 - Published: 05-December-2009
 
 ### Draft 0
 
-_Note that Draft 0 erroneously claimed to update another RFC, and was replaced the same day by Draft 1. It is included here for completeness only._
+_Note that Draft 0 erroneously claimed to update another RFC, and was replaced the same day by Draft 1.  It is included here for completeness only._
 
-- Specification: [draft-zyp-json-schema-00](../../draft-00/draft-zyp-json-schema-00.txt) (changes: Appendix-A))
-
+ - Specification: [draft-zyp-json-schema-00](../../draft-00/draft-zyp-json-schema-00.txt) (changes: Appendix-A))
 * [JSON Schema meta-schema](../../draft-00/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-00/hyper-schema)
-
 - Published: 05-December-2009
 
 ## Latest Snapshot (work in progress)
 
-The next unreleased draft is a work in progress. You can [give feedback and get involved on GitHub](https://github.com/json-schema-org/json-schema-spec).
+The next unreleased draft is a work in progress.  You can [give feedback and get involved on GitHub](https://github.com/json-schema-org/json-schema-spec).
 
-The specification links here link to the raw sources. We do not provide rendered [work-in-progress](work-in-progress) drafts except near the very end of a publication cycle, during the final review period.
+The specification links here link to the raw sources.  We do not provide rendered [work-in-progress](work-in-progress) drafts except near the very end of a publication cycle, during the final review period.
 
-- Core: [jsonschema-core.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-core.md)
-- Validation: [jsonschema-validation.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-validation.md)
-- Hyper-Schema: [jsonschema-hyperschema.xml](https://github.com/json-schema-org/json-hyperschema-spec/blob/main/jsonschema-hyperschema.xml)
+ - Core: [jsonschema-core.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-core.md)
+ - Validation: [jsonschema-validation.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-validation.md)
+ - Hyper-Schema: [jsonschema-hyperschema.xml](https://github.com/json-schema-org/json-hyperschema-spec/blob/main/jsonschema-hyperschema.xml)
 - Relative JSON Pointer: [relative-json-pointer.xml](https://github.com/json-schema-org/json-schema-spec/blob/master/relative-json-pointer.xml)
 - [JSON Schema meta-schema](https://github.com/json-schema-org/json-schema-spec/blob/master/schema.json)
 - [JSON Hyper-Schema meta-schema](https://github.com/json-schema-org/json-hyperschema-spec/blob/main/hyper-schema.json)

--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -5,15 +5,15 @@ section: docs
 
 <!-- Links on this page should be immutable - none of them should go to `/latest`, etc. -->
 
-You can find the latest released draft on the [Specification](../../specification) page.  The complex numbering and naming system for drafts and meta-schemas is fully explained here as well.
+You can find the latest released draft on the [Specification](../../specification) page. The complex numbering and naming system for drafts and meta-schemas is fully explained here as well.
 
 <TableOfContent depth={4} />
 
 ## Understanding draft names and numbers
 
-IETF Internet-Drafts (I-Ds) are named with the editor's name and a sequential number which resets with each new editor.  Meta-schemas were more-or-less numbered sequentially up through Draft 7, but the increasingly confusing mismatch between "draft-nn" versions on the meta-schemas and the IETF documents has made that unsustainable.  The practice of fixing meta-schema bugs in place to preserve the sequential numbering has also been controversial.
+IETF Internet-Drafts (I-Ds) are named with the editor's name and a sequential number which resets with each new editor. Meta-schemas were more-or-less numbered sequentially up through Draft 7, but the increasingly confusing mismatch between "draft-nn" versions on the meta-schemas and the IETF documents has made that unsustainable. The practice of fixing meta-schema bugs in place to preserve the sequential numbering has also been controversial.
 
-Starting with what had been called "Draft 8" while it was being written, meta-schemas are identified by the year and month of publication.  This allows for bug fixes to be published with new URIs (as long as it is not more than once a month).
+Starting with what had been called "Draft 8" while it was being written, meta-schemas are identified by the year and month of publication. This allows for bug fixes to be published with new URIs (as long as it is not more than once a month).
 
 ### Table of All Versions of Everything
 
@@ -27,141 +27,89 @@ For links to the somewhat more readably formatted versions on this web site, and
       <th>common name</th>
       <th>notes</th>
     </tr>
-    <tr>
+	<tr>
       <td>
-        <small><a href="../draft-00/draft-zyp-json-schema-00.txt">
-          draft-zyp-json-schema-00
-        </a></small>
+        <small><i>(TBD)</i></small>
       </td>
       <td>
-        <small>draft-00</small></td>
-      <td>
-        Draft 0
+        <small><i>(TBD)</i></small>
       </td>
       <td>
-        <small>due to a markup error, this draft was replaced by
-        <small>draft-01</small> on the same day</small>
+        Draft 2021-NN
+      </td>
+      <td>
+        <small>Milestone:
+        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/7">Draft 2021-NN</a>
+        </small>
       </td>
     </tr>
     <tr>
       <td>
-        <small><a href="../draft-01/draft-zyp-json-schema-01.html">
-          draft-zyp-json-schema-01
-        </a></small></td>
-      <td>
-        <small>draft-01</small>
+        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-00.html">
+          draft-bhutton-json-schema-00
+        </a></small></tt><br><br>
+        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-validation-00.html">
+          draft-bhutton-json-schema-validation-00
+        </a></small></tt><br><br>
+        <tt><small><a href="https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00">
+          draft-bhutton-relative-json-pointer-00
+        </a></small></tt><br>
       </td>
-      <td>
-        Draft 1
+      <td rowspan="3">
+        <tt><small>2020-12</small></tt>
       </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>
-        <small><a href="../draft-02/draft-zyp-json-schema-02.txt">
-          draft-zyp-json-schema-02
-        </a></small></td>
-      <td>
-        <small>draft-02</small>
+      <td rowspan="3">
+        Draft 2020-12
       </td>
-      <td>
-        Draft 2
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>
-        <small><a href="../draft-03/draft-zyp-json-schema-03.pdf">
-          draft-zyp-json-schema-03
-        </a></small>
-      </td>
-      <td>
-        <small>draft-03</small>
-      </td>
-      <td>
-        Draft 3
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>
-        <small><a href="../draft-04/draft-zyp-json-schema-04.html">
-          draft-zyp-json-schema-04
-        </a></small><br><br>
-        <small><a href="../draft-04/draft-fge-json-schema-validation-00.html">
-          draft-fge-json-schema-validation-00
-        </a></small><br><br>
-        <small><a href="../draft-04/draft-luff-json-hyper-schema-00.html">
-          draft-luff-json-hyper-schema-00
-        </a></small><br><br>
-        <small><a href="https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03">
-          draft-pbryan-zyp-json-ref-03
-        </a></small><br>
-      </td>
-      <td rowspan="2">
-        <small>draft-04</small>
-      </td>
-      <td>
-        Draft 4
-      </td>
-      <td>
+      <td rowspan="3">
         <small>
-        <small>json-ref</small> drafts
-        <small>00-02</small> were all published between
-        <small>json-schema-03</small> and
-        <small>json-schema-04</small>
+        Milestone:
+        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/8">draft-08-patch-1</a>
+        <br/>
+        Changes and fixes as a result of discussion with the OpenAPI community. (Includes breaking changes.)
         </small>
       </td>
     </tr>
+    <tr><td><!-- This empty row keeps the row colors aligned properly for the two "2020-12" versions --></td></tr>
     <tr>
       <td>
-        <small><a href="../draft-05/draft-wright-json-schema-00.pdf">
-          draft-wright-json-schema-00
-        </a></small><br><br>
-        <small><a href="../draft-05/draft-wright-json-schema-validation-00.pdf">
-          draft-wright-json-schema-validation-00
-        </a></small><br><br>
-        <small><a href="../draft-05/draft-wright-json-schema-hyperschema-00.pdf">
-          draft-wright-json-schema-hyperschema-00
-        </a></small><br>
-      </td>
-      <td>
-        Draft 5
-      </td>
-      <td>
-        <small>meta-schemas not changed, so
-        "<small>draft-05</small>" is really
-        <small>draft-04</small>
-        <br />
-        Milestone: <a href="https://github.com/json-schema-org/json-schema-spec/milestone/1">draft-5 (2016-10-13)</a></small>
+        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-01.html">
+          draft-bhutton-json-schema-01
+        </a></small></tt><br><br>
+        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-validation-01.html">
+          draft-bhutton-json-schema-validation-01
+        </a></small></tt><br>
+        <br/>
       </td>
     </tr>
-    <tr>
+	 <tr>
       <td>
-        <small><a href="../draft-06/draft-wright-json-schema-01.html">
-          draft-wright-json-schema-01
+        <small><a href="../draft/2019-09/draft-handrews-json-schema-02.html">
+          draft-handrews-json-schema-02
         </a></small><br><br>
-        <small><a href="../draft-06/draft-wright-json-schema-validation-01.html">
-          draft-wright-json-schema-validation-01
+        <small><a href="../draft/2019-09/draft-handrews-json-schema-validation-02.html">
+          draft-handrews-json-schema-validation-02
         </a></small><br><br>
-        <small><a href="../draft-06/draft-wright-json-schema-hyperschema-01.html">
-          draft-wright-json-schema-hyperschema-01
+        <small><a href="../draft/2019-09/draft-handrews-json-schema-hyperschema-02.html">
+          draft-handrews-json-schema-hyperschema-02
+        </a></small><br><br>
+        <small><a href="https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02">
+          draft-handrews-relative-json-pointer-02
         </a></small><br>
       </td>
       <td>
-        <small>draft-06</small>
+        <small>2019-09</small>
       </td>
       <td>
-        Draft 6
+        Draft 2019-09
       </td>
       <td>
-        <small>Milestones:
-        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/2">draft-6</a>,
-        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/4">Meta-schema draft-06</a>
+        <small>Milestone:
+        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/6">draft-08</a>
         </small>
       </td>
     </tr>
-    <tr>
+	<tr>
       <td>
         <small><a href="../draft-07/draft-handrews-json-schema-00.pdf">
           draft-handrews-json-schema-00
@@ -209,88 +157,141 @@ For links to the somewhat more readably formatted versions on this web site, and
         </a></small><br>
       </td>
     </tr>
-    <tr>
+	<tr>
       <td>
-        <small><a href="../draft/2019-09/draft-handrews-json-schema-02.html">
-          draft-handrews-json-schema-02
+        <small><a href="../draft-06/draft-wright-json-schema-01.html">
+          draft-wright-json-schema-01
         </a></small><br><br>
-        <small><a href="../draft/2019-09/draft-handrews-json-schema-validation-02.html">
-          draft-handrews-json-schema-validation-02
+        <small><a href="../draft-06/draft-wright-json-schema-validation-01.html">
+          draft-wright-json-schema-validation-01
         </a></small><br><br>
-        <small><a href="../draft/2019-09/draft-handrews-json-schema-hyperschema-02.html">
-          draft-handrews-json-schema-hyperschema-02
-        </a></small><br><br>
-        <small><a href="https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02">
-          draft-handrews-relative-json-pointer-02
+        <small><a href="../draft-06/draft-wright-json-schema-hyperschema-01.html">
+          draft-wright-json-schema-hyperschema-01
         </a></small><br>
       </td>
       <td>
-        <small>2019-09</small>
+        <small>draft-06</small>
       </td>
       <td>
-        Draft 2019-09
+        Draft 6
       </td>
       <td>
-        <small>Milestone:
-        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/6">draft-08</a>
+        <small>Milestones:
+        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/2">draft-6</a>,
+        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/4">Meta-schema draft-06</a>
         </small>
       </td>
     </tr>
-    <tr>
+	<tr>
       <td>
-        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-00.html">
-          draft-bhutton-json-schema-00
-        </a></small></tt><br><br>
-        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-validation-00.html">
-          draft-bhutton-json-schema-validation-00
-        </a></small></tt><br><br>
-        <tt><small><a href="https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00">
-          draft-bhutton-relative-json-pointer-00
-        </a></small></tt><br>
+        <small><a href="../draft-05/draft-wright-json-schema-00.pdf">
+          draft-wright-json-schema-00
+        </a></small><br><br>
+        <small><a href="../draft-05/draft-wright-json-schema-validation-00.pdf">
+          draft-wright-json-schema-validation-00
+        </a></small><br><br>
+        <small><a href="../draft-05/draft-wright-json-schema-hyperschema-00.pdf">
+          draft-wright-json-schema-hyperschema-00
+        </a></small><br>
       </td>
-      <td rowspan="3">
-        <tt><small>2020-12</small></tt>
+	  <td rowspan="2">
+        <small>draft-04</small>
       </td>
-      <td rowspan="3">
-        Draft 2020-12
+      <td>
+        Draft 5
       </td>
-      <td rowspan="3">
+      <td>
+        <small>meta-schemas not changed, so
+        "<small>draft-05</small>" is really
+        <small>draft-04</small>
+        <br />
+        Milestone: <a href="https://github.com/json-schema-org/json-schema-spec/milestone/1">draft-5 (2016-10-13)</a></small>
+      </td>
+    </tr>
+	<tr>
+      <td>
+        <small><a href="../draft-04/draft-zyp-json-schema-04.html">
+          draft-zyp-json-schema-04
+        </a></small><br><br>
+        <small><a href="../draft-04/draft-fge-json-schema-validation-00.html">
+          draft-fge-json-schema-validation-00
+        </a></small><br><br>
+        <small><a href="../draft-04/draft-luff-json-hyper-schema-00.html">
+          draft-luff-json-hyper-schema-00
+        </a></small><br><br>
+        <small><a href="https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03">
+          draft-pbryan-zyp-json-ref-03
+        </a></small><br>
+      </td>
+      <td>
+        Draft 4
+      </td>
+      <td>
         <small>
-        Milestone:
-        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/8">draft-08-patch-1</a>
-        <br/>
-        Changes and fixes as a result of discussion with the OpenAPI community. (Includes breaking changes.)
+        <small>json-ref</small> drafts
+        <small>00-02</small> were all published between
+        <small>json-schema-03</small> and
+        <small>json-schema-04</small>
         </small>
       </td>
     </tr>
-    <tr><td><!-- This empty row keeps the row colors aligned properly for the two "2020-12" versions --></td></tr>
-    <tr>
+	<tr>
       <td>
-        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-01.html">
-          draft-bhutton-json-schema-01
-        </a></small></tt><br><br>
-        <tt><small><a href="../draft/2020-12/draft-bhutton-json-schema-validation-01.html">
-          draft-bhutton-json-schema-validation-01
-        </a></small></tt><br>
-        <br/>
+        <small><a href="../draft-03/draft-zyp-json-schema-03.pdf">
+          draft-zyp-json-schema-03
+        </a></small>
+      </td>
+      <td>
+        <small>draft-03</small>
+      </td>
+      <td>
+        Draft 3
+      </td>
+      <td></td>
+    </tr>
+	<tr>
+      <td>
+        <small><a href="../draft-02/draft-zyp-json-schema-02.txt">
+          draft-zyp-json-schema-02
+        </a></small></td>
+      <td>
+        <small>draft-02</small>
+      </td>
+      <td>
+        Draft 2
+      </td>
+      <td></td>
+    </tr>
+	<tr>
+      <td>
+        <small><a href="../draft-01/draft-zyp-json-schema-01.html">
+          draft-zyp-json-schema-01
+        </a></small></td>
+      <td>
+        <small>draft-01</small>
+      </td>
+      <td>
+        Draft 1
+      </td>
+      <td></td>
+    </tr>
+	<tr>
+      <td>
+        <small><a href="../draft-00/draft-zyp-json-schema-00.txt">
+          draft-zyp-json-schema-00
+        </a></small>
+      </td>
+      <td>
+        <small>draft-00</small></td>
+      <td>
+        Draft 0
+      </td>
+      <td>
+        <small>due to a markup error, this draft was replaced by
+        <small>draft-01</small> on the same day</small>
       </td>
     </tr>
-    <tr>
-      <td>
-        <small><i>(TBD)</i></small>
-      </td>
-      <td>
-        <small><i>(TBD)</i></small>
-      </td>
-      <td>
-        Draft 2021-NN
-      </td>
-      <td>
-        <small>Milestone:
-        <a href="https://github.com/json-schema-org/json-schema-spec/milestone/7">Draft 2021-NN</a>
-        </small>
-      </td>
-    </tr>
+	
   </tbody>
 </table>
 
@@ -299,14 +300,14 @@ For links to the somewhat more readably formatted versions on this web site, and
 ### 2020-12
 
 - Specifications
-    - Core: [draft-bhutton-json-schema-01](../../draft/2020-12/draft-bhutton-json-schema-01.html) ([changes](../../draft/2020-12/draft-bhutton-json-schema-01.html#appendix-G))
-    - Validation: [draft-bhutton-json-schema-validation-01](../../draft/2020-12/draft-bhutton-json-schema-validation-01.html) ([changes](/draft/2020-12/draft-bhutton-json-schema-validation-01.html#appendix-C))
-    - Relative JSON Pointer: [draft-bhutton-relative-json-pointer-00](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00) ([changes](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00#appendix-A))
-    - Published: 16-June-2022
+  - Core: [draft-bhutton-json-schema-01](../../draft/2020-12/draft-bhutton-json-schema-01.html) ([changes](../../draft/2020-12/draft-bhutton-json-schema-01.html#appendix-G))
+  - Validation: [draft-bhutton-json-schema-validation-01](../../draft/2020-12/draft-bhutton-json-schema-validation-01.html) ([changes](/draft/2020-12/draft-bhutton-json-schema-validation-01.html#appendix-C))
+  - Relative JSON Pointer: [draft-bhutton-relative-json-pointer-00](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00) ([changes](https://tools.ietf.org/html/draft-bhutton-relative-json-pointer-00#appendix-A))
+  - Published: 16-June-2022
 - General use meta-schemas
-    - [JSON Schema meta-schema](../../draft/2020-12/schema)
-    - [JSON Hyper-Schema meta-schema](../../draft/2020-12/hyper-schema) (2019-09 Hyper-Schema with 2020-12 Validation)
-    - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2020-12/links)
+  - [JSON Schema meta-schema](../../draft/2020-12/schema)
+  - [JSON Hyper-Schema meta-schema](../../draft/2020-12/hyper-schema) (2019-09 Hyper-Schema with 2020-12 Validation)
+  - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2020-12/links)
 - Individual vocabulary meta-schemas
   - [Core Vocabulary meta-schema](../../draft/2020-12/meta/core)
   - [Applicator Vocabulary meta-schema](../../draft/2020-12/meta/applicator)
@@ -317,9 +318,9 @@ For links to the somewhat more readably formatted versions on this web site, and
   - [Content Vocabulary meta-schema](../../draft/2020-12/meta/content)
   - [Meta-Data Vocabulary meta-schema](../../draft/2020-12/meta/meta-data)
 - Output schemas
-    - [JSON Schema recommended output schema](../../draft/2020-12/output/schema)
+  - [JSON Schema recommended output schema](../../draft/2020-12/output/schema)
 - Output examples
-    - [JSON Schema verbose output example](../../draft/2020-12/output/verbose-example)
+  - [JSON Schema verbose output example](../../draft/2020-12/output/verbose-example)
 
 #### Obsolete Draft 2020-12 Documents
 
@@ -332,31 +333,31 @@ _These were updated without changing functionality or meta-schemas due to a few 
 
 ### Draft 2019-09 (formerly known as Draft 8)
 
-_**NOTE:** All meta-schema URIs now use `https://`.  While currently also available over plain HTTP due to the limitations of GitHub pages and the need to keep prior drafts available over HTTP, only the HTTPS URIs should be used._
+_**NOTE:** All meta-schema URIs now use `https://`. While currently also available over plain HTTP due to the limitations of GitHub pages and the need to keep prior drafts available over HTTP, only the HTTPS URIs should be used._
 
 - Specifications
-    - Core: [draft-handrews-json-schema-02](../../draft/2019-09/draft-handrews-json-schema-02.html) ([changes](draft/2019-09/draft-handrews-json-schema-02.html#rfc.appendix.G))
-    - Validation: [draft-handrews-json-schema-validation-02](../../draft/2019-09/draft-handrews-json-schema-validation-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-validation-02.html#rfc.appendix.C))
-    - Hyper-Schema: [draft-handrews-json-schema-hyperschema-02](../../draft/2019-09/draft-handrews-json-schema-hyperschema-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-hyperschema-02.html#rfc.appendix.B))
-    - Relative JSON Pointer: [draft-handrews-relative-json-pointer-02](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02) ([changes](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02#appendix-A))
-    - Published: 17-September-2019
+  - Core: [draft-handrews-json-schema-02](../../draft/2019-09/draft-handrews-json-schema-02.html) ([changes](draft/2019-09/draft-handrews-json-schema-02.html#rfc.appendix.G))
+  - Validation: [draft-handrews-json-schema-validation-02](../../draft/2019-09/draft-handrews-json-schema-validation-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-validation-02.html#rfc.appendix.C))
+  - Hyper-Schema: [draft-handrews-json-schema-hyperschema-02](../../draft/2019-09/draft-handrews-json-schema-hyperschema-02.html) ([changes](/draft/2019-09/draft-handrews-json-schema-hyperschema-02.html#rfc.appendix.B))
+  - Relative JSON Pointer: [draft-handrews-relative-json-pointer-02](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02) ([changes](https://tools.ietf.org/html/draft-handrews-relative-json-pointer-02#appendix-A))
+  - Published: 17-September-2019
 - General use meta-schemas
-    - [JSON Schema meta-schema](../../draft/2019-09/schema)
-    - [JSON Hyper-Schema meta-schema](../../draft/2019-09/hyper-schema)
-    - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2019-09/links)
+  - [JSON Schema meta-schema](../../draft/2019-09/schema)
+  - [JSON Hyper-Schema meta-schema](../../draft/2019-09/hyper-schema)
+  - [JSON Hyper-Schema Link Description Object meta-schema](../../draft/2019-09/links)
 - Individual vocabulary meta-schemas
-    - [Core Vocabulary meta-schema](../../draft/2019-09/meta/core)
-    - [Applicator Vocabulary meta-schema](../../draft/2019-09/meta/applicator)
-    - [Validation Vocabulary meta-schema](../../draft/2019-09/meta/validation)
-    - [Format Vocabulary meta-schema](../../draft/2019-09/meta/format)
-    - [Content Vocabulary meta-schema](../../draft/2019-09/meta/content)
-    - [Meta-Data Vocabulary meta-schema](../../draft/2019-09/meta/meta-data)
-    - [Hyper-Schema Vocabulary meta-schema](../../draft/2019-09/meta/hyper-schema)
+  - [Core Vocabulary meta-schema](../../draft/2019-09/meta/core)
+  - [Applicator Vocabulary meta-schema](../../draft/2019-09/meta/applicator)
+  - [Validation Vocabulary meta-schema](../../draft/2019-09/meta/validation)
+  - [Format Vocabulary meta-schema](../../draft/2019-09/meta/format)
+  - [Content Vocabulary meta-schema](../../draft/2019-09/meta/content)
+  - [Meta-Data Vocabulary meta-schema](../../draft/2019-09/meta/meta-data)
+  - [Hyper-Schema Vocabulary meta-schema](../../draft/2019-09/meta/hyper-schema)
 - Output schemas
-    - [JSON Schema recommended output schema](../../draft/2019-09/output/schema)
-    - [JSON Hyper-Schema recommended output schema](../../draft/2019-09/output/hyper-schema)
+  - [JSON Schema recommended output schema](../../draft/2019-09/output/schema)
+  - [JSON Hyper-Schema recommended output schema](../../draft/2019-09/output/hyper-schema)
 - Output examples
-    - [JSON Schema verbose output example](../../draft/2019-09/output/verbose-example)
+  - [JSON Schema verbose output example](../../draft/2019-09/output/verbose-example)
 
 ### Draft 7
 
@@ -390,61 +391,71 @@ _These were updated without changing functionality or meta-schemas due to a few 
 
 ### Draft 5
 
- - Core: [draft-wright-json-schema-00](../../draft-05/draft-wright-json-schema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-00.pdf#appendix-B))
- - Validation: [draft-wright-json-schema-validation-00](../../draft-05/draft-wright-json-schema-validation-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-validation-00.pdf#appendix-B))
- - Hyper-Schema: [draft-wright-json-schema-hyperschema-00](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf#appendix-B))
- - Draft 5 was primarily a cleanup of Draft 4 and continued to use the Draft 4 meta-schemas.
- - Published: 13-October-2016
+- Core: [draft-wright-json-schema-00](../../draft-05/draft-wright-json-schema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-00.pdf#appendix-B))
+- Validation: [draft-wright-json-schema-validation-00](../../draft-05/draft-wright-json-schema-validation-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-validation-00.pdf#appendix-B))
+- Hyper-Schema: [draft-wright-json-schema-hyperschema-00](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf) ([changes](../../draft-05/draft-wright-json-schema-hyperschema-00.pdf#appendix-B))
+- Draft 5 was primarily a cleanup of Draft 4 and continued to use the Draft 4 meta-schemas.
+- Published: 13-October-2016
 
 ### Draft 4
 
- - Core: [draft-zyp-json-schema-04](../../draft-04/draft-zyp-json-schema-04.html) ([changes](../../draft-04/draft-zyp-json-schema-04.html#rfc.appendix.A))
- - Validation: [draft-fge-json-schema-validation-00](../../draft-04/draft-fge-json-schema-validation-00.html) ([changes](../../draft-04/draft-fge-json-schema-validation-00.html#rfc.appendix.A))
- - Hyper-Schema: [draft-luff-json-hyper-schema-00](../../draft-04/draft-luff-json-hyper-schema-00.html) ([changes](../../draft-04/draft-luff-json-hyper-schema-00.html#rfc.appendix.A))
- - JSON Reference: [draft-pbryan-zyp-json-ref-03](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) ([changes](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#appendix-A))
- * [JSON Schema meta-schema](../../draft-04/schema)
- * [JSON Hyper-Schema meta-schema](../../draft-04/hyper-schema)
- - Published: 31-January-2013
+- Core: [draft-zyp-json-schema-04](../../draft-04/draft-zyp-json-schema-04.html) ([changes](../../draft-04/draft-zyp-json-schema-04.html#rfc.appendix.A))
+- Validation: [draft-fge-json-schema-validation-00](../../draft-04/draft-fge-json-schema-validation-00.html) ([changes](../../draft-04/draft-fge-json-schema-validation-00.html#rfc.appendix.A))
+- Hyper-Schema: [draft-luff-json-hyper-schema-00](../../draft-04/draft-luff-json-hyper-schema-00.html) ([changes](../../draft-04/draft-luff-json-hyper-schema-00.html#rfc.appendix.A))
+- JSON Reference: [draft-pbryan-zyp-json-ref-03](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) ([changes](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#appendix-A))
+
+* [JSON Schema meta-schema](../../draft-04/schema)
+* [JSON Hyper-Schema meta-schema](../../draft-04/hyper-schema)
+
+- Published: 31-January-2013
 
 ### Draft 3
 
- - Complete Specification: [draft-zyp-json-schema-03](../../draft-03/draft-zyp-json-schema-03.pdf) ([changes](../../draft-03/draft-zyp-json-schema-03.pdf#anchor54))
+- Complete Specification: [draft-zyp-json-schema-03](../../draft-03/draft-zyp-json-schema-03.pdf) ([changes](../../draft-03/draft-zyp-json-schema-03.pdf#anchor54))
+
 * [JSON Schema meta-schema](../../draft-03/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-03/hyper-schema)
+
 - Published: 22-November-2010
 
 ### Draft 2
 
- - Complete Specification: [draft-zyp-json-schema-02](../../draft-02/draft-zyp-json-schema-02.txt) (changes: Appendix-A)
+- Complete Specification: [draft-zyp-json-schema-02](../../draft-02/draft-zyp-json-schema-02.txt) (changes: Appendix-A)
+
 * [JSON Schema meta-schema](../../draft-02/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-02/hyper-schema)
+
 - Published: 23-March-2010
 
 ### Draft 1
 
- - Complete Specification: [draft-zyp-json-schema-01](../../draft-01/draft-zyp-json-schema-01.html) ([changes](../../draft-01/draft-zyp-json-schema-01.html#anchor54))
+- Complete Specification: [draft-zyp-json-schema-01](../../draft-01/draft-zyp-json-schema-01.html) ([changes](../../draft-01/draft-zyp-json-schema-01.html#anchor54))
+
 * [JSON Schema meta-schema](../../draft-01/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-01/hyper-schema)
+
 - Published: 05-December-2009
 
 ### Draft 0
 
-_Note that Draft 0 erroneously claimed to update another RFC, and was replaced the same day by Draft 1.  It is included here for completeness only._
+_Note that Draft 0 erroneously claimed to update another RFC, and was replaced the same day by Draft 1. It is included here for completeness only._
 
- - Specification: [draft-zyp-json-schema-00](../../draft-00/draft-zyp-json-schema-00.txt) (changes: Appendix-A))
+- Specification: [draft-zyp-json-schema-00](../../draft-00/draft-zyp-json-schema-00.txt) (changes: Appendix-A))
+
 * [JSON Schema meta-schema](../../draft-00/schema)
 * [JSON Hyper-Schema meta-schema](../../draft-00/hyper-schema)
+
 - Published: 05-December-2009
 
 ## Latest Snapshot (work in progress)
 
-The next unreleased draft is a work in progress.  You can [give feedback and get involved on GitHub](https://github.com/json-schema-org/json-schema-spec).
+The next unreleased draft is a work in progress. You can [give feedback and get involved on GitHub](https://github.com/json-schema-org/json-schema-spec).
 
-The specification links here link to the raw sources.  We do not provide rendered [work-in-progress](work-in-progress) drafts except near the very end of a publication cycle, during the final review period.
+The specification links here link to the raw sources. We do not provide rendered [work-in-progress](work-in-progress) drafts except near the very end of a publication cycle, during the final review period.
 
- - Core: [jsonschema-core.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-core.md)
- - Validation: [jsonschema-validation.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-validation.md)
- - Hyper-Schema: [jsonschema-hyperschema.xml](https://github.com/json-schema-org/json-hyperschema-spec/blob/main/jsonschema-hyperschema.xml)
+- Core: [jsonschema-core.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-core.md)
+- Validation: [jsonschema-validation.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-validation.md)
+- Hyper-Schema: [jsonschema-hyperschema.xml](https://github.com/json-schema-org/json-hyperschema-spec/blob/main/jsonschema-hyperschema.xml)
 - Relative JSON Pointer: [relative-json-pointer.xml](https://github.com/json-schema-org/json-schema-spec/blob/master/relative-json-pointer.xml)
 - [JSON Schema meta-schema](https://github.com/json-schema-org/json-schema-spec/blob/master/schema.json)
 - [JSON Hyper-Schema meta-schema](https://github.com/json-schema-org/json-hyperschema-spec/blob/main/hyper-schema.json)

--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -26,6 +26,7 @@ For links to the somewhat more readably formatted versions on this web site, and
       <th>meta-schema identifiers</th>
       <th>common name</th>
       <th>notes</th>
+      <th>published</th>
     </tr>
 	<tr>
       <td>
@@ -41,6 +42,9 @@ For links to the somewhat more readably formatted versions on this web site, and
         <small>Milestone:
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/7">Draft 2021-NN</a>
         </small>
+      </td>
+	  <td>
+        <small><i>(TBD)</i></small>
       </td>
     </tr>
     <tr>
@@ -69,6 +73,9 @@ For links to the somewhat more readably formatted versions on this web site, and
         Changes and fixes as a result of discussion with the OpenAPI community. (Includes breaking changes.)
         </small>
       </td>
+      <td rowspan="3">
+         <small>16-June-2022</small>
+      </td>
     </tr>
     <tr><td><!-- This empty row keeps the row colors aligned properly for the two "2020-12" versions --></td></tr>
     <tr>
@@ -82,7 +89,7 @@ For links to the somewhat more readably formatted versions on this web site, and
         <br/>
       </td>
     </tr>
-	 <tr>
+    <tr>
       <td>
         <small><a href="../draft/2019-09/draft-handrews-json-schema-02.html">
           draft-handrews-json-schema-02
@@ -108,8 +115,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/6">draft-08</a>
         </small>
       </td>
+      <td>
+	  <small>
+        17-September-2019
+		</small>
+      </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-07/draft-handrews-json-schema-00.pdf">
           draft-handrews-json-schema-00
@@ -139,6 +151,11 @@ For links to the somewhat more readably formatted versions on this web site, and
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/5">draft-07</a>
         </small>
       </td>
+      <td rowspan="3">
+	  <small>
+        19-March-2018
+		</small>
+      </td>
     </tr>
     <tr><td><!-- This empty row keeps the row colors aligned properly for the two "draft-07" versions --></td></tr>
     <tr>
@@ -157,7 +174,7 @@ For links to the somewhat more readably formatted versions on this web site, and
         </a></small><br>
       </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-06/draft-wright-json-schema-01.html">
           draft-wright-json-schema-01
@@ -181,8 +198,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         <a href="https://github.com/json-schema-org/json-schema-spec/milestone/4">Meta-schema draft-06</a>
         </small>
       </td>
+      <td>
+	  <small>
+        21-April-2017
+		</small>
+      </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-05/draft-wright-json-schema-00.pdf">
           draft-wright-json-schema-00
@@ -194,7 +216,7 @@ For links to the somewhat more readably formatted versions on this web site, and
           draft-wright-json-schema-hyperschema-00
         </a></small><br>
       </td>
-	  <td rowspan="2">
+      <td rowspan="2">
         <small>draft-04</small>
       </td>
       <td>
@@ -207,8 +229,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         <br />
         Milestone: <a href="https://github.com/json-schema-org/json-schema-spec/milestone/1">draft-5 (2016-10-13)</a></small>
       </td>
+      <td>
+		<small>
+        13-October-2016
+		</small>
+      </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-04/draft-zyp-json-schema-04.html">
           draft-zyp-json-schema-04
@@ -234,8 +261,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         <small>json-schema-04</small>
         </small>
       </td>
+      <td>
+	  <small>
+        31-January-2013
+		</small>
+      </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-03/draft-zyp-json-schema-03.pdf">
           draft-zyp-json-schema-03
@@ -248,8 +280,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         Draft 3
       </td>
       <td></td>
+      <td>
+	  <small>
+        22-November-2010
+		</small>
+      </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-02/draft-zyp-json-schema-02.txt">
           draft-zyp-json-schema-02
@@ -261,8 +298,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         Draft 2
       </td>
       <td></td>
+      <td>
+	  <small>
+        23-March-2010
+		</small>
+      </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-01/draft-zyp-json-schema-01.html">
           draft-zyp-json-schema-01
@@ -274,8 +316,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         Draft 1
       </td>
       <td></td>
+      <td>
+	  <small>
+        05-December-2009
+		</small>
+      </td>
     </tr>
-	<tr>
+    <tr>
       <td>
         <small><a href="../draft-00/draft-zyp-json-schema-00.txt">
           draft-zyp-json-schema-00
@@ -290,8 +337,13 @@ For links to the somewhat more readably formatted versions on this web site, and
         <small>due to a markup error, this draft was replaced by
         <small>draft-01</small> on the same day</small>
       </td>
+      <td>
+        <small>
+		05-December-2009
+		</small>
+      </td>
     </tr>
-	
+
   </tbody>
 </table>
 


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**Summary:**

- Inverted the order of the table.
- Added a new column called "Published" with release date
- Changed the columns order to go this way: Common Name, Published, meta-schema identifiers, Metaschemas and notes

**Issue Number:**
-  Closes #572 


**Screenshots/videos:**

Updated version of the table 

![image](https://github.com/json-schema-org/website/assets/63534268/3246890b-6de1-4890-96b6-5bbb18bb0757)
<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
Not relevant 

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
