### PR TITLE
Fix: Ignore Brackets Inside Strings in `getPartsOfArrayContent`

### DIFF
--- a/lib/getPartsOfJson.ts
+++ b/lib/getPartsOfJson.ts
@@ -366,21 +366,30 @@ const getPartsOfArrayContent = (
     const length = match.index - arrayPayloadIndex;
     const payload = serializedJson.substr(arrayPayloadIndex, length);
 
-    //ToDo filter brackets in strings
+    const stringMatches = getFindResultsByGlobalRegExp(payload, regexString);
+    let filteredPayload = payload;
+
+    // Replace content of strings with placeholders to avoid counting brackets inside them
+    stringMatches.forEach((stringMatch) => {
+      const stringContent = stringMatch.match;
+      const placeholder = '_'.repeat(stringContent.length);
+      filteredPayload = filteredPayload.replace(stringContent, placeholder);
+    });
+
     const countOpenCurlyBracketsInPayload = getFindResultsByGlobalRegExp(
-      payload,
+      filteredPayload,
       /\{/g,
     ).length;
     const countClosedCurlyBracketsInPayload = getFindResultsByGlobalRegExp(
-      payload,
+      filteredPayload,
       /\}/g,
     ).length;
     const countOpenSquaredBracketsInPayload = getFindResultsByGlobalRegExp(
-      payload,
+      filteredPayload,
       /\[/g,
     ).length;
     const countClosedSquaredBracketsInPayload = getFindResultsByGlobalRegExp(
-      payload,
+      filteredPayload,
       /\]/g,
     ).length;
     const openCurlyBrackets =


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: Ensures brackets inside strings are ignored during parsing in the getPartsOfArrayContent function.

**Issue Number:**

- Closes #1266

**Screenshots/videos:**
N/A

**If relevant, did you update the documentation?**

No updates required as this is a bugfix to existing functionality.

**Summary**

This pull request addresses a parsing error in the `getPartsOfArrayContent` function in `lib/getPartsOfJson.ts`. The function previously failed to ignore brackets (`{`, `}`, `[`, `]`) that appear inside strings, leading to incorrect parsing of JSON arrays. 

Before:
Example Input:
```json
[
  "{key:value}",
  "[nested]",
  "\"A String with {brackets}\"",
  "true",
  143,
  null
]
```
After:
The function now correctly parses the array values and ignores brackets inside strings.

**Does this PR introduce a breaking change?**
No breaking changes.
