### PR TITLE
Added navigation buttons in other sections of website

### DIFF
--- a/pages/[slug].page.tsx
+++ b/pages/[slug].page.tsx
@@ -7,6 +7,7 @@ import getStaticMarkdownProps from '~/lib/getStaticMarkdownProps';
 import { Headline1 } from '~/components/Headlines';
 import { SectionContext } from '~/context';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticPaths() {
   return getStaticMarkdownPaths('pages');
@@ -31,6 +32,12 @@ export default function StaticMarkdownPage({
       </Head>
       <Headline1>{frontmatter.title}</Headline1>
       <StyledMarkdown markdown={content} />
+      <NextPrevButton
+        prevLabel={frontmatter?.prev?.label}
+        prevURL={frontmatter?.prev?.url}
+        nextLabel={frontmatter?.next?.label}
+        nextURL={frontmatter?.next?.url}
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/implementers/[slug].page.tsx
+++ b/pages/implementers/[slug].page.tsx
@@ -7,6 +7,7 @@ import getStaticMarkdownProps from '~/lib/getStaticMarkdownProps';
 import { Headline1 } from '~/components/Headlines';
 import { SectionContext } from '~/context';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticPaths() {
   return getStaticMarkdownPaths('pages/implementers');
@@ -31,6 +32,12 @@ export default function StaticMarkdownPage({
       </Head>
       <Headline1>{frontmatter.title}</Headline1>
       <StyledMarkdown markdown={content} />
+      <NextPrevButton
+        prevLabel={frontmatter?.prev?.label}
+        prevURL={frontmatter?.prev?.url}
+        nextLabel={frontmatter?.next?.label}
+        nextURL={frontmatter?.next?.url}
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/implementers/_index.md
+++ b/pages/implementers/_index.md
@@ -1,6 +1,12 @@
 ---
 title: "For Implementers"
 section: docs
+prev: 
+  label: Structuring a complex schema
+  url: /understanding-json-schema/structuring
+next: 
+  label: Common Interfaces across Implementations
+  url: /implementers/interfaces
 ---
 
 For Implementers

--- a/pages/implementers/index.page.tsx
+++ b/pages/implementers/index.page.tsx
@@ -6,6 +6,7 @@ import StyledMarkdown from '~/components/StyledMarkdown';
 import { DocsHelp } from '~/components/DocsHelp';
 import { SectionContext } from '~/context';
 import Card from '~/components/Card';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const block1 = fs.readFileSync('pages/implementers/_index.md', 'utf-8');
@@ -17,13 +18,19 @@ export async function getStaticProps() {
   };
 }
 
-export default function ContentExample({ blocks }: { blocks: any[] }) {
+export default function ContentExample({
+  blocks,
+}: {
+  blocks: any[];
+  frontmatter: any;
+  content: any;
+}) {
   const markdownFile = '_indexPage';
 
   return (
     <SectionContext.Provider value='docs'>
       <StyledMarkdown markdown={blocks[0]} />
-      <section className='mt-10'>
+      <section className='my-10'>
         <div className='grid grid-cols-1 md:grid-cols-2 gap-4 w-12/12 md:w-11/12 lg:w-10/12 xl:w-10/12 m-auto'>
           <Card
             key='common-interfaces'
@@ -45,6 +52,12 @@ export default function ContentExample({ blocks }: { blocks: any[] }) {
           />
         </div>
       </section>
+      <NextPrevButton
+        prevLabel='Structuring a complex schema'
+        prevURL='/understanding-json-schema/structuring'
+        nextLabel='Common Interfaces across Implementations'
+        nextURL='/implementers/interfaces'
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/implementers/interfaces.md
+++ b/pages/implementers/interfaces.md
@@ -1,6 +1,12 @@
 ---
 title: Common Interfaces across JSON Schema Implementations
 section: implementers
+prev: 
+  label: For Implementers
+  url: /implementers
+next: 
+  label: Specification
+  url: /specification
 ---
 
 JSON Schema is extremely widely used and nearly equally widely implemented.

--- a/pages/learn/getting-started-step-by-step/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step/getting-started-step-by-step.md
@@ -1,6 +1,12 @@
 ---
 title: Creating your first schema
 section: docs
+prev: 
+  label: Overview
+  url: /learn
+next: 
+  label: Miscellaneous examples
+  url: /learn/miscellaneous-examples
 ---
 
 JSON Schema is a vocabulary that you can use to annotate and validate JSON documents. This tutorial guides you through the process of creating a JSON Schema.

--- a/pages/learn/getting-started-step-by-step/index.page.tsx
+++ b/pages/learn/getting-started-step-by-step/index.page.tsx
@@ -9,6 +9,7 @@ import StyledMarkdown from '~/components/StyledMarkdown';
 import { SectionContext } from '~/context';
 import { DocsHelp } from '~/components/DocsHelp';
 import GettingStarted from '~/components/GettingStarted';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const block1 = fs.readFileSync(
@@ -28,7 +29,13 @@ export async function getStaticProps() {
   };
 }
 
-export default function StyledValidator({ blocks }: { blocks: any[] }) {
+export default function StyledValidator({
+  blocks,
+}: {
+  blocks: any[];
+  frontmatter: any;
+  content: any;
+}) {
   const newTitle = 'Creating your first schema';
 
   return (
@@ -40,6 +47,12 @@ export default function StyledValidator({ blocks }: { blocks: any[] }) {
       <StyledMarkdown markdown={blocks[0]} />
       <GettingStarted />
       <StyledMarkdown markdown={blocks[1]} />
+      <NextPrevButton
+        prevLabel='Overview'
+        prevURL='/learn'
+        nextLabel='Miscellaneous examples'
+        nextURL='/learn/miscellaneous-examples'
+      />
       <DocsHelp />
     </SectionContext.Provider>
   );

--- a/pages/learn/glossary.md
+++ b/pages/learn/glossary.md
@@ -1,6 +1,12 @@
 ---
 title: JSON Schema Glossary
 section: docs
+prev: 
+  label: Other Examples
+  url: /learn/json-schema-examples
+next: 
+  label: JSON Schema Keywords
+  url: /understanding-json-schema/keywords
 ---
 
 This document collects short explanations of terminology one may encounter within the JSON Schema community.

--- a/pages/learn/index.page.tsx
+++ b/pages/learn/index.page.tsx
@@ -5,6 +5,7 @@ import { Headline1 } from '~/components/Headlines';
 import { SectionContext } from '~/context';
 import Card from '~/components/Card';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export default function Welcome() {
   const markdownFile = '_indexPage';
@@ -39,6 +40,12 @@ export default function Welcome() {
           link='https://tour.json-schema.org/'
         />
       </div>
+      <NextPrevButton
+        prevLabel='Code of Conduct'
+        prevURL='/overview/code-of-conduct'
+        nextLabel='Creating your first Schema'
+        nextURL='/learn/getting-started-step-by-step'
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/learn/json-schema-examples.md
+++ b/pages/learn/json-schema-examples.md
@@ -5,8 +5,8 @@ prev:
   label: Modeling a file system
   url: /learn/file-system
 next: 
-  label: Miscellaneous examples
-  url: /learn/miscellaneous-examples
+  label: JSON Scehma Glossary
+  url: /learn/glossary
 ---
 
 In this page, you will find examples illustrating different use cases to help you get the most out of your JSON Schemas. These examples cover a wide range of scenarios, and each example comes with accompanying JSON data and explanation, showcasing how JSON Schemas can be applied to various domains. You can modify these examples to suit your specific needs, as this is just one of the many ways you can utilize JSON Schemas.

--- a/pages/learn/miscellaneous-examples.md
+++ b/pages/learn/miscellaneous-examples.md
@@ -1,6 +1,9 @@
 ---
 section: docs
 title: Miscellaneous Examples
+prev : 
+  label: Creating your first Schema
+  url: /learn/getting-started-step-by-step
 next: 
   label: Modelling a file system
   url: /learn/file-system

--- a/pages/overview/code-of-conduct/index.page.tsx
+++ b/pages/overview/code-of-conduct/index.page.tsx
@@ -39,8 +39,8 @@ export default function Content({
       <NextPrevButton
         prevLabel='Similar-Technologies'
         prevURL='/overview/similar-technologies'
-        nextLabel='What is JSON Schema'
-        nextURL='/overview/what-is-jsonschema'
+        nextLabel='Getting Started'
+        nextURL='/learn'
       />
       <DocsHelp />
     </SectionContext.Provider>

--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -1,6 +1,12 @@
 ---
 title: Specification Links
 section: docs
+prev: 
+  label: Specification
+  url: /specification
+next: 
+  label: Migration
+  url: /specification/migration
 ---
 
 <!-- Links on this page should be immutable - none of them should go to `/latest`, etc. -->

--- a/pages/specification.md
+++ b/pages/specification.md
@@ -1,6 +1,12 @@
 ---
 title: Specification [#section]
 section: docs
+prev: 
+  label: Common Interfaces across Implementations
+  url: /implementers/interfaces
+next: 
+  label: Specification Links
+  url: /specification-links
 ---
 
 The current version is *2020-12*!

--- a/pages/specification/json-hyper-schema/_index.md
+++ b/pages/specification/json-hyper-schema/_index.md
@@ -1,5 +1,11 @@
 ---
 title: JSON Hyper-Schema
+prev: 
+  label: Release Notes
+  url: /specification/release-notes
+next: 
+  label: What is JSON Schema?
+  url: /overview/what-is-jsonschema
 ---
 
 ### Introduction

--- a/pages/specification/json-hyper-schema/index.page.tsx
+++ b/pages/specification/json-hyper-schema/index.page.tsx
@@ -6,6 +6,7 @@ import StyledMarkdown from '~/components/StyledMarkdown';
 import { SectionContext } from '~/context';
 import { Headline1 } from '~/components/Headlines';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const index = fs.readFileSync(
@@ -44,6 +45,12 @@ export default function ImplementationsPages({
 
       <StyledMarkdown markdown={blocks.index} />
       <StyledMarkdown markdown={blocks.body} />
+      <NextPrevButton
+        prevLabel={frontmatter?.prev?.label}
+        prevURL={frontmatter?.prev?.url}
+        nextLabel={frontmatter?.next?.label}
+        nextURL={frontmatter?.next?.url}
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/specification/migration/_index.md
+++ b/pages/specification/migration/_index.md
@@ -1,6 +1,12 @@
 ---
 title: Migrating from older drafts
 section: docs
+prev: 
+  label: Specification Links
+  url: /specification-links
+next: 
+  label: Release Notes
+  url: /specification/release-notes
 ---
 
 The release notes discuss the changes impacting users and implementers:

--- a/pages/specification/migration/index.page.tsx
+++ b/pages/specification/migration/index.page.tsx
@@ -7,6 +7,7 @@ import { Headline1 } from '~/components/Headlines';
 import { SectionContext } from '~/context';
 import Card from '~/components/Card';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const index = fs.readFileSync(
@@ -42,7 +43,7 @@ export default function ImplementationsPages({
       <Headline1>{frontmatter.title}</Headline1>
       <StyledMarkdown markdown={blocks.index} />
       <StyledMarkdown markdown={blocks.body} />
-      <div className='w-full lg:w-full grid grid-cols-1 sm:grid-cols-2 gap-6 my-[10px] mx-auto mt-8'>
+      <div className='w-full lg:w-full grid grid-cols-1 sm:grid-cols-2 gap-6 my-[10px] mx-auto mt-8 mb-4'>
         <Card
           title='Draft 2019-09 to Draft 2020-12'
           body='Details for migrations from Draft 2019-09 to 2020-12.'
@@ -72,6 +73,12 @@ export default function ImplementationsPages({
           link='/draft-06/json-schema-release-notes'
         />
       </div>
+      <NextPrevButton
+        prevLabel={frontmatter?.prev?.label}
+        prevURL={frontmatter?.prev?.url}
+        nextLabel={frontmatter?.next?.label}
+        nextURL={frontmatter?.next?.url}
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/specification/release-notes/_index.md
+++ b/pages/specification/release-notes/_index.md
@@ -1,6 +1,12 @@
 ---
 title: Release notes
 type: docs
+prev: 
+  label: Migration
+  url: /specification/migration
+next: 
+  label: JSON Hyper-Schema
+  url: /specification/json-hyper-schema
 ---
 
 Find below the Release Notes of all JSON Schema drafts:

--- a/pages/specification/release-notes/index.page.tsx
+++ b/pages/specification/release-notes/index.page.tsx
@@ -7,6 +7,7 @@ import { Headline1 } from '~/components/Headlines';
 import { SectionContext } from '~/context';
 import Card from '~/components/Card';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const index = fs.readFileSync(
@@ -42,7 +43,7 @@ export default function ImplementationsPages({
       <Headline1>{frontmatter.title}</Headline1>
       <StyledMarkdown markdown={blocks.index} />
       <StyledMarkdown markdown={blocks.body} />
-      <div className='w-full lg:w-full grid grid-cols-1 sm:grid-cols-2 gap-6 my-[10px] mx-auto mt-8'>
+      <div className='w-full lg:w-full grid grid-cols-1 sm:grid-cols-2 gap-6 my-[10px] mx-auto mt-8 mb-6'>
         <Card
           title='Draft 2020-12'
           body='Draft 2020-12 release notes.'
@@ -79,6 +80,12 @@ export default function ImplementationsPages({
           link='/draft-05#explanation-for-lack-of-draft-05-meta-schema'
         />
       </div>
+      <NextPrevButton
+        prevLabel={frontmatter?.prev?.label}
+        prevURL={frontmatter?.prev?.url}
+        nextLabel={frontmatter?.next?.label}
+        nextURL={frontmatter?.next?.url}
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/understanding-json-schema/[slug].page.tsx
+++ b/pages/understanding-json-schema/[slug].page.tsx
@@ -7,6 +7,7 @@ import getStaticMarkdownProps from '~/lib/getStaticMarkdownProps';
 import { Headline1 } from '~/components/Headlines';
 import { DocsHelp } from '~/components/DocsHelp';
 import { SectionContext } from '~/context';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticPaths() {
   return getStaticMarkdownPaths('pages/understanding-json-schema');
@@ -31,6 +32,12 @@ export default function StaticMarkdownPage({
       </Head>
       <Headline1>{frontmatter.title || 'NO TITLE!'}</Headline1>
       <StyledMarkdown markdown={content} />
+      <NextPrevButton
+        prevLabel={frontmatter?.prev?.label}
+        prevURL={frontmatter?.prev?.url}
+        nextLabel={frontmatter?.next?.label}
+        nextURL={frontmatter?.next?.url}
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/understanding-json-schema/_index.md
+++ b/pages/understanding-json-schema/_index.md
@@ -1,6 +1,12 @@
 ---
 title: "Understanding JSON Schema"
 section: docs
+prev: 
+  label: JSON Schema Keywords
+  url: /understanding-json-schema/keywords
+next: 
+  label: Conventions
+  url: /understanding-json-schema/conventions
 ---
 
 Understanding JSON Schema

--- a/pages/understanding-json-schema/about.md
+++ b/pages/understanding-json-schema/about.md
@@ -1,6 +1,12 @@
 ---
 title: "What is a schema?"
 section: "docs"
+prev: 
+  label: Conventions used
+  url: /understanding-json-schema/conventions
+next: 
+  label: The basics
+  url: /understanding-json-schema/basics
 ---
 
 If you\'ve ever used XML Schema, RelaxNG or ASN.1 you probably already

--- a/pages/understanding-json-schema/basics.md
+++ b/pages/understanding-json-schema/basics.md
@@ -1,6 +1,12 @@
 ---
 title: The basics
 section: docs
+prev: 
+  label: What is a Schema?
+  url: /understanding-json-schema/about
+next: 
+  label: JSON Schema reference
+  url: /understanding-json-schema/reference
 ---
 
 In [What is a schema?](../understanding-json-schema/about), we described what a [schema](../learn/glossary#schema) is,

--- a/pages/understanding-json-schema/conventions.md
+++ b/pages/understanding-json-schema/conventions.md
@@ -1,6 +1,12 @@
 ---
 section: docs
 title: "Conventions used in this documentation"
+prev: 
+  label: Understanding JSON Schema
+  url: /understanding-json-schema
+next: 
+  label: What is a Schema?
+  url: /understanding-json-schema/about
 ---
 
 ## Language-specific notes

--- a/pages/understanding-json-schema/index.page.tsx
+++ b/pages/understanding-json-schema/index.page.tsx
@@ -5,6 +5,7 @@ import matter from 'gray-matter';
 import StyledMarkdown from '~/components/StyledMarkdown';
 import { DocsHelp } from '~/components/DocsHelp';
 import { SectionContext } from '~/context';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const block1 = fs.readFileSync(
@@ -19,12 +20,24 @@ export async function getStaticProps() {
   };
 }
 
-export default function ContentExample({ blocks }: { blocks: any[] }) {
+export default function ContentExample({
+  blocks,
+}: {
+  blocks: any[];
+  frontmatter: any;
+  content: any;
+}) {
   const markdownFile = '_indexPage';
 
   return (
     <SectionContext.Provider value='docs'>
       <StyledMarkdown markdown={blocks[0]} />
+      <NextPrevButton
+        prevLabel='JSON Schema Keywords'
+        prevURL='/understanding-json-schema/keywords'
+        nextLabel='Conventions used'
+        nextURL='/understanding-json-schema/conventions'
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/understanding-json-schema/keywords/index.page.tsx
+++ b/pages/understanding-json-schema/keywords/index.page.tsx
@@ -9,6 +9,7 @@ import { Headline1, Headline4 } from '~/components/Headlines';
 import { DocsHelp } from '~/components/DocsHelp';
 import Link from 'next/link';
 import Image from 'next/image';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const datas = yaml.load(
@@ -86,7 +87,12 @@ export default function StaticMarkdownPage({ datas }: { datas: DataObject[] }) {
               ),
           )}
       </div>
-
+      <NextPrevButton
+        prevLabel='JSON Schema Glossary'
+        prevURL='/learn/glossary'
+        nextLabel='Understanding JSON Schema'
+        nextURL='/understanding-json-schema'
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/understanding-json-schema/reference/[slug].page.tsx
+++ b/pages/understanding-json-schema/reference/[slug].page.tsx
@@ -7,6 +7,7 @@ import getStaticMarkdownPaths from '~/lib/getStaticMarkdownPaths';
 import getStaticMarkdownProps from '~/lib/getStaticMarkdownProps';
 import { SectionContext } from '~/context';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticPaths() {
   return getStaticMarkdownPaths('pages/understanding-json-schema/reference');
@@ -34,6 +35,12 @@ export default function StaticMarkdownPage({
       </Head>
       <Headline1>{frontmatter.title || 'NO TITLE!'}</Headline1>
       <StyledMarkdown markdown={content} />
+      <NextPrevButton
+        prevLabel={frontmatter?.prev?.label}
+        prevURL={frontmatter?.prev?.url}
+        nextLabel={frontmatter?.next?.label}
+        nextURL={frontmatter?.next?.url}
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/understanding-json-schema/reference/annotations.md
+++ b/pages/understanding-json-schema/reference/annotations.md
@@ -1,6 +1,12 @@
 ---
 title: "Annotations"
 section: docs
+prev: 
+  label: Generic keywords
+  url: /understanding-json-schema/reference/generic
+next: 
+  label: Comments
+  url: /understanding-json-schema/reference/comments
 ---
 
 JSON Schema includes a few [keywords](../../learn/glossary#keyword), that aren\'t strictly used for

--- a/pages/understanding-json-schema/reference/array.md
+++ b/pages/understanding-json-schema/reference/array.md
@@ -1,6 +1,12 @@
 ---
 title: "array"
 section: docs
+prev: 
+  label: Object
+  url: /understanding-json-schema/reference/object
+next: 
+  label: Boolean
+  url: /understanding-json-schema/reference/boolean
 ---
 
 <Keywords label="single: array" />

--- a/pages/understanding-json-schema/reference/boolean.md
+++ b/pages/understanding-json-schema/reference/boolean.md
@@ -1,6 +1,12 @@
 ---
 title: "boolean"
 section: docs
+prev: 
+  label: Array
+  url: /understanding-json-schema/reference/array
+next: 
+  label: 'Null'
+  url: /understanding-json-schema/reference/null
 ---
 
 <Keywords label="single: boolean" />

--- a/pages/understanding-json-schema/reference/combining.md
+++ b/pages/understanding-json-schema/reference/combining.md
@@ -1,6 +1,12 @@
 ---
 title: "Schema Composition"
 section: docs
+prev: 
+  label: 'Media: string-encoding non-JSON data'
+  url: /understanding-json-schema/reference/non_json_data
+next: 
+  label: Applying Subschemas Conditionally
+  url: /understanding-json-schema/reference/conditionals
 ---
 
 <Keywords label="schema composition" />

--- a/pages/understanding-json-schema/reference/comments.md
+++ b/pages/understanding-json-schema/reference/comments.md
@@ -1,6 +1,12 @@
 ---
 title: "Comments"
 section: docs
+prev: 
+  label: Annotations
+  url: /understanding-json-schema/reference/annotations
+next: 
+  label: Enumerated values
+  url: /understanding-json-schema/reference/enum
 ---
 
 <Star label="New in draft 7" />

--- a/pages/understanding-json-schema/reference/conditionals.md
+++ b/pages/understanding-json-schema/reference/conditionals.md
@@ -1,6 +1,12 @@
 ---
 title: "Applying Subschemas Conditionally"
 section: docs
+prev: 
+  label: Schema Composition
+  url: /understanding-json-schema/reference/combining
+next: 
+  label: Declaring a Dialect
+  url: /understanding-json-schema/reference/schema
 ---
 
 <Keywords label="single: conditionals; dependentRequired single: property dependentRequired" />

--- a/pages/understanding-json-schema/reference/const.md
+++ b/pages/understanding-json-schema/reference/const.md
@@ -1,6 +1,12 @@
 ---
 title: "Constant values"
 section: docs
+prev: 
+  label: Enumerated values
+  url: /understanding-json-schema/reference/enum
+next: 
+  label: 'Media: string-encoding non-JSON data'
+  url: /understanding-json-schema/reference/non_json_data
 ---
 
 <Star label="New in draft 6" />

--- a/pages/understanding-json-schema/reference/enum.md
+++ b/pages/understanding-json-schema/reference/enum.md
@@ -1,6 +1,12 @@
 ---
 title: "Enumerated values"
 section: docs
+prev: 
+  label: Comments
+  url: /understanding-json-schema/reference/comments
+next: 
+  label: Constant values
+  url: /understanding-json-schema/reference/const
 ---
 
 The `enum` [keyword](../../learn/glossary#keyword) is used to restrict a value to a fixed set of values.

--- a/pages/understanding-json-schema/reference/generic.md
+++ b/pages/understanding-json-schema/reference/generic.md
@@ -1,6 +1,12 @@
 ---
 title: "Generic keywords"
 section: docs
+prev: 
+  label: Type Specific Keywords
+  url: /understanding-json-schema/reference/type
+next: 
+  label: 'Media : string-encoding non-JSON data'
+  url: /understanding-json-schema/reference/non_json_data
 ---
 
 * [Annotations](../../understanding-json-schema/reference/annotations)

--- a/pages/understanding-json-schema/reference/index.page.tsx
+++ b/pages/understanding-json-schema/reference/index.page.tsx
@@ -5,6 +5,7 @@ import matter from 'gray-matter';
 import StyledMarkdown from '~/components/StyledMarkdown';
 import { SectionContext } from '~/context';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
   const block1 = fs.readFileSync(
@@ -19,11 +20,23 @@ export async function getStaticProps() {
   };
 }
 
-export default function ContentExample({ blocks }: { blocks: any[] }) {
+export default function ContentExample({
+  blocks,
+}: {
+  blocks: any[];
+  frontmatter: any;
+  content: any;
+}) {
   const markdownFile = '_indexPage';
   return (
     <SectionContext.Provider value='docs'>
       <StyledMarkdown markdown={blocks[0]} />
+      <NextPrevButton
+        prevLabel='The basics'
+        prevURL='/understanding-json-schema/basics'
+        nextLabel='Type-specific keywords'
+        nextURL='/understanding-json-schema/reference/type'
+      />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>
   );

--- a/pages/understanding-json-schema/reference/non_json_data.md
+++ b/pages/understanding-json-schema/reference/non_json_data.md
@@ -1,6 +1,12 @@
 ---
 title: "Media: string-encoding non-JSON data"
 section: docs
+prev: 
+  label: Generic Keywords
+  url: /understanding-json-schema/reference/generic
+next: 
+  label: Schema Composition
+  url: /understanding-json-schema/reference/combining
 ---
 
 <Keywords label="single: non-JSON data single: media"/>

--- a/pages/understanding-json-schema/reference/null.md
+++ b/pages/understanding-json-schema/reference/null.md
@@ -1,6 +1,12 @@
 ---
 title: "null"
 section: docs
+prev: 
+  label: boolean
+  url: /understanding-json-schema/reference/boolean
+next: 
+  label: Generic Keywords
+  url: /understanding-json-schema/reference/generic
 ---
 
 When a [schema](../../learn/glossary#schema) specifies a `type` of `null`, it has only one acceptable value: `null`.

--- a/pages/understanding-json-schema/reference/numeric.md
+++ b/pages/understanding-json-schema/reference/numeric.md
@@ -1,6 +1,12 @@
 ---
 title: "Numeric types"
 section: docs
+prev: 
+  label: Regular Expressions
+  url: /understanding-json-schema/reference/regular_expressions
+next: 
+  label: Object
+  url: /understanding-json-schema/reference/object
 ---
 
 <Keywords label="single: integer single: number single: types; numeric" />

--- a/pages/understanding-json-schema/reference/object.md
+++ b/pages/understanding-json-schema/reference/object.md
@@ -1,6 +1,12 @@
 ---
 title: "object"
 section: docs
+prev: 
+  label: Numeric Types
+  url: /understanding-json-schema/reference/numeric
+next: 
+  label: Array
+  url: /understanding-json-schema/reference/array
 ---
 
 <Keywords label="single: object" />

--- a/pages/understanding-json-schema/reference/regular_expressions.md
+++ b/pages/understanding-json-schema/reference/regular_expressions.md
@@ -1,6 +1,12 @@
 ---
 title: "Regular Expressions"
 section: docs
+prev: 
+  label: String
+  url: /understanding-json-schema/reference/string
+next: 
+  label: Numeric types
+  url: /understanding-json-schema/reference/numeric
 ---
 
 <Keywords label="regular expressions" />

--- a/pages/understanding-json-schema/reference/schema.md
+++ b/pages/understanding-json-schema/reference/schema.md
@@ -1,6 +1,12 @@
 ---
 title: "Declaring a Dialect"
 section: docs
+prev: 
+  label: Applying Subschemas Conditionally
+  url: /understanding-json-schema/reference/conditionals
+next: 
+  label: Structuring a complex schema
+  url: /understanding-json-schema/structuring
 ---
 
 A version of JSON Schema is called a [dialect](../../learn/glossary#dialect). A dialect represents the

--- a/pages/understanding-json-schema/reference/string.md
+++ b/pages/understanding-json-schema/reference/string.md
@@ -1,6 +1,12 @@
 ---
 title: string
 section: docs
+prev: 
+  label: Type-specific keywords
+  url: /understanding-json-schema/reference/type
+next: 
+  label: Regular expressions
+  url: /understanding-json-schema/reference/regular_expressions
 ---
 
 The `string` type is used for strings of text. It may contain Unicode characters.

--- a/pages/understanding-json-schema/reference/type.md
+++ b/pages/understanding-json-schema/reference/type.md
@@ -1,6 +1,12 @@
 ---
 title: "Type-specific keywords"
 section: docs
+prev: 
+  label: JSON Schema Reference
+  url: /understanding-json-schema/reference
+next: 
+  label: Generic Keywords
+  url: /understanding-json-schema/reference/generic
 ---
 
 The `type` [keyword](../../learn/glossary#keyword) is fundamental to JSON Schema. It specifies the data

--- a/pages/understanding-json-schema/structuring.md
+++ b/pages/understanding-json-schema/structuring.md
@@ -1,6 +1,12 @@
 ---
 title: "Structuring a complex schema"
 section: docs
+prev: 
+  label: Declaring a dialect
+  url: /understanding-json-schema/reference/schema
+next: 
+  label: For Implementers
+  url: /implementers
 ---
 
 <Keywords label="single: single: structure" />


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Enhancement: Added navigation buttons to Getting Started, Reference and Specification sections
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1072  <!-- Replace ___ with the issue number this PR resolves -->

<!--Add link to it-->
**Summary**
- This PR basically adds navigation buttons to Getting Started, Reference and Specifications section of JSON-Schema website for better navigation throughout the website.

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
