### PR TITLE
Change cypress-ajv-schema-validator from Javascript to JavaScript

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1472,7 +1472,7 @@
 - name: cypress-ajv-schema-validator
   description: 'Cypress plugin that validates API responses against Plain JSON schemas, and whole Swagger and OpenAPI documents using the Ajv JSON Schema validator. It provides a user-friendly view of validated data, highlighting each validation error and the exact reason for the mismatch. Seamless integration, fast and lightweight.'
   toolingTypes: ['validator', 'util-testing']
-  languages: ['Javascript']
+  languages: ['JavaScript']
   maintainers:
     - name: 'Sebastian Clavijo Suero'
       username: 'sclavijosuero'


### PR DESCRIPTION
Currently on the page the cypress-ajv-schema-validator is the only one that writes it Java**s**cript instead of Java**S**cript. Which means it ends up with it's own entry on:

https://json-schema.org/tools?query=&sortBy=name&sortOrder=ascending&groupBy=languages&licenses=&languages=&drafts=&toolingTypes=&environments=&showObsolete=false#javascript while also breaking the anchor link (since that one is 100% case insensitive).