### PR TITLE
Add background color to the selected tag in blog page

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -209,7 +209,10 @@ export default function StaticMarkdownPage({
               key={tag}
               value={tag}
               onClick={handleClick}
-              className='bg-blue-100 hover:bg-blue-200 cursor-pointer font-semibold text-blue-800 inline-block px-3 py-1 rounded-full mb-4 mr-4 text-sm dark:bg-slate-700 dark:text-blue-100'
+              className={`cursor-pointer 
+			          font-semibold inline-block px-3 py-1 4
+			          rounded-full mb-4 mr-4 text-sm 
+			          ${currentFilterTag === tag ? 'dark:bg-blue-200 dark:text-slate-700 bg-blue-800 text-blue-100' : 'dark:bg-slate-700 dark:text-blue-100 bg-blue-100 text-blue-800 hover:bg-blue-200 hover:dark:bg-slate-600'}`}
             >
               {tag}
             </button>


### PR DESCRIPTION


**What kind of change does this PR introduce?**
- This PR adds selection effect to the [blog](https://json-schema.org/blog) category tags and adds hover effect on the tags (for dark mode)
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #627 

**Screenshots/videos:**

![input](https://github.com/json-schema-org/website/assets/63534268/8550ce9f-8963-470d-9859-05819ddc7d99)

**If relevant, did you update the documentation?**
Not relevant 

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
