### PR TITLE
[tooling-data]: add @cfworker/json-schema bowtie identifer

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -523,6 +523,8 @@
     draft: ['7', '4', '2019-09', '2020-12']
   toolingListingNotes: 'Built for Cloudflare workers, browsers, and Node.js'
   lastUpdated: '2023-02-28'
+  bowtie:
+    identifier: 'js-json-schema'
 
 - name: JSON Schema Library
   description: 'Customizable and hackable json-validator and json-schema utilities for traversal, data generation and validation'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR aims to add the missing bowtie identifier for `@cfworker/json-schema` to fix the unavailable outlink to bowtie on the `/tools` page.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Closes: #976 

**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
