### PR TITLE
Update Json.NET Schema to support 2020-12

### DIFF
--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -9,10 +9,10 @@
       last-updated: "2022-08-31"
     - name: Json.NET Schema
       url: https://www.newtonsoft.com/jsonschema
-      date-draft: [2019-09]
+      date-draft: [2020-12, 2019-09]
       draft: [7, 6, 4, 3]
       license: "AGPL-3.0-only"
-      last-updated: "2022-08-31"
+      last-updated: "2024-06-08"
     - name: Corvus.JsonSchema
       url: https://github.com/corvus-dotnet/corvus.jsonschema
       date-draft: [2020-12, 2019-09]


### PR DESCRIPTION
Follow up to https://github.com/json-schema-org/website/pull/715 now that it's publically released.