### PR TITLE
Fix hyperschema links again

### DIFF
--- a/pages/specification/json-hyper-schema/_index.md
+++ b/pages/specification/json-hyper-schema/_index.md
@@ -15,15 +15,15 @@ In essence:
 
 ### Hyper Schema Specification
 
-- Hyper-Schema: [draft-handrews-json-schema-hyperschema-02](/draft/2019-09/draft-handrews-json-schema-hyperschema-02.html)
+- Hyper-Schema: [draft-handrews-json-schema-hyperschema-02](../draft/2019-09/json-schema-hypermedia.html)
 - Relative JSON Pointer: [draft-bhutton-relative-json-pointer-00](https://datatracker.ietf.org/doc/html/draft-bhutton-relative-json-pointer-00.html)
 
 **Schemas:**
 
-- [JSON Hyper-Schema meta-schema](/draft/2020-12/hyper-schema)
-- [JSON Hyper-Schema vocabulary schema](/draft/2020-12/meta/hyper-schema)
-- [JSON Hyper-Schema Link Description Object meta-schema](/draft/2020-12/links)
-- [JSON Schema Output schemas and examples](/draft/2019-09/output/hyper-schema)
+- [JSON Hyper-Schema meta-schema](../draft/2020-12/hyper-schema)
+- [JSON Hyper-Schema vocabulary schema](../draft/2020-12/meta/hyper-schema)
+- [JSON Hyper-Schema Link Description Object meta-schema](../draft/2020-12/links)
+- [JSON Schema Output schemas and examples](../draft/2019-09/output/hyper-schema)
 
 ### Release Notes
 


### PR DESCRIPTION
This fixes the problem with the links I mentioned in https://github.com/json-schema-org/website/pull/998#issuecomment-2392505313. I figured out that it works when the links use `..`. These links should be equivalent indicating that something is wrong with the way the way the website is setup or a bug in Next.js. This works around the problem, but doesn't fix the underlying issue. It will bite us again if not addressed in the future.