### PR TITLE
Update main.md to add new package to schema generator section

### DIFF
--- a/pages/implementations/main.md
+++ b/pages/implementations/main.md
@@ -43,6 +43,7 @@ For example, the only incompatibilities between draft-04 and draft-06 involve `e
   -   <userevent type='plausible-event-name=activation-click-tool'>[Json.NET](https://www.newtonsoft.com/jsonschema)</userevent> (AGPL-3.0) - generates schemas from .NET types
   -   <userevent type='plausible-event-name=activation-click-tool'>[NJsonSchema](https://github.com/RSuter/NJsonSchema/)</userevent> - (Ms-PL) - generates schemas from .NET types, see issue [574](https://github.com/RSuter/NJsonSchema/issues/574) for draft-06+ support progress
   -   <userevent type='plausible-event-name=activation-click-tool'>[JsonSchema.Net.Generation](https://github.com/gregsdennis/json-everything)</userevent> (MIT) - generates schemas from .NET types
+  -   <userevent type='plausible-event-name=activation-click-tool'>[LateApexEarlySpeed.Json.Schema](https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema)</userevent> (BSD-3-Clause) - generates schemas from fluent builders & .NET types
 -   Go
   -   <userevent type='plausible-event-name=activation-click-tool'>[jsonschema](https://github.com/invopop/jsonschema)</userevent> - (MIT) - generate schemas from Go structs. Supports Draft 2020-12.
 -   PHP

--- a/pages/implementations/main.md
+++ b/pages/implementations/main.md
@@ -43,7 +43,7 @@ For example, the only incompatibilities between draft-04 and draft-06 involve `e
   -   <userevent type='plausible-event-name=activation-click-tool'>[Json.NET](https://www.newtonsoft.com/jsonschema)</userevent> (AGPL-3.0) - generates schemas from .NET types
   -   <userevent type='plausible-event-name=activation-click-tool'>[NJsonSchema](https://github.com/RSuter/NJsonSchema/)</userevent> - (Ms-PL) - generates schemas from .NET types, see issue [574](https://github.com/RSuter/NJsonSchema/issues/574) for draft-06+ support progress
   -   <userevent type='plausible-event-name=activation-click-tool'>[JsonSchema.Net.Generation](https://github.com/gregsdennis/json-everything)</userevent> (MIT) - generates schemas from .NET types
-  -   <userevent type='plausible-event-name=activation-click-tool'>[LateApexEarlySpeed.Json.Schema](https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema)</userevent> (BSD-3-Clause) - generates schemas from fluent builders & .NET types
+  -   <userevent type='plausible-event-name=activation-click-tool'>[LateApexEarlySpeed.Json.Schema](https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema)</userevent> (BSD-3-Clause) - generates schemas (draft 2020.12) from fluent builders & .NET types
 -   Go
   -   <userevent type='plausible-event-name=activation-click-tool'>[jsonschema](https://github.com/invopop/jsonschema)</userevent> - (MIT) - generate schemas from Go structs. Supports Draft 2020-12.
 -   PHP


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Hi, recently .NET implementation 'Lateapexearlyspeed.Json.Schema' can also support output standard JSON schema based on functionalities of fluent builder pattern and generator from .net types, so not sure if it is possible to add it to 'Schema generator' page section ? thanks !