### PR TITLE
Fixed #1248 - Improved Bold Text Contrast in Dark Mode

### DIFF
--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -173,7 +173,7 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
             h4: { component: Headline4 },
             strong: {
               component: ({ children }) => (
-                <strong className='font-semibold text-slate-800 dark:text-slate-500'>
+                <strong className='font-semibold text-slate-800 dark:text-slate-200'>
                   {children}
                 </strong>
               ),


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
🐛 Bugfix: Improves the contrast of bold text in dark mode.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1248


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->
**Before Fix:**  
![before fix](https://github.com/user-attachments/assets/861e3a74-e6e8-4ab1-8a70-4c7b50ceaa72)

**After Fix:**  
![after bug fix](https://github.com/user-attachments/assets/3a1b3253-b62e-4d29-b7d1-0bc8270036b9)


**If relevant, did you update the documentation?**

No updates were needed as this is a UI bugfix.

**Summary**

This PR fixes a bug where bold text in dark mode had insufficient contrast, making it harder to read compared to light mode. The fix enhances the visibility of bold text while maintaining a cohesive design. This resolves a common complaint about text readability in dark mode.

**Does this PR introduce a breaking change?**

No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Additional Notes:**

Tested on different devices and browsers to ensure consistency.
No migration path is needed since this is a minor visual update.
