### PR TITLE
Fix - fix markdown render in tools page

### DIFF
--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -8,7 +8,7 @@ import toTitleCase from '../lib/toTitleCase';
 import Link from 'next/link';
 import Image from 'next/image';
 import Tag from './ui/Tag';
-import Markdown from 'markdown-to-jsx';
+import StyledMarkdown from '~/components/StyledMarkdown';
 
 export default function ToolingDetailModal({
   tool,
@@ -134,9 +134,7 @@ export default function ToolingDetailModal({
             {tool.toolingListingNotes && (
               <div className='break-inside-avoid mb-4'>
                 <h3 className='text-lg font-semibold'>Tooling Listing Notes</h3>
-                <div className='prose dark:prose-invert'>
-                  <Markdown>{tool.toolingListingNotes}</Markdown>
-                </div>
+                <StyledMarkdown markdown={tool.toolingListingNotes} />
               </div>
             )}
 

--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -8,6 +8,7 @@ import toTitleCase from '../lib/toTitleCase';
 import Link from 'next/link';
 import Image from 'next/image';
 import Tag from './ui/Tag';
+import Markdown from 'markdown-to-jsx';
 
 export default function ToolingDetailModal({
   tool,
@@ -133,7 +134,9 @@ export default function ToolingDetailModal({
             {tool.toolingListingNotes && (
               <div className='break-inside-avoid mb-4'>
                 <h3 className='text-lg font-semibold'>Tooling Listing Notes</h3>
-                <p>{tool.toolingListingNotes}</p>
+                <div className='prose dark:prose-invert'>
+                  <Markdown>{tool.toolingListingNotes}</Markdown>
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix: Ensures that tooling listing notes are processed as markdown.

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1346 

**Screenshots/videos:**

[<!--Add screenshots or videos wherever possible.-->](https://github.com/user-attachments/assets/756231e5-0d54-4ae5-8c30-725e54099c9e)

**If relevant, did you update the documentation?**

No

**Summary**

This PR addresses the issue where tooling listing notes were not being processed as markdown. The raw markdown text was displayed instead of rendering correctly. The issue occurred due to a missing markdown parser in the rendering pipeline for these notes. The changes fix that

**Does this PR introduce a breaking change?**

No