### PR TITLE
Fix: Removing warnnings from console

### DIFF
--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -489,7 +489,7 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
                 );
               },
             },
-            TableOfContent: {
+            tableofcontent: {
               component: ({ depth }) => {
                 // eslint-disable-next-line react-hooks/rules-of-hooks
                 const fullMarkdown = useContext(FullMarkdownContext);

--- a/pages/learn/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step.md
@@ -7,7 +7,7 @@ JSON Schema is a vocabulary that you can use to annotate and validate JSON docum
 
 After you create the JSON Schema document, you can validate the example data against your schema using a validator in a language of your choice. See <userevent type='plausible-event-name=activation-explore-tools'>[Tools](https://json-schema.org/implementations)</userevent> for a current list of supported validators.
 
-<TableOfContent depth={2} />
+<tableofcontent depth={2} />
 
 <span id="overview"></span>
 

--- a/pages/md-style-guide.md
+++ b/pages/md-style-guide.md
@@ -151,7 +151,7 @@ Danger is a special type of info box in which text showing any danger can be sho
 Table of Contents provides a structured overview of the main sections or chapters within the current page/document.
 
 ```markdown
-<TableOfContent content={content} depth={depth} />
+<tableofcontent content={content} depth={depth} />
 ```
 
 ---

--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -7,7 +7,7 @@ section: docs
 
 You can find the latest released draft on the [Specification](../../specification) page.  The complex numbering and naming system for drafts and meta-schemas is fully explained here as well.
 
-<TableOfContent depth={4} />
+<tableofcontent depth={4} />
 
 ## Understanding draft names and numbers
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Removing warnings from Dev console 

**Issue Number:**

-  Closes #760 

**Screenshots/videos:**

Warnings before change 
![Screenshot from 2024-06-17 09-01-21](https://github.com/json-schema-org/website/assets/124715224/d0c4225a-ead7-423e-a52c-2acca85e196d)



**Summary**
Warnings from dev console is removed. 
