### PR TITLE
closes Bug: Annotation card link broken 

### DIFF
--- a/pages/understanding-json-schema/reference/metadata.md
+++ b/pages/understanding-json-schema/reference/metadata.md
@@ -6,7 +6,7 @@ prev:
   url: /understanding-json-schema/reference/const
 next: 
   label: Annotations
-  url: /understanding-json-schema/reference/annotations
+  url: http://localhost:3000/understanding-json-schema/reference/annotations
 ---
 
 Annotations and comments are not directly related to the core structure and constraints of the JSON Schema itself. As such, keywords for annotations and comments are not required, however, using them can improve the maintainability of your schemas.  

--- a/pages/understanding-json-schema/reference/metadata.md
+++ b/pages/understanding-json-schema/reference/metadata.md
@@ -6,7 +6,7 @@ prev:
   url: /understanding-json-schema/reference/const
 next: 
   label: Annotations
-  url: http://localhost:3000/understanding-json-schema/reference/annotations
+  url: /understanding-json-schema/reference/annotations
 ---
 
 Annotations and comments are not directly related to the core structure and constraints of the JSON Schema itself. As such, keywords for annotations and comments are not required, however, using them can improve the maintainability of your schemas.  


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bug fix

**Issue Number:**

-  Closes #1459


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

Not needed

**Summary**

This PR fixes an incorrect local URL  `http://localhost:3000//understanding-json-schema/reference/annotations` 
replacing it with the correct relative path `/understanding-json-schema/reference/annotations`.
in `metadata.md`

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
