### PR TITLE
Fix : pro help sidebar alignment and add buttons

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -380,7 +380,11 @@ export const DocsNav = ({
             setOpen={setOpen}
           />
           <DocLink uri='/overview/faq' label='FAQ' setOpen={setOpen} />
-          <DocLink uri='/overview/pro-help' label='Pro Help' setOpen={setOpen} />
+          <DocLink
+            uri='/overview/pro-help'
+            label='Pro Help'
+            setOpen={setOpen}
+          />
           <DocLink
             uri='/overview/similar-technologies'
             label='Similar Technologies'

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -380,7 +380,7 @@ export const DocsNav = ({
             setOpen={setOpen}
           />
           <DocLink uri='/overview/faq' label='FAQ' setOpen={setOpen} />
-          <DocLink uri='/pro-help' label='Pro Help' setOpen={setOpen} />
+          <DocLink uri='/overview/pro-help' label='Pro Help' setOpen={setOpen} />
           <DocLink
             uri='/overview/similar-technologies'
             label='Similar Technologies'

--- a/pages/overview/faq/index.page.tsx
+++ b/pages/overview/faq/index.page.tsx
@@ -26,8 +26,8 @@ export default function Content() {
       <NextPrevButton
         prevLabel='Case Studies'
         prevURL='/overview/case-studies'
-        nextLabel='Similar Technologies'
-        nextURL='/overview/similar-technologies'
+        nextLabel='Pro Help'
+        nextURL='/overview/pro-help'
       />
       <DocsHelp markdownFile={markdownFile} />
     </SectionContext.Provider>

--- a/pages/overview/pro-help/index.page.tsx
+++ b/pages/overview/pro-help/index.page.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import fs from 'fs';
-import { getLayout } from '~/components/SiteLayout';
+import { getLayout } from '~/components/Sidebar';
 import Head from 'next/head';
 import { Headline1 } from '~/components/Headlines';
 import { SectionContext } from '~/context';
 import { DocsHelp } from '~/components/DocsHelp';
+import NextPrevButton from '~/components/NavigationButtons';
 
 interface ContractorLink {
   title: string;
@@ -48,16 +49,15 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
   const newTitle = 'Need pro help with JSON Schema?';
 
   return (
-    <SectionContext.Provider value='pro-help'>
+    <SectionContext.Provider value='docs'>
       <Head>
         <title>{newTitle}</title>
       </Head>
       <div
-        className='max-w-screen-xl block px-4 sm:px-6 lg:px-8 mt-12 mx-auto w-full'
+        className='max-w-screen-xl block lg:px-8 mx-auto w-full pt-0 mt-0'
         data-testid='pro-help'
       >
-        <br />
-        <div className='mt-6'>
+        <div>
           <Headline1>{newTitle}</Headline1>
           <p>
             Whether you need training, personalized advice, or custom JSON
@@ -208,6 +208,12 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
             <br />
           </div>
         </div>
+        <NextPrevButton
+          prevLabel='FAQ'
+          prevURL='/overview/faq'
+          nextLabel='Similar Technologies'
+          nextURL='/overview/similar-technologies'
+        />
         <DocsHelp />
       </div>
     </SectionContext.Provider>

--- a/pages/overview/similar-technologies.md
+++ b/pages/overview/similar-technologies.md
@@ -2,8 +2,8 @@
 section: docs
 title: Similar Technologies
 prev: 
-  label: FAQs
-  url: '/overview/faq'
+  label: Pro Help
+  url: '/overview/pro-help'
 next: 
   label: Code of Conduct
   url: '/overview/code-of-conduct'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

1.  Pro Help Page Sidebar and Navigation Buttons:
- Added "Go Back" and "Up Next" buttons to the Pro Help page for consistent 
- Aligned the sidebar to match the logical flow of pages: Case Studies → FAQ → Pro Help → Similar 
- Fixed layout misalignment issues on the top and left of the Pro Help page.
2. Arrow Navigation Updates Across Pages
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1291 


**Screenshots/videos:**

[Screencast from 2025-01-14 13-31-31.webm](https://github.com/user-attachments/assets/0676c54c-a336-4c44-8229-111ea2072204)
<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
No

<!--Add link to it-->

**Summary**

#1291  - Fixes Pro Help page sidebar alignment, adds navigation buttons, and standardizes arrow navigation across pages.

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
