### PR TITLE
adjusting the link in ambassador page

### DIFF
--- a/components/AmbassadorsBanner.tsx
+++ b/components/AmbassadorsBanner.tsx
@@ -15,7 +15,7 @@ const AmbassadorBanner: React.FC = () => {
         </p>
         <div className='w-full grid grid-cols-1 sm:grid-cols-2 gap-4 my-4 mx-auto'>
           <Link
-            href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors#become-an-json-schema-ambassador'
+            href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors#become-a-json-schema-ambassador'
             className='inline-block px-6 py-3 bg-blue-600 text-white font-semibold text-center rounded hover:bg-blue-700 transition duration-300'
           >
             Become Ambassador


### PR DESCRIPTION


**What kind of change does this PR introduce?**

bugfix

**Issue Number:**
Closes #1524 

**Summary**

This PR fixes the issue on the Ambassadors page where the link at the bottom of the page incorrectly leads to the wrong section. The URL currently contains `#become-an-json-schema-ambassador`, but it should be `#become-a-json-schema-ambassador`. This update ensures the link navigates to the correct section when clicked.

**Does this PR introduce a breaking change?**

no

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x ] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).