### PR TITLE
side bar drop down fix

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -269,6 +269,12 @@ export const DocsNav = ({
   });
   useEffect(() => {
     const pathWtihoutFragment = extractPathWithoutFragment(router.asPath);
+    setActive({
+      getDocs: false,
+      getStarted: false,
+      getReference: false,
+      getSpecification: false,
+    });
     if (getDocsPath.includes(pathWtihoutFragment)) {
       setActive({ ...active, getDocs: true });
     } else if (getStartedPath.includes(pathWtihoutFragment)) {
@@ -279,7 +285,7 @@ export const DocsNav = ({
       setActive({ ...active, getSpecification: true });
     }
   }, [router.asPath]);
-
+ 
   const handleClickDoc = () => {
     setActive({ ...active, getDocs: !active.getDocs });
   };


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
# Bug Fix: Sidebar Dropdown for Specification Tab

## Overview
This fix addresses a bug in the sidebar dropdown functionality for the specification tab. Previously, the dropdown would automatically open when the URL matched but would not close when the URL or active tab changed. This led to inconsistent behavior and a suboptimal user experience.

---


**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1355 



**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

https://github.com/user-attachments/assets/2b66ba6f-78ea-4345-8c27-4614a884015b


**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
- None. This fix maintains backward compatibility.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
