### PR TITLE
Added proper links for jsonschema-core.md and jsonschema-validation.md

### DIFF
--- a/pages/specification-links.md
+++ b/pages/specification-links.md
@@ -498,8 +498,8 @@ The next unreleased draft is a work in progress.  You can [give feedback and get
 
 The specification links here link to the raw sources.  We do not provide rendered [work-in-progress](work-in-progress) drafts except near the very end of a publication cycle, during the final review period.
 
- - Core: [jsonschema-core.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-core.md)
- - Validation: [jsonschema-validation.md](https://github.com/json-schema-org/json-schema-spec/blob/main/jsonschema-validation.md)
+ - Core: [jsonschema-core.md](https://github.com/json-schema-org/json-schema-spec/blob/main/specs/jsonschema-core.md)
+ - Validation: [jsonschema-validation.md](https://github.com/json-schema-org/json-schema-spec/blob/main/specs/jsonschema-validation.md)
  - Hyper-Schema: [jsonschema-hyperschema.xml](https://github.com/json-schema-org/json-hyperschema-spec/blob/main/jsonschema-hyperschema.xml)
 - Relative JSON Pointer: [relative-json-pointer.xml](https://github.com/json-schema-org/json-schema-spec/blob/master/relative-json-pointer.xml)
 - [JSON Schema meta-schema](https://github.com/json-schema-org/json-schema-spec/blob/master/schema.json)


### PR DESCRIPTION
Added proper links for jsonschema-core.md and jsonschema-validation.md in specification-links.md


<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
I have added proper links for jsonschema-core.md and jsonschema-validation.md.
https://github.com/json-schema-org/json-schema-spec/blob/main/specs/jsonschema-core.md
https://github.com/json-schema-org/json-schema-spec/blob/main/specs/jsonschema-validation.md

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1239 ___ <!-- Replace ___ with the issue number this PR resolves -->
-  Related to #___ <!-- Use when the PR doesn't completely resolve an issue -->
-  Others? <!-- Add any additional notes or references here -->


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
NO
