### PR TITLE
[DocsHelp]: add DocsHelp Feedback to Google Sheets

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -23,7 +23,7 @@ export function DocsHelp({ markdownFile }: DocsHelpProps) {
 
     try {
       const response = await fetch(
-        'https://script.google.com/macros/s/AKfycby8c_NEFS5SLT4ibv5DuCE2BYzcxfFuAuqY8bX_Q5eEF9_hHW0p3nYP7ugmlL17KD4/exec',
+        'https://script.google.com/macros/s/AKfycbx9KA_BwTdsYgOfTLrHAxuhHs_wgYibB5_Msj9XP1rL5Ip4A20g1O609xAuTZmnbhRv/exec',
         {
           redirect: 'follow',
           method: 'POST',

--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -18,15 +18,23 @@ export function DocsHelp({ markdownFile }: DocsHelpProps) {
   async function createFeedbackHandler(event: FormEvent) {
     event.preventDefault();
     const formData = new FormData(feedbackFormRef.current!);
-    formData.append('page', router.asPath);
+    formData.append('feedback-page', router.asPath);
     setIsSubmitting(true);
 
     try {
       const response = await fetch(
-        'https://feedback-collector.json-schema.workers.dev/submit',
+        'https://script.google.com/macros/s/AKfycby8c_NEFS5SLT4ibv5DuCE2BYzcxfFuAuqY8bX_Q5eEF9_hHW0p3nYP7ugmlL17KD4/exec',
         {
+          redirect: 'follow',
           method: 'POST',
-          body: formData,
+          headers: {
+            'Content-Type': 'text/plain;charset=utf-8',
+          },
+          body: JSON.stringify({
+            feedbackPage: formData.get('feedback-page'),
+            feedbackVote: formData.get('feedback-vote'),
+            feedbackComment: formData.get('feedback-comment'),
+          }),
         },
       );
 

--- a/cypress/components/DocsHelp.cy.tsx
+++ b/cypress/components/DocsHelp.cy.tsx
@@ -110,14 +110,14 @@ describe('DocsHelp Component', () => {
     // mocking the feedback api call
     cy.intercept(
       'POST',
-      'https://feedback-collector.json-schema.workers.dev/submit',
+      'https://script.google.com/macros/s/AKfycbx9KA_BwTdsYgOfTLrHAxuhHs_wgYibB5_Msj9XP1rL5Ip4A20g1O609xAuTZmnbhRv/exec',
       {
         statusCode: 200,
         body: { success: true },
       },
     ).as('feedback');
 
-    /* click on yes button and check if feedback form is visible 
+    /* click on yes button and check if feedback form is visible
        Note: checking both yes and no button to cover both scenarios */
     cy.get(FEEDBACK_FORM_YES_BUTTON).click();
     cy.get(FEEDBACK_FORM_NO_BUTTON).click();
@@ -142,7 +142,7 @@ describe('DocsHelp Component', () => {
     // check if clicking on yes button should show feedback form
     cy.intercept(
       'POST',
-      'https://feedback-collector.json-schema.workers.dev/submit',
+      'https://script.google.com/macros/s/AKfycbx9KA_BwTdsYgOfTLrHAxuhHs_wgYibB5_Msj9XP1rL5Ip4A20g1O609xAuTZmnbhRv/exec',
       {
         statusCode: 500,
         body: { error: 'Internal Server Error' },
@@ -172,7 +172,7 @@ describe('DocsHelp Component', () => {
     // check if clicking on yes button should show feedback form
     cy.intercept(
       'POST',
-      'https://feedback-collector.json-schema.workers.dev/submit',
+      'https://script.google.com/macros/s/AKfycbx9KA_BwTdsYgOfTLrHAxuhHs_wgYibB5_Msj9XP1rL5Ip4A20g1O609xAuTZmnbhRv/exec',
       {
         forceNetworkError: true,
       },


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR aims to update the DocsHelp Feedback component to use Google Sheets for feedback.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Closes #882 


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
