### PR TITLE
fix broken link (#1032)

### DIFF
--- a/pages/learn/glossary.md
+++ b/pages/learn/glossary.md
@@ -143,7 +143,7 @@ Applications which use JSON Schema internally without exposing that functionalit
 
 ### validation result
 
-The [validation result](../blog/posts/get-started-with-json-schema-in-node-js.md#creating-a-schema-and-validating-data) in the context of JSON Schema refers to the outcome of applying the entire JSON Schema to the entire instance document. This outcome can encompass more than just a boolean assertion and may include various output formats, such as error messages, error codes, or detailed validation reports. It signifies whether the instance document adheres to the rules and constraints specified in the schema. The validation result signifies whether the instance document passes or fails validation against the [schema](#schema).
+The [validation result](../blog/posts/get-started-with-json-schema-in-node-js#creating-a-schema-and-validating-data) in the context of JSON Schema refers to the outcome of applying the entire JSON Schema to the entire instance document. This outcome can encompass more than just a boolean assertion and may include various output formats, such as error messages, error codes, or detailed validation reports. It signifies whether the instance document adheres to the rules and constraints specified in the schema. The validation result signifies whether the instance document passes or fails validation against the [schema](#schema).
 
 ### vocabulary
 


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

- bugfix:when we are at the https://json-schema.org/learn/glossary#validation-result and click the validation result link it shows 404 error because the link is incorrect as it is not redirecting that page .Now the link is working correctly

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1032



 <!-- Replace ___ with the issue number this PR resolves -->



**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->
https://github.com/user-attachments/assets/f4ee09bc-2d0f-4325-9f54-09302d67a90f

**If relevant, did you update the documentation?**
No

<!--Add link to it-->


<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
