### PR TITLE
Fix: correct vertical alignment issue in schema example

### DIFF
--- a/components/JsonEditor.tsx
+++ b/components/JsonEditor.tsx
@@ -319,6 +319,7 @@ export default function JsonEditor({ initialCode }: { initialCode: string }) {
           </div>
         </div>
         <Editable
+          className='overflow-x-auto'
           data-test='json-editor'
           onCopy={(e) => {
             e.preventDefault();
@@ -363,7 +364,6 @@ export default function JsonEditor({ initialCode }: { initialCode: string }) {
                     (jsonPathsWithJsonScope) => jsonPathsWithJsonScope.jsonPath,
                   )
                   .includes(leaf.syntaxPart?.parentJsonPath);
-                // console.log('jsonPathsWithJsonScope', jsonPathsWithJsonScope, leaf, leaf.syntaxPart?.parentJsonPath)
                 if (
                   isJsonScope &&
                   jsonSchemaReferences.objectProperty[leaf.text]
@@ -410,7 +410,7 @@ export default function JsonEditor({ initialCode }: { initialCode: string }) {
                   if (!link) return;
                   router.push(link);
                 }}
-                className={classnames('pb-2', textStyles)}
+                className={classnames('pb-2', textStyles, 'whitespace-pre')}
                 title={leaf.syntaxPart?.type}
                 {...attributes}
               >

--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -309,18 +309,18 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
               return (
                 <div className='overflow-x-auto rounded-lg bg-gray-800 text-white'>
                   <Highlight
-                    language={language.replace('language-', '')}
+                    language={language}
                     style={atomOneDark}
                     showLineNumbers
                     lineNumberStyle={{
                       color: '#888',
-                      fontSize: '12px',
+                      fontSize: '16px',
                       paddingRight: '10px',
                     }}
                     customStyle={{
                       padding: '12px',
                       fontFamily: 'monospace',
-                      fontSize: '14px',
+                      fontSize: '16px',
                     }}
                     codeTagProps={{
                       style: {

--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -313,7 +313,7 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
                     style={atomOneDark}
                     showLineNumbers
                     lineNumberStyle={{
-                      color: '#888',
+                      color: '#64748B',
                       fontSize: '16px',
                       paddingRight: '10px',
                     }}

--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -307,34 +307,25 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
               }
 
               return (
-                <div className='overflow-x-auto flex-basis-0 max-w-full min-w-0 shrink lg:max-w-[800px] xl:max-w-[900px]'>
-                  {/* definitely not the best way to prevent overflowing. found no better way that worked */}
+                <div className='overflow-x-auto rounded-lg bg-gray-800 text-white'>
                   <Highlight
-                    language={language}
-                    wrapLines={true}
-                    wrapLongLines={true}
-                    customStyle={{
-                      borderRadius: 10,
-                      paddingTop: 15,
-                      paddingBottom: 10,
-                      paddingLeft: 10,
-                      marginBottom: 20,
-                      maxWidth: '100%',
-                    }}
-                    lineNumberStyle={{
-                      marginRight: 10,
-                    }}
+                    language={language.replace('language-', '')}
                     style={atomOneDark}
                     showLineNumbers
-                    startingLineNumber={1}
-                    lineProps={() => {
-                      const isHighlighted = false;
-                      return {
-                        className: `${isHighlighted ? 'bg-code-editor-dark-highlight block ml-10 w-full' : ''} pr-8`,
-                      };
+                    lineNumberStyle={{
+                      color: '#888',
+                      fontSize: '12px',
+                      paddingRight: '10px',
+                    }}
+                    customStyle={{
+                      padding: '12px',
+                      fontFamily: 'monospace',
+                      fontSize: '14px',
                     }}
                     codeTagProps={{
-                      className: 'mr-8',
+                      style: {
+                        fontFamily: 'monospace',
+                      },
                     }}
                   >
                     {code}


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This is a bugfix for the vertical alignment issue in the JSON schema example in the [documentation](https://json-schema.org/learn/getting-started-step-by-step#add-an-external-reference).

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1293  <!-- Replace ___ with the issue number this PR resolves -->


**Screenshots/videos:**

![image](https://github.com/user-attachments/assets/1598d01c-9c81-4e7f-b8ab-643ce6cd68e2)

**If relevant, did you update the documentation?**

No.

**Summary**

The schema example under "To link to the external geographical location schema" had improper vertical alignment, specifically for the "warehouseLocation" key. This PR fixes the alignment issue, ensuring better readability and consistency in the example.

**Does this PR introduce a breaking change?**

No