### PR TITLE
fix: prev/next button background contrast improved and responsiveness added

### DIFF
--- a/components/NavigationButtons.tsx
+++ b/components/NavigationButtons.tsx
@@ -37,8 +37,8 @@ export default function NextPrevButton({
       {prevURL && prevLabel ? (
         <div className='h-auto w-1/2'>
           <div
-            className='cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:hover:shadow-2xl dark:drop-shadow-lg 
-          lg:text-left'
+            className='cursor-pointer rounded border border-gray-200 bg-slate-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-500 hover:shadow-xl dark:bg-slate-900 dark:shadow-xl dark:hover:shadow-2xl dark:drop-shadow-lg 
+          sm:text-left'
           >
             <Link href={prevURL}>
               <div className='text-primary dark:text-slate-300 flex flex-row gap-5 text-[18px]'>
@@ -65,9 +65,9 @@ export default function NextPrevButton({
 
       {nextURL && nextLabel ? (
         <div className='h-auto w-1/2'>
-          <div className='h-full cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:drop-shadow-lg dark:hover:shadow-2xl lg:text-right'>
+          <div className='h-full cursor-pointer rounded border border-gray-200 bg-slate-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-500 hover:shadow-xl dark:bg-slate-900 dark:shadow-xl dark:drop-shadow-lg dark:hover:shadow-2xl sm:text-right'>
             <Link href={nextURL}>
-              <div className='text-primary  dark:text-slate-300 flex flex-row-reverse gap-5 text-[18px]'>
+              <div className='text-primary dark:text-slate-300 flex flex-row-reverse gap-5 text-[18px]'>
                 <Image
                   src={'/icons/arrow.svg'}
                   height={10}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: improved the background color of prev/next button for better visibility and fixed the responsiveness in different size of screen

**Issue Number:**

-  Closes #1292 

**Screenshots/videos:**

[Screencast from 2025-01-20 12-50-32.webm](https://github.com/user-attachments/assets/eade520f-b22b-4374-a8c7-3fe9aa53ef8d)

![Screenshot from 2025-01-20 12-53-28](https://github.com/user-attachments/assets/b03e530b-c227-445f-88da-97b347a55b8b)


**If relevant, did you update the documentation?**

No

**Summary**

#1292 - This PR resolves the issue of bad background contrast in prev/next button and improved the visibility of the botton and also fixed the responsiveness of the botton.

**Does this PR introduce a breaking change?**

No
