### PR TITLE
fix: arrow svg compatible with dark mode and responsiveness of text

### DIFF
--- a/components/NavigationButtons.tsx
+++ b/components/NavigationButtons.tsx
@@ -33,60 +33,59 @@ export default function NextPrevButton({
   nextURL,
 }: any) {
   return (
-    <div className='mb-4 flex flex-row gap-4'>
+    <div className='mb-4 flex flex-wrap gap-4 sm:flex-nowrap'>
       {prevURL && prevLabel ? (
-        <div className='h-auto w-1/2'>
+        <div className='w-full sm:w-1/2'>
           <div
             className='cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:hover:shadow-2xl dark:drop-shadow-lg 
-          sm:text-left'
+            flex flex-col items-center sm:items-start'
           >
-            <Link href={prevURL}>
-              <div className='text-primary dark:text-slate-300 flex flex-row gap-5 text-[18px]'>
+            <Link href={prevURL} className='w-full'>
+              <div className='flex flex-row gap-3 items-center text-[16px] sm:text-[18px] text-primary dark:text-slate-300'>
                 <Image
                   src={'/icons/arrow.svg'}
-                  height={10}
-                  width={10}
+                  height={12}
+                  width={12}
                   alt='prev icon'
-                  className='rotate-180 w-5 '
+                  className='rotate-180 w-5'
                 />
-                <div className='my-auto inline font-bold uppercase'>
-                  Go Back
-                </div>
+                <div className='font-bold uppercase'>Go Back</div>
               </div>
-              <div className='my-2 text-base font-medium text-slate-600 dark:text-slate-300'>
+              <div className='mt-2 text-sm sm:text-base font-medium text-slate-600 dark:text-slate-300'>
                 {prevLabel}
               </div>
             </Link>
           </div>
         </div>
       ) : (
-        <div className='h-auto w-1/2'></div>
+        <div className='hidden sm:block w-1/2'></div>
       )}
 
       {nextURL && nextLabel ? (
-        <div className='h-auto w-1/2'>
-          <div className='h-full cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:drop-shadow-lg dark:hover:shadow-2xl sm:text-right'>
-            <Link href={nextURL}>
-              <div className='text-primary  dark:text-slate-300 flex flex-row-reverse gap-5 text-[18px]'>
+        <div className='w-full sm:w-1/2'>
+          <div
+            className='cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:drop-shadow-lg dark:hover:shadow-2xl 
+            flex flex-col items-center sm:items-end'
+          >
+            <Link href={nextURL} className='w-full'>
+              <div className='flex flex-row-reverse gap-3 items-center text-[16px] sm:text-[18px] text-primary dark:text-slate-300'>
                 <Image
                   src={'/icons/arrow.svg'}
-                  height={10}
-                  width={10}
-                  alt='next icon '
+                  height={12}
+                  width={12}
+                  alt='next icon'
                   className='w-5'
                 />
-                <div className='my-auto inline font-bold uppercase '>
-                  Up Next
-                </div>
+                <div className='font-bold uppercase'>Up Next</div>
               </div>
-              <div className='my-2 text-base font-medium text-slate-600 dark:text-slate-300'>
+              <div className='mt-2 text-sm sm:text-base font-medium text-slate-600 dark:text-slate-300'>
                 {nextLabel}
               </div>
             </Link>
           </div>
         </div>
       ) : (
-        <div className='h-auto w-1/2'></div>
+        <div className='hidden sm:block w-1/2'></div>
       )}
     </div>
   );

--- a/components/NavigationButtons.tsx
+++ b/components/NavigationButtons.tsx
@@ -38,7 +38,7 @@ export default function NextPrevButton({
         <div className='h-auto w-1/2'>
           <div
             className='cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:hover:shadow-2xl dark:drop-shadow-lg 
-          lg:text-left'
+          sm:text-left'
           >
             <Link href={prevURL}>
               <div className='text-primary dark:text-slate-300 flex flex-row gap-5 text-[18px]'>
@@ -65,7 +65,7 @@ export default function NextPrevButton({
 
       {nextURL && nextLabel ? (
         <div className='h-auto w-1/2'>
-          <div className='h-full cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:drop-shadow-lg dark:hover:shadow-2xl lg:text-right'>
+          <div className='h-full cursor-pointer rounded border border-gray-200 p-4 text-center shadow-md transition-all duration-300 ease-in-out hover:border-gray-300 hover:shadow-lg dark:shadow-xl dark:drop-shadow-lg dark:hover:shadow-2xl sm:text-right'>
             <Link href={nextURL}>
               <div className='text-primary  dark:text-slate-300 flex flex-row-reverse gap-5 text-[18px]'>
                 <Image

--- a/public/icons/arrow.svg
+++ b/public/icons/arrow.svg
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M6 12H18M18 12L13 7M18 12L13 17" stroke="#002cc4" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<svg
+  width="800px"
+  height="800px"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M6 12H18M18 12L13 7M18 12L13 17"
+    stroke="#2563EB"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
 </svg>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

- Improved the color contrast of arrows in "Go Back" and "Up Next" buttons in dark mode. (used #2563EB for Arrow svg i.e color used for hyperlinks across the website)
- Ensured consistent vertical stacking and alignment of text and arrows across screen sizes.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1292

**Screenshots/videos:**

![Screenshot from 2025-03-06 04-55-00](https://github.com/user-attachments/assets/f33c4e5f-1826-4cd1-8645-2f2fcca84db6)


<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

No
<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
