### PR TITLE
[Fix] Recall and re-render images in mobile

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -103,14 +103,10 @@ export default function Layout({
               <MainNavigation />
             </div>
           </header>
-          {showMobileNav ? (
-            <div ref={mobileNavRef}>
-              <MobileNav />
-              {children}
-            </div>
-          ) : (
-            <div>{children}</div>
-          )}
+          <div ref={mobileNavRef}>
+            {showMobileNav && <MobileNav />}
+            {children}
+          </div>
           <ScrollButton />
           <Footer />
         </main>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

-  Closes #994

**Screenshots/videos:**

https://github.com/user-attachments/assets/4399559d-05a8-4a0d-8c7e-fc90e69ce834

**If relevant, did you update the documentation?**

No relevant

**Summary**

The error is due to re-rendering the children prop in a ternary operator

**Does this PR introduce a breaking change?**

No
