### PR TITLE
Improve draft info render for arrays-additional items

### DIFF
--- a/pages/understanding-json-schema/reference/array.md
+++ b/pages/understanding-json-schema/reference/array.md
@@ -183,18 +183,17 @@ additional items in a tuple beyond what is defined in `prefixItems`. The
 value of the `items` keyword is a schema that all additional items must
 pass in order for the keyword to validate.
 
-[tabs-start "Draft-specific info"]
-
-[tab "Draft 4 - 2019-09"]
+<Infobox label="Draft 4 - 2019-09">
 Before to Draft 2020-12, you would use the `additionalItems`
 keyword to constrain additional items on a tuple. It works the same
 as `items`, only the name has changed.
-[tab "Draft 6 - 2019-09"]
+</Infobox>
+
+<Infobox label="Draft 6 - 2019-09">
 In Draft 6 - 2019-09, the `additionalItems` keyword is ignored if
 there is not a "tuple validation" `items` keyword present in the
 same schema.
-
-[tabs-end]
+</InfoBox>
 
 Here, we\'ll reuse the example schema above, but set `items` to `false`,
 which has the effect of disallowing extra items in the tuple.


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix of render the draft specific info of [UJS arrays](https://json-schema.org/understanding-json-schema/reference/array#additionalitems).

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #231 

**Screenshots/videos:**

![image](https://github.com/json-schema-org/website/assets/81156510/e6553b23-cf79-4454-8d86-f7d03993c93e)

