### PR TITLE
Fix the ordered list discrepancy on getting started page

### DIFF
--- a/pages/learn/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step.md
@@ -98,7 +98,7 @@ Using the product catalog example, `productId` is a numeric value that uniquely 
 
 To add the `properties` object to the schema:
 
-1. Add the `properties` validation keyword to the end of the (test1)schema:
+1. Add the `properties` validation keyword to the end of the schema:
 
     ```jsonc
     ...

--- a/pages/learn/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step.md
@@ -98,33 +98,31 @@ Using the product catalog example, `productId` is a numeric value that uniquely 
 
 To add the `properties` object to the schema:
 
-1. Add the `properties` validation keyword to the end of the schema:
+1. Add the `properties` validation keyword to the end of the (test1)schema:
 
-
-```jsonc
-...
-  "title": "Product",
-  "description": "A product from Acme's catalog",
-  "type": "object",
-  "properties": {
-    "productId": {}
-  }
-```
+    ```jsonc
+    ...
+      "title": "Product",
+      "description": "A product from Acme's catalog",
+      "type": "object",
+      "properties": {
+        "productId": {}
+      }
+    ```
 
 2. Add the `productId` keyword, along with the following schema annotations:
     * `description`: describes what `productId` is. In this case, it’s the product’s unique identifier.
     * `type`: defines what kind of data is expected. For this example, since the product identifier is a numeric value, use `integer`.
 
-
-```jsonc
-...
-  "properties": {
-    "productId": {
-      "description": "The unique identifier for a product",
-      "type": "integer"
-    }
-  }
-```
+      ```jsonc
+      ...
+        "properties": {
+          "productId": {
+            "description": "The unique identifier for a product",
+            "type": "integer"
+          }
+        }
+      ```
 
 With the new `properties` validation keyword, the overall schema looks like this:
 
@@ -176,43 +174,40 @@ To define a required property:
 
 1. Inside the `properties` object, add the `price` key. Include the usual schema annotations `description` and `type`, where `type` is a number:
 
-
-```jsonc
-  "properties": {
-    ...
-    "price": {
-      "description": "The price of the product",
-      "type": "number"
-    }
-  }
+    ```jsonc
+      "properties": {
+        ...
+        "price": {
+          "description": "The price of the product",
+          "type": "number"
+        }
+      }
 ```
 
 2. Add the `exclusiveMinimum` validation keyword and set the value to zero:
 
-
-```jsonc
-  "price": {
-    "description": "The price of the product",
-    "type": "number",
-    "exclusiveMinimum": 0
-  }
-```
+    ```jsonc
+      "price": {
+        "description": "The price of the product",
+        "type": "number",
+        "exclusiveMinimum": 0
+      }
+    ```
 
 3. Add the `required` validation keyword to the end of the schema, after the `properties` object. Add `productID`, `productName`, and the new `price` key to the array:
 
-
-```jsonc
-...
-  "properties": {
+    ```jsonc
     ...
-    "price": {
-      "description": "The price of the product",
-      "type": "number",
-      "exclusiveMinimum": 0
-    },
-  },
-  "required": [ "productId", "productName", "price" ]
-```
+      "properties": {
+        ...
+        "price": {
+          "description": "The price of the product",
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+      },
+      "required": [ "productId", "productName", "price" ]
+    ```
 
 With the new `required` keyword and `price` key, the overall schema looks like this:
 
@@ -257,62 +252,58 @@ To define an optional property:
 
 1. Inside the `properties` object, add the `tags` keyword. Include the usual schema annotations `description` and `type`, and define `type` as an array:
 
- 
-```jsonc
-...
-  "properties": {
+    ```jsonc
     ...
-    "tags": {
-      "description": "Tags for the product",
-      "type": "array"
-    }
-  }
-```
+      "properties": {
+        ...
+        "tags": {
+          "description": "Tags for the product",
+          "type": "array"
+        }
+      }
+    ```
 
 2. Add a new validation keyword for `items` to define what appears in the array. For example, `string`:
 
-
-```jsonc
-...
-    "tags": {
-      "description": "Tags for the product",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    }
-```
+    ```jsonc
+    ...
+        "tags": {
+          "description": "Tags for the product",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+    ```
 
 3. To make sure there is at least one item in the array, use the `minItems` validation keyword:
 
-    
-```jsonc
-...
-    "tags": {
-      "description": "Tags for the product",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1
-    }
-```
+    ```jsonc
+    ...
+        "tags": {
+          "description": "Tags for the product",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        }
+    ```
 
 4. To make sure that every item in the array is unique, use the `uniqueItems` validation keyword and set it to `true`:
 
-    
-```jsonc
-...
-    "tags": {
-      "description": "Tags for the product",
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
-      "minItems": 1,
-      "uniqueItems": true
-    }
-```
+    ```jsonc
+    ...
+        "tags": {
+          "description": "Tags for the product",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+    ```
 
 With the new `tags` keyword, the overall schema looks like this:
 
@@ -363,68 +354,63 @@ To create a nested data structure:
 
 1. Inside the `properties` object, create a new key called `dimensions`:
 
-
-```jsonc
-...
-  "properties": {
-  ...
-    "dimensions": {}
-  }
-```
+    ```jsonc
+    ...
+      "properties": {
+      ...
+        "dimensions": {}
+      }
+    ```
 
 2. Define the `type` validation keyword as `object`:
 
-
-```jsonc
-...
-  "dimensions": {
-    "type": "object",
-  }
+    ```jsonc
+    ...
+      "dimensions": {
+        "type": "object",
+      }
 ```
 
 3. Add the `properties` validation keyword to contain the nested data structure. Inside the new `properties` keyword, add keywords for `length`, `width`, and `height` that all use the `number` type:
 
-
-```jsonc
-...
-  "dimensions": {
-    "type": "object",
-    "properties": {
-      "length": {
-        "type": "number"
-      },
-      "width": {
-        "type": "number"
-      },
-      "height": {
-        "type": "number"
+    ```jsonc
+    ...
+      "dimensions": {
+        "type": "object",
+        "properties": {
+          "length": {
+            "type": "number"
+          },
+          "width": {
+            "type": "number"
+          },
+          "height": {
+            "type": "number"
+          }
+        }
       }
-    }
-  }
 ```
 
 4. To make each of these properties required, add a `required` validation keyword inside the `dimensions` object:
    
-
-    
-```jsonc
-...
-  "dimensions": {
-    "type": "object",
-    "properties": {
-      "length": {
-        "type": "number"
-      },
-      "width": {
-        "type": "number"
-      },
-      "height": {
-        "type": "number"
-      }
-    },
-    "required": [ "length", "width", "height" ]
-}
-```
+    ```jsonc
+    ...
+      "dimensions": {
+        "type": "object",
+        "properties": {
+          "length": {
+            "type": "number"
+          },
+          "width": {
+            "type": "number"
+          },
+          "height": {
+            "type": "number"
+          }
+        },
+        "required": [ "length", "width", "height" ]
+    }
+    ```
 
 Using the new nested data structures, the overall schema looks like this:
 
@@ -515,25 +501,23 @@ To reference this schema in the product catalog schema:
 
 1. Inside the `properties` object, add a key named `warehouseLocation`:
 
-
-```jsonc
-...
-  "properties": {
-  ...
-    "warehouseLocation": {}
-  }
-```
+    ```jsonc
+    ...
+      "properties": {
+      ...
+        "warehouseLocation": {}
+      }
+    ```
 
 2. To link to the external geographical location schema, add the `$ref` schema keyword and the schema URL:
 
-
-```jsonc
-...
-  "warehouseLocation": {
-    "description": "Coordinates of the warehouse where the product is located.",
-    "$ref": "https://example.com/geographical-location.schema.json"
-  }
-```
+    ```jsonc
+    ...
+      "warehouseLocation": {
+        "description": "Coordinates of the warehouse where the product is located.",
+        "$ref": "https://example.com/geographical-location.schema.json"
+      }
+    ```
 
 With the external schema reference, the overall schema looks like this:
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes the ordered list Discrepancy observed on the [getting-started-step-by-step](https://json-schema.org/learn/getting-started-step-by-step#optional) as reported in the issue #653 

**Issue Number:**
-  Closes #653 


**Screenshots of fix**
![image](https://github.com/json-schema-org/website/assets/41142068/00ea1c3c-208a-4b21-a311-ada2d0be2d45)

![image](https://github.com/json-schema-org/website/assets/41142068/c7d07389-49a2-49e3-81ef-5a1a63dd3010)


**Summary**
It was a markdown spacing issue. Found the fix here [markdown-continue-numbered-list](https://stackoverflow.com/questions/18088955/markdown-continue-numbered-list) and applied. 

`Note` - This might need to be applied to other pages as well which has this problem.

**Does this PR introduce a breaking change?**
No

CC - @benjagm @gregsdennis  @jviotti 
