### PR TITLE
Bug : Fix dark page issue on pro help page

### DIFF
--- a/pages/pro-help/index.page.tsx
+++ b/pages/pro-help/index.page.tsx
@@ -98,7 +98,7 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
               >
                 <h1 className='text-xl mb-3 font-semibold'>
                   {contractor.name}
-                  <span className='ms-4 border border-gray-200 text-base uppercase bg-zinc-200 px-2 py-1 rounded'>
+                  <span className='ms-4 border border-gray-200 text-base uppercase bg-zinc-200 text-gray-800 px-2 py-1 rounded dark:border-gray-600 dark:bg-zinc-700 dark:text-gray-200'>
                     {contractor.type}
                   </span>
                 </h1>
@@ -135,15 +135,17 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                       href={`https://www.linkedin.com/in/${contractor.linkedin}`}
                       target='blank'
                     >
-                      <svg
+                     <svg
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox='0 0 448 512'
                         strokeWidth={1.5}
                         stroke='currentColor'
-                        className='w-5 inline-block me-1'
-                      >
-                        <path d='M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z' />
+                        fill='currentColor'
+                        className='w-5 inline-block me-1 text-gray-800 dark:text-white'
+>                       <path d='M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z' />
                       </svg>
+
+
                       <span className='max-sm:hidden'>
                         {`https://www.linkedin.com/in/${contractor.linkedin}`}
                       </span>
@@ -157,14 +159,14 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                       target='blank'
                     >
                       <svg
-                        xmlns='http://www.w3.org/2000/svg'
-                        viewBox='0 0 496 512'
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 496 512"
                         strokeWidth={1.5}
-                        stroke='currentColor'
-                        className='w-5 inline-block me-1'
-                      >
-                        <path d='M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z' />
+                        stroke="currentColor"
+                        className="w-5 inline-block me-1 fill-current text-gray-800 dark:text-gray-200"
+>                       <path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
                       </svg>
+
                       <span className='max-sm:hidden'>
                         {`https://github.com/${contractor.github}`}
                       </span>
@@ -180,7 +182,11 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                     />
                     <a
                       href={`mailto:${contractor.email}`}
-                      className='text-center mt-3 mb-2 block px-4 py-1 text-sm text-blue-700 font-semibold border border-blue-700 hover:text-white hover:bg-blue-700 hover:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-700 focus:ring-offset-2 max-sm:px-16'
+                      className='text-center mt-3 mb-2 block px-4 py-1 text-sm font-semibold border 
+                     border-blue-700 text-blue-700 bg-transparent hover:text-white hover:bg-blue-700 
+              hover:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-700 
+              focus:ring-offset-2 dark:text-white dark:border-white dark:hover:bg-white 
+              dark:hover:text-blue-700 max-sm:px-16'  
                     >
                       Reach out
                     </a>

--- a/pages/pro-help/index.page.tsx
+++ b/pages/pro-help/index.page.tsx
@@ -133,18 +133,18 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                     <a
                       className='text-sm underline me-8'
                       href={`https://www.linkedin.com/in/${contractor.linkedin}`}
-                      target='blank'>
-                     <svg
+                      target='blank'
+                    >
+                      <svg
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox='0 0 448 512'
                         strokeWidth={1.5}
                         stroke='currentColor'
                         fill='currentColor'
-                        className='w-5 inline-block me-1 text-gray-800 dark:text-white'>
+                        className='w-5 inline-block me-1 text-gray-800 dark:text-white'
+                      >
                         <path d='M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z' />
                       </svg>
-
-
                       <span className='max-sm:hidden'>
                         {`https://www.linkedin.com/in/${contractor.linkedin}`}
                       </span>
@@ -158,12 +158,13 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                       target='blank'
                     >
                       <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 496 512"
+                        xmlns='http://www.w3.org/2000/svg'
+                        viewBox='0 0 496 512'
                         strokeWidth={1.5}
-                        stroke="currentColor"
-                        className="w-5 inline-block me-1 fill-current text-gray-800 dark:text-gray-200"
->                       <path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z" />
+                        stroke='currentColor'
+                        className='w-5 inline-block me-1 fill-current text-gray-800 dark:text-gray-200'
+                      >                       
+                        <path d='M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z' />
                       </svg>
 
                       <span className='max-sm:hidden'>
@@ -182,10 +183,10 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                     <a
                       href={`mailto:${contractor.email}`}
                       className='text-center mt-3 mb-2 block px-4 py-1 text-sm font-semibold border 
-                     border-blue-700 text-blue-700 bg-transparent hover:text-white hover:bg-blue-700 
-              hover:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-700 
-              focus:ring-offset-2 dark:text-white dark:border-white dark:hover:bg-white 
-              dark:hover:text-blue-700 max-sm:px-16'  
+                      border-blue-700 text-blue-700 bg-transparent hover:text-white hover:bg-blue-700 
+                      hover:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-700 
+                      focus:ring-offset-2 dark:text-white dark:border-white dark:hover:bg-white 
+                      dark:hover:text-blue-700 max-sm:px-16' 
                     >
                       Reach out
                     </a>

--- a/pages/pro-help/index.page.tsx
+++ b/pages/pro-help/index.page.tsx
@@ -163,7 +163,7 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                         strokeWidth={1.5}
                         stroke='currentColor'
                         className='w-5 inline-block me-1 fill-current text-gray-800 dark:text-gray-200'
-                      >                       
+                      >
                         <path d='M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z' />
                       </svg>
 
@@ -183,10 +183,10 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                     <a
                       href={`mailto:${contractor.email}`}
                       className='text-center mt-3 mb-2 block px-4 py-1 text-sm font-semibold border 
-                      border-blue-700 text-blue-700 bg-transparent hover:text-white hover:bg-blue-700 
+                    border-blue-700 text-blue-700 bg-transparent hover:text-white hover:bg-blue-700 
                       hover:border-transparent focus:outline-none focus:ring-2 focus:ring-blue-700 
-                      focus:ring-offset-2 dark:text-white dark:border-white dark:hover:bg-white 
-                      dark:hover:text-blue-700 max-sm:px-16' 
+                      focus:ring-offset-2 dark:text-white dark:border-white dark:hover:bg-white
+                    dark:hover:text-blue-700 max-sm:px-16'
                     >
                       Reach out
                     </a>

--- a/pages/pro-help/index.page.tsx
+++ b/pages/pro-help/index.page.tsx
@@ -133,16 +133,15 @@ export default function ProHelp({ contractorData }: ProHelpPageProps) {
                     <a
                       className='text-sm underline me-8'
                       href={`https://www.linkedin.com/in/${contractor.linkedin}`}
-                      target='blank'
-                    >
+                      target='blank'>
                      <svg
                         xmlns='http://www.w3.org/2000/svg'
                         viewBox='0 0 448 512'
                         strokeWidth={1.5}
                         stroke='currentColor'
                         fill='currentColor'
-                        className='w-5 inline-block me-1 text-gray-800 dark:text-white'
->                       <path d='M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z' />
+                        className='w-5 inline-block me-1 text-gray-800 dark:text-white'>
+                        <path d='M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z' />
                       </svg>
 
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -295,7 +295,7 @@ border-radius: 4px; */
   border-radius: 8px;
 }
 .scrollbar-hidden {
-  scrollbar-width: none; 
+  scrollbar-width: none;
 }
 .scrollbar-hidden::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
Hello Maintainers,
I have fixed the issues outlined in #1289
Please review the changes and let me know if there are any adjustments required. I would greatly appreciate it if you could merge this pull request after review.
Thank you for your time and effort in maintaining this project!


**What kind of change does this PR introduce?**
   - Bugfix

**Issue Number:**
    -  Closes #1289


**Screenshots/videos:**

![Screenshot (114)](https://github.com/user-attachments/assets/33a6c576-af5e-4cb4-b485-e59420cf9b4a)

https://github.com/user-attachments/assets/8eae088a-de75-4490-99e3-7c84bc8e54f4


**If relevant, did you update the documentation?**

 - Not Applicable

**Summary**

  - Updated LinkedIn and GitHub icons to white for better visibility.
  - Changed the TSC label text color to a darker shade for proper contrast.
  - Enhanced the "Reach out" button to improve readability and visibility in dark mode.

**Does this PR introduce a breaking change?**

No
