### PR TITLE
[components][DocsHelp.tsx]: Fix "Edit this page on Github" fails when the URL contains a fragment

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import React, { FormEvent, useRef, useState } from 'react';
+import extractPathWithoutFragment from '~/lib/extractPathWithoutFragment';
 
 interface DocsHelpProps {
   markdownFile?: string;
@@ -275,7 +276,7 @@ export function DocsHelp({ markdownFile }: DocsHelpProps) {
               target='_blank'
               rel='noreferrer'
               className='px-[16px] py-[8px] cursor-pointer border-solid border-[#aaaaaa] border rounded-md hover:bg-gray-200 dark:hover:bg-gray-600'
-              href={`https://github.com/json-schema-org/website/blob/main/pages${markdownFile ? (markdownFile === '_indexPage' ? router.asPath + '/_index.md' : router.asPath + '.md') : `/${path}/index.page.tsx`}`}
+              href={`https://github.com/json-schema-org/website/blob/main/pages${markdownFile ? (markdownFile === '_indexPage' ? extractPathWithoutFragment(router.asPath) + '/_index.md' : extractPathWithoutFragment(router.asPath) + '.md') : `/${path}/index.page.tsx`}`}
             >
               <svg
                 className='inline-block select-none align-text-bottom mr-1'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR aims to fix the unintentional behaviour of `Edit this page on Github` button inside `DocsHelp` component which directs the user to invalid file when the URL contains a hash fragment. This is achieved by utilising the existing `extractPathWithoutFragment` method in the `lib` directory which performs its function as suggested by name, to extract path after removing the fragment before its passed on to the link generator.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #725  <!-- Replace ___ with the issue number this PR resolves -->

**Does this PR introduce a breaking change?**
No
