### PR TITLE
docs: fix Scehma/Schema typo for Next button label on json-schema-exa…

### DIFF
--- a/pages/learn/json-schema-examples.md
+++ b/pages/learn/json-schema-examples.md
@@ -5,7 +5,7 @@ prev:
   label: Modeling a file system
   url: /learn/file-system
 next: 
-  label: JSON Scehma Glossary
+  label: JSON Schema Glossary
   url: /learn/glossary
 ---
 


### PR DESCRIPTION
…mples page

A small typo made its way to the website in commit 72ae16842af8 ("Added navigation buttons in other sections of website (#1218)"), let's fix that mistake.

Fixes: 72ae16842af8 ("Added navigation buttons in other sections of website (#1218)")


**What kind of change does this PR introduce?**

Fixes a typo.

**Issue Number:**
Do I really need to open an issue for just this typo?

**Screenshots/videos:**

https://json-schema.org/learn/json-schema-examples

**If relevant, did you update the documentation?**

Only doc was changed.

**Summary**

Fixing typo, see https://json-schema.org/learn/json-schema-examples, bottom right for the next chapter: JSON Scehma Glossary.

**Does this PR introduce a breaking change?**

No?

Cc @json-schema-org/docs-team
