### PR TITLE
update validate-tooling-data for eliminate case insensitive languages

### DIFF
--- a/.github/workflows/validate-tooling-data.yml
+++ b/.github/workflows/validate-tooling-data.yml
@@ -47,6 +47,49 @@ jobs:
             const data = yaml.load(fs.readFileSync(dataPath, 'utf-8'));
             const ajv = new Ajv({ allErrors: true });
             addFormats(ajv);
+
+            ajv.addKeyword({
+              keyword: 'caseInsensitiveUnique',
+              type: 'array',
+              validate: function (schema, data) {
+                if (!Array.isArray(data)) return false;
+                
+                const languagesSet = new Set();
+                const languagesLowercaseSet = new Set();
+                data.forEach((tool) => {
+                  if (tool.languages) {
+                    tool.languages.forEach((language) => {
+                      languagesSet.add(language);
+                      languagesLowercaseSet.add(language.toLowerCase());
+                    });
+                  }
+                });
+                if (languagesSet.size !== languagesLowercaseSet.size) {
+                  console.error('Duplicate languages found');
+                  const lowercaseMap = new Map();
+                  languagesSet.forEach((language) => {
+                    lowercaseMap.set(
+                      language.toLowerCase(), 
+                      (lowercaseMap.get(language.toLowerCase()) || 0) + 1
+                    );
+                  });
+                  
+                  lowercaseMap.forEach((value, key) => {
+                    if (value > 1) {
+                      console.log('Duplicate found for:', key);
+                    }
+                  });
+                  validate.errors = [{
+                    keyword: 'caseInsensitiveUnique',
+                    message: 'array contains case-insensitive duplicates',
+                    params: { keyword: 'caseInsensitiveUnique' }
+                  }];
+                  return false;
+                }
+                return true;
+              }
+            });
+
             const validate = ajv.compile(schema);
             const valid = validate(data);
             if (!valid) {

--- a/data/tooling-data.schema.json
+++ b/data/tooling-data.schema.json
@@ -88,6 +88,7 @@
       "languages": {
         "description": "The language or languages a tool is built in. In the case of a validator, this will likely be the language it is written in. In the case of a conversion or transformation tool, these are the languages that are supported in some capacity.",
         "type": "array",
+        "caseInsensitiveUnique": true,
         "items": {
           "description": "Individual language name, from the list unless not included.",
           "type": "string",


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Feature - Adds case-insensitive unique validation for language entries
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1443  <!-- Replace ___ with the issue number this PR resolves -->
-  Related to #___ <!-- Use when the PR doesn't completely resolve an issue -->
-  Others? <!-- Add any additional notes or references here -->


**Screenshots/videos:**
Forcefully made mistakes in the name of language,
![image](https://github.com/user-attachments/assets/ef58b8aa-2c03-4a14-823f-1f612abb363d)

Validator finds the mistake,
![image](https://github.com/user-attachments/assets/99150093-dd07-4efb-9399-3adf9ddf244a)

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**
This PR introduces case-insensitive unique validation for language entries in the tooling data to solve several existing problems:
1. Inconsistent language casing across tools (e.g., "JavaScript" vs "javascript" vs "JAVASCRIPT")
2. Potential confusion for users seeing the same language listed multiple times

My solution:
Implements a custom AJV keyword `caseInsensitiveUnique` that:
- Detects and reports case-insensitive duplicates using set
- Provides clear error messages for easy fixes
```
           ajv.addKeyword({
              keyword: 'caseInsensitiveUnique',
              type: 'array',
              validate: function (schema, data) {
                if (!Array.isArray(data)) return false;
                
                const languagesSet = new Set();
                const languagesLowercaseSet = new Set();
                data.forEach((tool) => {
                  if (tool.languages) {
                    tool.languages.forEach((language) => {
                      languagesSet.add(language);
                      languagesLowercaseSet.add(language.toLowerCase());
                    });
                  }
                });
                if (languagesSet.size !== languagesLowercaseSet.size) {
                  console.error('Duplicate languages found');
                  const lowercaseMap = new Map();
                  languagesSet.forEach((language) => {
                    lowercaseMap.set(
                      language.toLowerCase(), 
                      (lowercaseMap.get(language.toLowerCase()) || 0) + 1
                    );
                  });
                  
                  lowercaseMap.forEach((value, key) => {
                    if (value > 1) {
                      console.log('Duplicate found for:', key);
                    }
                  });
                  validate.errors = [{
                    keyword: 'caseInsensitiveUnique',
                    message: 'array contains case-insensitive duplicates',
                    params: { keyword: 'caseInsensitiveUnique' }
                  }];
                  return false;
                }
                return true;
              }
            });
```
 
<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**  
✅ **Yes**

**Impact:**  
This PR enforces **case-insensitive uniqueness** for language entries. Any existing tooling data that includes language names with inconsistent casing—such as `"JavaScript"` and `"javascript"`—will now **fail validation**. This change helps eliminate redundancy and confusion caused by duplicate entries with different letter cases.

**Who is affected:**  
Tool maintainers and contributors who have added language entries with varying casing.

**Migration Path:**  
Update your `languages` arrays to ensure that each language appears only once in a consistent format, preferably matching the casing defined in the schema enum. For example:

```yaml
# ❌ Before
languages:
  - "JavaScript"
  - "javascript"
  - "Go"
  - "go"

# ✅ After
languages:
  - "JavaScript"
  - "Go"
