### PR TITLE
[tools]: Add DocsHelp feedback and modal Bowtie detailed report outlink

### DIFF
--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -9,6 +9,7 @@ import type {
   JSONSchemaTool,
 } from '../JSONSchemaTool';
 import toTitleCase from '../lib/toTitleCase';
+import Link from 'next/link';
 
 export default function ToolingDetailModal({
   tool,
@@ -276,6 +277,13 @@ export default function ToolingDetailModal({
                       )}
                     </div>
                   )}
+                  <Link
+                    className='text-[14px] underline italic'
+                    href={`https://bowtie.report/#/implementations/${tool.bowtie?.identifier}`}
+                    target='_blank'
+                  >
+                    View detailed report
+                  </Link>
                 </div>
               )
             )}

--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import yaml from 'js-yaml';
 
 import { SectionContext } from '~/context';
+import { DocsHelp } from '~/components/DocsHelp';
 import { Headline1 } from '~/components/Headlines';
 import { getLayout } from '~/components/SiteLayout';
 import { DRAFT_ORDER } from '~/lib/config';
@@ -204,6 +205,8 @@ export default function ToolingPage({
               transform={transform}
               setTransform={setTransform}
             />
+
+            <DocsHelp />
           </main>
         </div>
       </div>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR aims to add DocsHelp feedback form to the new tooling page and add Bowtie detailed report outlink to the Tooling Modal view.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #___ <!-- Replace ___ with the issue number this PR resolves -->
-  Related to #___ <!-- Use when the PR doesn't completely resolve an issue -->
-  Others? <!-- Add any additional notes or references here -->


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
