### PR TITLE
Update stale-issues-prs.yml to increase the number of days to mark an issue as stale from 30 to 180

### DIFF
--- a/.github/workflows/stale-issues-prs.yml
+++ b/.github/workflows/stale-issues-prs.yml
@@ -55,7 +55,7 @@ jobs:
         stale-pr-label: 'Status: Stale'
         
         # Number of days of inactivity before an issue/PR is marked as stale.
-        days-before-stale: 30
+        days-before-stale: 180
        
         # Number of days of inactivity before an issue/PR is closed.
         days-before-close: 180


### PR DESCRIPTION
**Summary**

This PR updates stale-issues-prs.yml to increase the number of days to mark an issue as stale from 30 to 180. The reason is the development speed is much slower so we need more range for such and operation.
