### PR TITLE
Fixed 404 Error On Main Docs Page

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -301,7 +301,7 @@ export function DocsHelp({ markdownFile }: DocsHelpProps) {
               target='_blank'
               rel='noreferrer'
               className='px-[16px] py-[8px] cursor-pointer border-solid border-[#aaaaaa] border rounded-md hover:bg-gray-200 dark:hover:bg-gray-600'
-              href={`https://github.com/json-schema-org/website/blob/main/pages${markdownFile ? (markdownFile === '_indexPage' ? extractPathWithoutFragment(router.asPath) + '/_index.md' : extractPathWithoutFragment(router.asPath) + '.md') : `/${path}/index.page.tsx`}`}
+              href={`https://github.com/json-schema-org/website/blob/main/pages${markdownFile ? (markdownFile === '_indexPage' ? extractPathWithoutFragment(router.asPath) + '/index.page.tsx' : extractPathWithoutFragment(router.asPath) + '.md') : `/${path}/index.page.tsx`}`}
               data-test='edit-on-github-link'
             >
               <svg


### PR DESCRIPTION
# Fix: 404 Error On Docs Home Page Contribute Button

Impacted URL: https://json-schema.org/docs

**Issue Number:**
-  Closes #1012 

Just some proposed changes to fix the issue

**Summary**
- Changed url for contribute on github button from https://github.com/json-schema-org/website/blob/main/pages/docs/_index.md (404) to https://github.com/json-schema-org/website/blob/main/pages/docs/index.page.tsx (200)

**Does this PR introduce a breaking change?** No
