### PR TITLE
Feat: Making dark mode consistent for tabsgroup and thead

### DIFF
--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -140,8 +140,9 @@ const TabsGroup = ({ markdown }: { markdown: string }) => {
                 className={classnames(
                   'p-4 px-6 text-slate-700 font-medium border-b-2 rounded-t-lg',
                   {
-                    'border-blue-400 text-blue-500 bg-blue-50': isActive,
-                    'border-white/0 cursor-pointer text-slate-700 hover:border-blue-50 hover:bg-blue-50/20':
+                    'border-blue-400 text-blue-500 bg-blue-50 dark:bg-slate-900 dark:text-white':
+                      isActive,
+                    'border-white/0 cursor-pointer dark:text-white text-slate-700 hover:border-blue-50  hover:bg-blue-50/20':
                       !isActive,
                   },
                 )}
@@ -152,7 +153,7 @@ const TabsGroup = ({ markdown }: { markdown: string }) => {
           })}
         </div>
       </div>
-      <div className='border-slate-100 mb-4 p-6 from-slate-50/50 to-slate-50/100 rounded-xl bg-gradient-to-b dark:from-slate-600 dark:to-slate-900'>
+      <div className='border-slate-100 mb-4 p-6 from-slate-50/50 to-slate-50/100 rounded-xl bg-gradient-to-b dark:from-slate-700/50 dark:to-slate-900/50'>
         <StyledMarkdownBlock markdown={activeTab.markdown} />
       </div>
     </div>

--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -267,7 +267,7 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
             },
             th: {
               component: ({ children }) => (
-                <th className='border border-slate-300 dark:text-white p-4 font-semibold text-black'>
+                <th className='border border-slate-300 dark:text-white p-4 dark:bg-slate-900 font-semibold text-black'>
                   {children}
                 </th>
               ),


### PR DESCRIPTION
**What kind of change does this PR introduce?**
1. Making dark mode consistent for tabsgroup.
2. Making dark mode consistent for thead.
3. Imporved gradient color. 



**Issue Number:**

-  Closes #608 

**Screenshots/videos:**

**Before**

Tabsgroup
![image](https://github.com/json-schema-org/website/assets/124715224/c069b814-b1c6-450a-9ddf-34a0e0d5dbdf)


Thead
![image](https://github.com/json-schema-org/website/assets/124715224/e668de11-1e27-44ec-ad78-d2efe3b33e5f)



**After**

Tabsgroup
![image](https://github.com/json-schema-org/website/assets/124715224/bf242a9b-92aa-429b-8dd6-71388282bbc1)

Thead
![image](https://github.com/json-schema-org/website/assets/124715224/16187b15-a6b0-44b8-ac69-4ce01eb0e432)

<!--Add screenshots or videos wherever possible.-->
