### PR TITLE
🐛 Bug #1248 fixed , [bold text harder to read]

### DIFF
--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -173,7 +173,7 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
             h4: { component: Headline4 },
             strong: {
               component: ({ children }) => (
-                <strong className='font-semibold text-slate-800 dark:text-slate-500'>
+                <strong className='font-semibold text-slate-800 dark:text-slate-200'>
                   {children}
                 </strong>
               ),


### PR DESCRIPTION
What kind of change does this PR introduce?
🐛 Bugfix : Improves the contrast of bold text in dark mode.

Issue Number:
Closes #1248 



**Screenshots/videos:**

Before : [
![website bold before](https://github.com/user-attachments/assets/3ec98ea5-d4c2-4e40-854b-99ea5a3a21dc)
]

After : 
![website bold after](https://github.com/user-attachments/assets/cb1546b3-ac4b-4161-a8d6-b14f64845275)


If relevant, did you update the documentation?

No updates were needed as this is a UI bugfix.

Summary

This PR fixes a bug where bold text in dark mode had insufficient contrast, making it harder to read compared to light mode. The fix enhances the visibility of bold text while maintaining a cohesive design. This resolves a common complaint about text readability in dark mode. 

Does this PR introduce a breaking change?

No.

Additional Notes:

Tested on different devices and browsers to ensure consistency.
I didn't implement anything drastically new as all of it was aligned with the theme of the website.

