### PR TITLE
sagold/json-schema-library supports Draft 2019

### DIFF
--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -257,7 +257,7 @@
       url: https://github.com/sagold/json-schema-library
       notes: "Built for Node.js and browsers. Customizable json-validator and json-schema utilities for traversal, data generation and validation"
       date-draft: []
-      draft: [7, 6, 4]
+      draft: [2019-09, 7, 6, 4]
       license: MIT
       last-updated: "2022-08-31"
     - name: djv


### PR DESCRIPTION
sagold/json-schema-library supports Draft 2019, with some [minor caveats](https://github.com/sagold/json-schema-library/blob/773ace88126ba70203c1ed98c2697855de41d9a2/README.md?plain=1#L45-L49)

Updated docs to reflect this.