### PR TITLE
Fix Typo in Environment Variables Setup Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git submodule init
 git submodule update
 ```
 
-### Setup Enviroment Variables 
+### Setup Environment Variables 
 
 1. Create a new `.env` file by copying the contents of the `.env.example` into `.env` file. Use this command:
 ```


### PR DESCRIPTION
closes #866 

This pull request corrects a minor typo in the documentation for setting up environment variables. The term "Enviroment" has been corrected to "Environment" for clarity and accuracy. This fix ensures that the documentation is clear and professional.