### PR TITLE
Bug: #1281 fixed, [Dark/Light Mode Toggle Doesn't Close Automatically on Mobile]

### DIFF
--- a/components/DarkModeToggle.tsx
+++ b/components/DarkModeToggle.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import React from 'react';
 import Image from 'next/image';
 
@@ -46,8 +46,30 @@ export default function DarkModeToggle() {
     }
   }, [theme, resolvedTheme]);
 
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowSelect(false);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, []);
+
   return (
-    <div className='relative w-10 h-10 dark-mode-toggle-container'>
+    <div
+      ref={dropdownRef}
+      className='relative w-10 h-10 dark-mode-toggle-container'
+    >
       <button
         onClick={() => setShowSelect(!showSelect)}
         className='dark-mode-toggle rounded-md dark:hover:bg-gray-700 p-1.5 hover:bg-gray-100 transition duration-150 '

--- a/cypress/components/DarkModeToggle.cy.tsx
+++ b/cypress/components/DarkModeToggle.cy.tsx
@@ -68,6 +68,21 @@ describe('DarkModeToggle Component', () => {
     });
   });
 
+  // Test closing the menu when clicking outside
+  it('should close the menu when clicking outside', () => {
+    // Click on the toggle button to open the menu
+    cy.get(TOGGLE_BUTTON).click();
+
+    // Check if the menu is open
+    cy.get(THEME_DROPDOWN).should('have.css', 'display', 'block');
+
+    // Simulate clicking outside the dropdown
+    cy.get('body').click(0, 0); // Click at the top-left corner of the body
+
+    // Check if the menu is closed
+    cy.get(THEME_DROPDOWN).should('have.css', 'display', 'none');
+  });
+
   // Test Theme Selection Functionality
   describe('Theme Selection', () => {
     const themes = [


### PR DESCRIPTION
… on Mobile]


<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
bugfix: Fixes Dark/Light Mode Toggle Doesn't Close Automatically on Mobile. 

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Closes #1281
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1281 __ <!-- Replace ___ with the issue number this PR resolves -->
-  Related to #___ <!-- Use when the PR doesn't completely resolve an issue -->
-  Others? <!-- Add any additional notes or references here -->


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->
Here is a screen recording 

https://github.com/user-attachments/assets/5d2220c6-f67a-4773-ae4e-747fe7861627

**If relevant, did you update the documentation?**
No documentation change
<!--Add link to it-->

**Summary**
Before:
If user interacts outside of the toggle menu on mobile devices then the theme toggle menu was staying there .

After:
Now it will close the theme toggle menu when user interacts with other page items on mobile devices

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No Breaiking Changes

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
