### PR TITLE
feat[tools]: add micronaut json schema as tooling

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1285,6 +1285,21 @@
   source: 'https://github.com/Fatal1ty/mashumaro'
   lastUpdated: '2024-04-30'
 
+- name: Micronaut JSON Schema
+  description: 'Generates JSON Schema from Java classes, supporting the Micronaut framework.'
+  toolingTypes: ['code-to-schema']
+  languages: ['Java']
+  maintainers:
+    - name: 'Micronaut Team'
+      username: 'micronaut-projects'
+      platform: 'github'
+  license: 'Apache-2.0'
+  source: 'https://github.com/micronaut-projects/micronaut-json-schema'
+  homepage: 'https://micronaut.io'
+  supportedDialects:
+    draft: ['2020-12']
+  lastUpdated: '2025-01-22'
+
 - name: drf-jsonschema-serializer
   description: 'drf-jsonschema-serializer generates schemas from Django Rest Framework serializers.'
   toolingTypes: ['code-to-schema']

--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1290,8 +1290,14 @@
   toolingTypes: ['code-to-schema']
   languages: ['Java']
   maintainers:
-    - name: 'Micronaut Team'
-      username: 'micronaut-projects'
+    - name: 'Elif Kurtay'
+      username: 'elifKurtay'
+      platform: 'github'
+    - name: 'Sergio del Amo'
+      username: 'sdelamo'
+      platform: 'github'
+    - name: 'Andriy Dmytruk'
+      username: 'andriy-dmytruk'
       platform: 'github'
   license: 'Apache-2.0'
   source: 'https://github.com/micronaut-projects/micronaut-json-schema'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR adds a new tool, micronaut-json-schema, to the JSON Schema Ecosystem page.

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #993 


**Screenshots/videos:**

[Screencast from 2025-01-22 14-20-26.webm](https://github.com/user-attachments/assets/6eab7966-9418-4ae0-a3be-86b537be1c02)

![image](https://github.com/user-attachments/assets/a0a52330-9eb9-4cb8-83e3-26a890222bf6)


**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

This PR adds the micronaut-json-schema tool to the JSON Schema ecosystem. The tool generates JSON Schema from Java classes and is part of the Micronaut framework. It supports the 2020-12 JSON Schema dialect and is categorized as a code-to-schema tool.

Details added to the YAML file include:
1. Tool name and description
2. Supported language (Java)
3. Tooling type (code-to-schema)
4. Maintainers (Micronaut Team)
5. License (Apache-2.0)
6. Source repository URL
7. Homepage URL
8. Supported JSON Schema dialects (2020-12)
9. Last updated date



**Does this PR introduce a breaking change?**

No