### PR TITLE
Add first-come, first-served policy to claiming issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,9 +117,11 @@ Most PRs, will be left open for a minimum of 14 days.  Minor fixes may be merged
 
 Contributors to our Docs or our Blog can have a look at the [custom markdown style guide](https://json-schema.org/md-style-guide) with a list of useful markdown tags providing tools to easily create cool content that provides a better user experience.
 
-## Triage
+## Triage and claiming an issue
 
-Please check the [triage process](https://github.com/json-schema-org/.github/blob/main/TRIAGE.md) to learn how we review and label incoming issues . 
+Please check the [triage process](https://github.com/json-schema-org/.github/blob/main/TRIAGE.md) to learn how we review and label incoming issues. 
+
+To claim an issue, leave a comment in the conversation thread for a project maintainer to review your request. You can begin working on the changes after you have been assigned to the issue. The JSON Schema project follows a first-come, first-served policy for issue claims, ensuring that issues are addressed in the order they are claimed.
 
 ## Feedback
 


### PR DESCRIPTION
Add a first-come, first-served policy to claiming issues


<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
To ensure fairness and prevent unnecessary work, implement a first-come, first-served policy for claiming issues.

Contributors are requested to leave a comment expressing their interest in an issue.
A project maintainer will then review the issue and assign it to the contributor.
Work on the issue should only commence after receiving this assignment.

This policy helps us effectively triage issues and ensures that contributors' efforts are directed toward the most appropriate tasks.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #___ <!-- Replace ___ with the issue number this PR resolves -->
-  Related to #___ <!-- Use when the PR doesn't completely resolve an issue -->
-  Others? <!-- Add any additional notes or references here -->


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?** No 

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
