### PR TITLE
Update calendar url after changing Google Account

### DIFF
--- a/pages/community/index.page.tsx
+++ b/pages/community/index.page.tsx
@@ -49,7 +49,7 @@ export const getStaticProps: GetStaticProps = async () => {
     }
   }
   const remoteICalUrl =
-    'https://calendar.google.com/calendar/ical/info%40json-schema.org/public/basic.ics';
+    'https://calendar.google.com/calendar/ical/json.schema.community%40gmail.com/public/basic.ics';
   const datesInfo = await fetchRemoteICalFile(remoteICalUrl)
     .then((icalData: any) =>
       printEventsForNextFourWeeks(ical.parseICS(icalData)),

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -61,7 +61,7 @@ export const getStaticProps: GetStaticProps = async () => {
   }
   // Example usage:
   const remoteICalUrl =
-    'https://calendar.google.com/calendar/ical/info%40json-schema.org/public/basic.ics'; // Replace with the actual URL
+    'https://calendar.google.com/calendar/ical/json.schema.community%40gmail.com/public/basic.ics'; // Replace with the actual URL
   const datesInfo = await fetchRemoteICalFile(remoteICalUrl)
     .then((icalData: any) =>
       printEventsForNextFourWeeks(ical.parseICS(icalData)),
@@ -547,7 +547,7 @@ const Home = (props: any) => {
                 </div>
 
                 <a
-                  href='https://calendar.google.com/calendar/embed?src=info%40json-schema.org&ctz=Europe%2FLondon'
+                  href='https://calendar.google.com/calendar/embed?src=json.schema.community%40gmail.com&ctz=Europe%2FLondon'
                   className='w-full lg:w-1/2 rounded border-2 bg-primary text-white hover:bg-blue-700 transition-all duration-300 ease-in-out h-[40px] text-center flex items-center justify-center mx-auto dark:border-none'
                   target='_blank'
                   rel='noopener noreferrer'


### PR DESCRIPTION
**Summary**

After upgrading the Google account, the previous calendar became private. We need to update the url.