### PR TITLE
feat: add glossary term for Anchor

### DIFF
--- a/pages/learn/glossary.md
+++ b/pages/learn/glossary.md
@@ -127,9 +127,9 @@ Subschemas may themselves contain sub-subschemas, though colloquially one genera
 
 ### anchor 
 
-The `$anchor` keyword is one of the ways to identify the location of a subschema within a document. By applying an anchor, the subschema becomes identifiable via a plain-name URI string. An anchor is also a shorter alternative to using a JSON Pointer for identifying a subschema. 
+An anchor helps you to identify the location of a subschema within your JSON document. By applying an anchor to a subschema using the `$anchor` property, the subschema becomes identifiable via a plain-name URI string containing the value of the `$anchor` property starting with a `#` character. An example of a plain-name URI is `https://example.com/schemas/vehicle#owners` identifying the `owners` subschema within the `vehicle` JSON document. An anchor is also a shorter alternative to using a JSON Pointer for identifying a subschema. 
 
-
+<!-- TODO: add reference to JSON pointer term as a see more. -->
 ### tooling
 
 A JSON Schema tool (or colloquially "tooling") is any software application or library for working with or evaluating schemas in some way.

--- a/pages/learn/glossary.md
+++ b/pages/learn/glossary.md
@@ -127,7 +127,7 @@ Subschemas may themselves contain sub-subschemas, though colloquially one genera
 
 ### anchor 
 
-An anchor helps you to identify the location of a subschema within your JSON document. By applying an anchor to a subschema using the `$anchor` property, the subschema becomes identifiable via a plain-name URI string containing the value of the `$anchor` property starting with a `#` character. An example of a plain-name URI is `https://example.com/schemas/vehicle#owners` identifying the `owners` subschema within the `vehicle` JSON document. An anchor is also a shorter alternative to using a JSON Pointer for identifying a subschema. 
+An anchor identifies the location of a subschema within a JSON document. By applying an anchor to a subschema using the `$anchor` keyword, the subschema becomes identifiable via a plain-name URI string containing the value of the `$anchor` property starting with a `#` character. An example of a plain-name URI is `https://example.com/schemas/vehicle#owners` identifying the `owners` subschema within the `vehicle` JSON document. An anchor is also a shorter alternative to using a JSON Pointer for identifying a subschema. 
 
 <!-- TODO: add reference to JSON pointer term as a see more. -->
 ### tooling

--- a/pages/learn/glossary.md
+++ b/pages/learn/glossary.md
@@ -124,6 +124,12 @@ Said more plainly, whether a particular value is a subschema or not depends on i
 
 Subschemas may themselves contain sub-subschemas, though colloquially one generally uses the term "subschema" regardless of the level of nesting, further clarifying which larger schema is the parent schema whenever needed.
 
+
+### anchor 
+
+The `$anchor` keyword is one of the ways to identify the location of a subschema within a document. By applying an anchor, the subschema becomes identifiable via a plain-name URI string. An anchor is also a shorter alternative to using a JSON Pointer for identifying a subschema. 
+
+
 ### tooling
 
 A JSON Schema tool (or colloquially "tooling") is any software application or library for working with or evaluating schemas in some way.


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This pull request will add a definition for the `anchor` and `ref` terms to the glossary page as mentioned in this [comment](https://github.com/json-schema-org/website/issues/266#issuecomment-2065652423).  

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
-  Related to #266 

Depends on #677

**Screenshots/videos:**
<img width="2047" alt="Screenshot 2024-04-26 at 12 30 28" src="https://github.com/json-schema-org/website/assets/29664439/be9e9011-bd04-4b5c-8006-5c3421e6cb65">


**If relevant, did you update the documentation?**
No

**Summary**
This is a contribution to the ongoing effort to define the terms for JSON-Schema within a glossary page. 

**Does this PR introduce a breaking change?**
No