### PR TITLE
Fix: URL color on homepage in dark-mode

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -512,19 +512,19 @@ const Home = (props: any) => {
               If you ❤️ JSON Schema consider becoming a{' '}
               <a
                 href='https://json-schema.org/overview/sponsors'
-                className='border-b border-black'
+                className='border-b border-black dark:border-white'
               >
                 sponsor
               </a>
               , a{' '}
               <a
                 href='https://json-schema.org/overview/sponsors#benefits-of-being-an-individual-backer'
-                className='border-b border-black '
+                className='border-b border-black dark:border-white'
               >
                 backer
               </a>{' '}
               or hiring our{' '}
-              <a href='/pro-help' className='border-b border-black'>
+              <a href='/pro-help' className='border-b border-black dark:border-white'>
                 pro services
               </a>
               .
@@ -532,7 +532,7 @@ const Home = (props: any) => {
             <p className='w-5/6 lg:w-3/5 mx-auto'>
               <a
                 href='https://opencollective.com/json-schema'
-                className='border-b border-black'
+                className='border-b border-black dark:border-white'
               >
                 Support us!
               </a>
@@ -696,7 +696,7 @@ const Home = (props: any) => {
               <br />
               <a
                 href='mailto:info@json-schema.org'
-                className='border-b border-black'
+                className='border-b border-black dark:border-white'
               >
                 Email us
               </a>{' '}

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -524,7 +524,10 @@ const Home = (props: any) => {
                 backer
               </a>{' '}
               or hiring our{' '}
-              <a href='/pro-help' className='border-b border-black dark:border-white'>
+              <a
+                href='/pro-help'
+                className='border-b border-black dark:border-white'
+              >
                 pro services
               </a>
               .


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR updates the color of the URL displayed on the homepage in dark mode for improved visibility.

**Issue Number:**
-  Closes #1267 

**Screenshots/videos:**
![image](https://github.com/user-attachments/assets/955783f1-04aa-4a7b-815b-28581a93c6bc)

**Summary**
In dark mode, the URL on the homepage was underlined in black, making it difficult for users to identify. This PR changes the underline color to white, ensuring better visibility and enhancing usability.

**Does this PR introduce a breaking change?**
No
