### PR TITLE
Rename JSON Toolkit to Blaze

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1483,8 +1483,23 @@
   lastUpdated: '2024-05-31'
 
 - name: JSON Toolkit
-  description: 'JSON Toolkit is a swiss-army knife library for expressive JSON programming in modern C++'
-  toolingTypes: ['validator', 'util-general-processing']
+  description: 'JSON Toolkit is a swiss-army knife library for expressive JSON programming in modern C++, and it comes with various JSON Schema foundational utilities, like bundling, analyzing references, and more'
+  toolingTypes: ['util-general-processing']
+  languages: ['C++']
+  maintainers:
+    - name: 'Juan Cruz Viotti'
+      username: 'jviotti'
+      platform: 'github'
+  license: 'AGPL-3.0 and Commercial'
+  source: 'https://github.com/sourcemeta/jsontoolkit'
+  supportedDialects:
+    draft: ['0', '1', '2', '3', '4', '6', '7', '2019-09', '2020-12']
+  toolingListingNotes: 'Comes with its own JSON parser'
+  lastUpdated: '2024-10-15'
+
+- name: Blaze
+  description: 'Blaze is an ultra high-performance JSON Schema validator built on the JSON Toolkit library'
+  toolingTypes: ['validator']
   languages: ['C++']
   maintainers:
     - name: 'Juan Cruz Viotti'
@@ -1494,7 +1509,6 @@
   source: 'https://github.com/sourcemeta/blaze'
   supportedDialects:
     draft: ['4', '6', '7', '2019-09', '2020-12']
-  toolingListingNotes: 'Comes with its own JSON parser'
   lastUpdated: '2024-10-15'
   bowtie:
     identifier: 'cpp-blaze'

--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1109,7 +1109,7 @@
       'bundler',
     ]
   environments: ['Command Line']
-  dependsOnValidators: ['https://github.com/sourcemeta/jsontoolkit']
+  dependsOnValidators: ['https://github.com/sourcemeta/blaze']
   maintainers:
     - name: 'Juan Cruz Viotti'
       username: 'jviotti'
@@ -1491,13 +1491,13 @@
       username: 'jviotti'
       platform: 'github'
   license: 'AGPL-3.0 and Commercial'
-  source: 'https://github.com/sourcemeta/jsontoolkit'
+  source: 'https://github.com/sourcemeta/blaze'
   supportedDialects:
     draft: ['4', '6', '7', '2019-09', '2020-12']
   toolingListingNotes: 'Comes with its own JSON parser'
-  lastUpdated: '2024-06-13'
+  lastUpdated: '2024-10-15'
   bowtie:
-    identifier: 'cpp-jsontoolkit'
+    identifier: 'cpp-blaze'
 
 - name: cypress-ajv-schema-validator
   description: 'Cypress plugin that validates API responses against Plain JSON schemas, and whole Swagger and OpenAPI documents using the Ajv JSON Schema validator. It provides a user-friendly view of validated data, highlighting each validation error and the exact reason for the mismatch. Seamless integration, fast and lightweight.'


### PR DESCRIPTION
We extracted the JSON Schema validator out of the JSON Toolkit project into a project of its own, called "Blaze", which depends on JSON Toolkit.

Also see https://github.com/bowtie-json-schema/bowtie/pull/1593