### PR TITLE
docs(implementations): added Schema generator dadav/helm-schema

### DIFF
--- a/pages/implementations/main.md
+++ b/pages/implementations/main.md
@@ -77,6 +77,8 @@ For example, the only incompatibilities between draft-04 and draft-06 involve `e
   -   <userevent type='plausible-event-name=activation-click-tool'>[jsonschema.net](https://www.jsonschema.net/)</userevent> - generates schemas from example data
   -   <userevent type='plausible-event-name=activation-click-tool'>[Liquid Online Tools](https://www.liquid-technologies.com/online-json-to-schema-converter)</userevent> - infer JSON Schema from sample JSON data
   -   <userevent type='plausible-event-name=activation-click-tool'>[quicktype.io](https://app.quicktype.io/#l=schema)</userevent> - infer JSON Schema from samples, and generate TypeScript, C++, go, Java, C#, Swift, etc. types from JSON Schema
+-   Helm
+  -   <userevent type='plausible-event-name=activation-click-tool'>[dadav/helm-schema](https://github.com/dadav/helm-schema)</userevent> (MIT) - generate _values.schema.json_ from Helm _values.yaml_; compatible with [helm-docs](https://github.com/norwoodj/helm-docs) comments
 
 ### From model
 


### PR DESCRIPTION
This merge request adds [dadav/helm-schema](https://github.com/dadav/helm-schema) as a _Schema generator - From data_.

After finding [helm-docs](https://github.com/norwoodj/helm-docs) for creating human readable tables of Helm `values.yaml` files in Markdown or HTML tables, I was looking for a similiarily intuitive tool to do the same for rendering JSON schema; but most had custom syntax, requiring to duplicate the `description` for each property.

@dadav [helm-schema](https://github.com/dadav/helm-schema) does exactly that, integrating with already present _helm-docs_ comments, while being able to specify additional schema related properties for automatically creating `values.schema.json` from `values.yaml`.

