### PR TITLE
Annotation link fix

### DIFF
--- a/pages/understanding-json-schema/reference/metadata.md
+++ b/pages/understanding-json-schema/reference/metadata.md
@@ -6,7 +6,7 @@ prev:
   url: /understanding-json-schema/reference/const
 next: 
   label: Annotations
-  url: http://localhost:3000/understanding-json-schema/reference/annotations
+  url: /understanding-json-schema/reference/annotations
 ---
 
 Annotations and comments are not directly related to the core structure and constraints of the JSON Schema itself. As such, keywords for annotations and comments are not required, however, using them can improve the maintainability of your schemas.  


### PR DESCRIPTION
**What kind of change does this PR introduce?**

"Up Next" card under the link - https://json-schema.org/understanding-json-schema/reference/metadata has reference to annotations link pointing to local URL reference. Removed and made it as relative URL just like the 'comments'

**Screenshot:**

<img width="473" alt="image" src="https://github.com/user-attachments/assets/f624f37e-d4ee-4ada-81fd-a113f840ea37" />
