### PR TITLE
docs: add note clarifying multipleOf implementation

### DIFF
--- a/pages/understanding-json-schema/reference/numeric.md
+++ b/pages/understanding-json-schema/reference/numeric.md
@@ -162,7 +162,7 @@ The multiple can be a floating point number:
 4.021
 ```
 
-<Infobox label="Note"> The JSON Specification allows an arbitrary implementation of the `multipleOf` keyword and is not constrained by the floating-point behavior of most programming languages. In contrast, most programming languages adhere to the IEEE754 standard for floating-point numbers, which can result in discrepancies between validation according to the JSON Specification and the behavior in programming languages. </Infobox>
+<Infobox label="Note"> The JSON Schema Specification defines numerical precision independently of the IEEE 754 standard. This means developers do not need to worry about the typical limitations of floating-point arithmetic, such as precision loss or representation errors, which are common in most programming languages. </Infobox>
 
 <Keywords label="single: number; range single: maximum single: exclusiveMaximum single: minimum single: exclusiveMinimum" />
 

--- a/pages/understanding-json-schema/reference/numeric.md
+++ b/pages/understanding-json-schema/reference/numeric.md
@@ -162,7 +162,7 @@ The multiple can be a floating point number:
 4.021
 ```
 
-<Infobox label="Note"> The JSON Schema Specification defines numerical precision independently of the IEEE 754 standard. This means developers do not need to worry about the typical limitations of floating-point arithmetic, such as precision loss or representation errors, which are common in most programming languages. </Infobox>
+<Infobox label="Note"> The JSON Specification defines numerical precision independently of the IEEE 754 standard. This means developers do not need to worry about the typical limitations of floating-point arithmetic, such as precision loss or representation errors, which are common in most programming languages. </Infobox>
 
 <Keywords label="single: number; range single: maximum single: exclusiveMaximum single: minimum single: exclusiveMinimum" />
 

--- a/pages/understanding-json-schema/reference/numeric.md
+++ b/pages/understanding-json-schema/reference/numeric.md
@@ -162,6 +162,7 @@ The multiple can be a floating point number:
 4.021
 ```
 
+<Infobox label="Note"> The JSON Specification allows an arbitrary implementation of the `multipleOf` keyword and is not constrained by the floating-point behavior of most programming languages. In contrast, most programming languages adhere to the IEEE754 standard for floating-point numbers, which can result in discrepancies between validation according to the JSON Specification and the behavior in programming languages. </Infobox>
 
 <Keywords label="single: number; range single: maximum single: exclusiveMaximum single: minimum single: exclusiveMinimum" />
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation update

**Issue Number:**

-  Closes #1113 


**Screenshots/videos:**

![image](https://github.com/user-attachments/assets/edf30ec4-5fda-423b-8f63-ec739fe63c9b)


**Summary**

Add a note explaining the difference between float-point implementation of programming languages and json schema

**Does this PR introduce a breaking change?**

No, it does not.

**Other**

I believe this note can be clearer, better if I also provide an example, not sure about it though. Please let me know about it.