### PR TITLE
Fix: maxProperties Keyword Not Found in Documentation

### DIFF
--- a/data/keywords.yml
+++ b/data/keywords.yml
@@ -280,6 +280,16 @@
       title: Range
     - url: 'https://json-schema.org/draft/2020-12/json-schema-validation#name-maximum'
       title: Draft 2020-12
+- name: maxProperties
+  vocabulary: [Validation]
+  learnjsonschemalink: 'https://www.learnjsonschema.com/2020-12/validation/maxproperties'
+  links:
+    - url: 'https://json-schema.org/understanding-json-schema/reference/object#size'
+      title: Size
+    - url: 'https://json-schema.org/draft/2020-12/json-schema-validation#name-maxproperties'
+      title: maxProperties
+    - url: 'https://json-schema.org/draft/2020-12/json-schema-validation#name-maxproperties'
+      title: Draft 2020-12
 - name: minitems
   vocabulary: [Validation]
   learnjsonschemalink: 'https://www.learnjsonschema.com/2020-12/validation/minitems'


### PR DESCRIPTION
**What kind of change does this PR introduce?**
add some code for maxProperties keywords 


**Issue Number:**
Issue #1052 
close #1052 


**Screenshots/videos:**
![Screenshot 2024-10-22 154335](https://github.com/user-attachments/assets/9c0d7486-28fb-4d0e-8c4a-76738d819878)


