### PR TITLE
Fix: Inconsistent Navigation Buttons and Sidebar Order in Documentation

### DIFF
--- a/pages/overview/faq/index.page.tsx
+++ b/pages/overview/faq/index.page.tsx
@@ -26,8 +26,8 @@ export default function Content() {
       <NextPrevButton
         prevLabel='Case Studies'
         prevURL='/overview/case-studies'
-        nextLabel='Similar Technologies'
-        nextURL='/overview/similar-technologies'
+        nextLabel='Pro Help'
+        nextURL='/pro-help'
       />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>

--- a/pages/pro-help/index.page.tsx
+++ b/pages/pro-help/index.page.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import { Headline1 } from '~/components/Headlines';
 import { SectionContext } from '~/context';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 interface ContractorLink {
   title: string;
@@ -208,6 +209,12 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
             <br />
           </div>
         </div>
+        <NextPrevButton
+          prevLabel='FAQ'
+          prevURL='/overview/faq'
+          nextLabel='Similar Technologies'
+          nextURL='/overview/similar-technologies'
+        />
         <DocsHelp />
       </div>
     </SectionContext.Provider>


### PR DESCRIPTION
Bug Fix Summary:

- Fixed the missing "Go Back" and "Up Next" buttons on the Pro Help page.

- Updated the sidebar order to match the "Up Next" navigation flow for consistency.

Closes Issue: #1291 

Does this PR introduce a breaking change?

- No breaking changes introduced. This PR resolves a UI inconsistency.