### PR TITLE
Add JSON Toolkit as a C++ implementation

### DIFF
--- a/data/validator-libraries-modern.yml
+++ b/data/validator-libraries-modern.yml
@@ -53,6 +53,12 @@
       draft: [7, 6, 4]
       license: Boost Software License 1.0
       last-updated: "2024-04-22"
+    - name: JSON Toolkit
+      url: https://github.com/sourcemeta/jsontoolkit
+      notes: Comes with its own JSON parser
+      draft: [7, 6, 4]
+      license: AGPL-3.0 and commercial
+      last-updated: "2024-06-13"
 - name: Clojure
   implementations:
     - name: jinx


### PR DESCRIPTION
Also getting into Bowtie just now: https://github.com/bowtie-json-schema/bowtie/pull/1293. It supports Draft 4, 6, and 7, and I'm actively working on the rest (including older ones).