### PR TITLE
fix: updated icon `alt`s

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -373,7 +373,7 @@ export const DocsNav = ({
           onClick={handleClickGet}
         >
           <div className='flex  items-center align-middle'>
-            <img src={`${learn_icon}`} alt='eye icon' className='mr-2' />
+            <img src={`${learn_icon}`} alt='compass icon' className='mr-2' />
             <SegmentHeadline label='Getting Started' />
           </div>
           <svg
@@ -434,7 +434,7 @@ export const DocsNav = ({
           onClick={handleClickReference}
         >
           <div className='flex  items-center align-middle'>
-            <img src={`${reference_icon}`} alt='eye icon' className='mr-2' />
+            <img src={`${reference_icon}`} alt='book icon' className='mr-2' />
             <SegmentHeadline label='Reference' />
           </div>
           <svg
@@ -617,7 +617,7 @@ export const DocsNav = ({
           onClick={handleClickSpec}
         >
           <div className='flex  items-center align-middle'>
-            <img src={`${spec_icon}`} alt='eye icon' className='mr-2' />
+            <img src={`${spec_icon}`} alt='clipboard icon' className='mr-2' />
             <SegmentHeadline label='Specification' />
           </div>
           <svg


### PR DESCRIPTION


<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Update the alt text of icons so that the page is more accessible

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
I don't think there is any


**Screenshots/videos:**
This is how the page looks like if you disable JS in the browser.
![image](https://github.com/json-schema-org/website/assets/113300767/1feede62-d6d3-4b37-b20c-e7f3cab0f5d2)


<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
I don't think it is relevant.

<!--Add link to it-->

**Summary**

Somehow all icons had an `alt` text of `eye icon` even if they were different icons.


<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
no.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
