### PR TITLE
Made the blog images and description uniform in height

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -251,10 +251,12 @@ export default function StaticMarkdownPage({
                       href={`/blog/posts/${blogPost.slug}`}
                       className='inline-flex flex-col flex-1 w-full'
                     >
+			    <div className=' h-max-[200px] w-full  object-cover'>
                       <div
                         className='bg-slate-50 h-[160px] w-full self-stretch mr-3 bg-cover bg-center'
                         style={{ backgroundImage: `url(${frontmatter.cover})` }}
                       />
+			    </div>
                       <div className=' p-4 flex flex-col flex-1 justify-between'>
                         <div>
                           <div>
@@ -277,7 +279,7 @@ export default function StaticMarkdownPage({
                               {frontmatter.type || 'Unknown Type'}
                             </div>
                           </div>
-                          <div className='text-lg font-semibold'>
+                          <div className='text-lg h-[80px] font-semibold'>
                             {frontmatter.title}
                           </div>
 

--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -246,7 +246,7 @@ export default function StaticMarkdownPage({
 
               return (
                 <section key={blogPost.slug}>
-                  <div className='h-[498px] flex border rounded-lg shadow-sm hover:shadow-lg transition-all overflow-hidden dark:border-slate-500'>
+                  <div className='h-[510px] flex border rounded-lg shadow-sm hover:shadow-lg transition-all overflow-hidden dark:border-slate-500'>
                     <Link
                       href={`/blog/posts/${blogPost.slug}`}
                       className='inline-flex flex-col flex-1 w-full'


### PR DESCRIPTION

**Bugfix**


**#1434:**

-  Closes #1434 



**Screenshots/videos:**
<img width="1470" alt="Screenshot of localhost" src="https://github.com/user-attachments/assets/ce80b52e-1984-456a-a9fc-d381f8ac3f87" />

https://github.com/user-attachments/assets/6c55d83b-54e6-4a5a-a383-8a04eba4e280




**Summary**

In this PR as per the requirement of the issue #1434 the size of all the images in the Blog page is made uniform.
I have added a max height if 200px on a div and wrapped the image inside the div. 
To accommodate the  change  I have to make the overall blog card a little bigger that is 498px -> 510px.
added a height of 80px to title of the blog by which we have achieved the uniformness in the description of the blogs.


**Does this PR introduce a breaking change?**
The PR increases the overall UI much better and due to which the user experience  becomes better.
