### PR TITLE
fix : remove dummy text present on https://json-schema.org/overview/case-studies page

### DIFF
--- a/pages/overview/case-studies/index.page.tsx
+++ b/pages/overview/case-studies/index.page.tsx
@@ -31,7 +31,8 @@ export default function ContentExample() {
       </Head>
       <Headline1>{newTitle}</Headline1>
       <p className='text-[18px]'>
-        Learn how organizations are adopting JSON Schema to improve data management, ensure consistency, and streamline workflows across systems.
+        Learn how organizations are adopting JSON Schema to improve data
+        management, ensure consistency, and streamline workflows across systems.
       </p>
       <div className='mx-auto my-[10px] mt-8 grid w-full grid-cols-1 gap-6 sm:grid-cols-2 lg:w-full'>
         {data.map((element, index) => (

--- a/pages/overview/case-studies/index.page.tsx
+++ b/pages/overview/case-studies/index.page.tsx
@@ -31,7 +31,6 @@ export default function ContentExample() {
       </Head>
       <Headline1>{newTitle}</Headline1>
       <p className='text-[18px]'>
-        {/* Please fix below dummy text and make it two to three liner so that we can remove the bug of layout shifting :) */}
         Learn how organizations are adopting JSON Schema to improve data management, ensure consistency, and streamline workflows across systems.
       </p>
       <div className='mx-auto my-[10px] mt-8 grid w-full grid-cols-1 gap-6 sm:grid-cols-2 lg:w-full'>

--- a/pages/overview/case-studies/index.page.tsx
+++ b/pages/overview/case-studies/index.page.tsx
@@ -32,9 +32,7 @@ export default function ContentExample() {
       <Headline1>{newTitle}</Headline1>
       <p className='text-[18px]'>
         {/* Please fix below dummy text and make it two to three liner so that we can remove the bug of layout shifting :) */}
-        Learn how organizations are adopting and benefiting from JSON Schema.
-        Please replace this text with a two to three liner so that we can avoid
-        the layout shifting bug.
+        Learn how organizations are adopting JSON Schema to improve data management, ensure consistency, and streamline workflows across systems.
       </p>
       <div className='mx-auto my-[10px] mt-8 grid w-full grid-cols-1 gap-6 sm:grid-cols-2 lg:w-full'>
         {data.map((element, index) => (


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Replaces the Dummy Text present on https://json-schema.org/overview/case-studies page under the "Case Studies" header with some meaningful text

**Issue Number:**
-  Closes #1236 

**Screenshot**
![Dummy Text Issue Solved](https://github.com/user-attachments/assets/1ba4f1cf-9120-4a36-85e6-59c93bf04301)