### PR TITLE
fix: modify the new-implementation.yml to trigger workflow on first PR

### DIFF
--- a/.github/workflows/new-implementation.yml
+++ b/.github/workflows/new-implementation.yml
@@ -23,12 +23,22 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: process.env.NEW_TOOL_MESSAGE,
-            })
+              state: 'all'
+            });
+
+            const userPRs = pullRequests.filter(pr => pr.user.login === context.actor);
+
+            if (userPRs.length === 0) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: process.env.NEW_TOOL_MESSAGE,
+              })
+            }
         env:
           NEW_TOOL_MESSAGE: |
             Hey there 👋!


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Closes https://github.com/json-schema-org/website/issues/755
Screenshots/videos:

**If relevant, did you update the documentation?**

No

**Summary**
This adds an additional condition to the existing check to trigger the action for first time contributors only for th path "data/tooling-data.yml"

Does this PR introduce a breaking change?

No