### PR TITLE
[Fixed]: Navbar Active State Not Highlighting Docs and Specification related pages 

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -137,7 +137,10 @@ const MainNavLink = ({
   className?: string;
 }) => {
   const router = useRouter();
-  const isActiveNav = router.asPath.startsWith(uri);
+  const isActiveNav =
+    router.asPath.startsWith(uri) ||
+    (uri === '/docs' && router.asPath.startsWith('/overview')) ||
+    (uri === '/specification' && router.asPath.startsWith('/draft'));
 
   return (
     <Link


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bugfix for  Navbar Active State Not Highlighting Docs and Specification on related pages 

**Issue Number:**

- 🐛[Bug: Navbar Active State Not Highlighting "Docs" and "Specification" on Related Pages #1535](https://github.com/json-schema-org/website/issues/1535)


**Screenshots**
![image](https://github.com/user-attachments/assets/9dfdaca3-66a0-43ac-9573-19f70d7e6f18)
![image](https://github.com/user-attachments/assets/327e5ec1-90d5-408b-b23f-72719843a525)
![image](https://github.com/user-attachments/assets/fd00ad40-a988-44c1-ab17-a2016acf9567)


**If relevant, did you update the documentation?**
N/A

**Summary**
- This PR fixes an issue where the navbar links for "Docs" and "Specification" were not highlighted as active when visiting related subpages. 
- Previously, the `isActive` condition only checked if the `router.asPath` started with `/docs` or `/specification`, which did not account for related subpages like `/overview/...` or `/draft/....`
**Changes Made**
- Updated the `isActiveNav` condition to include related `subpaths`:
    - Docs: Now considers `/overview/...` as part of the "Docs" section.
    - Specification: Now includes `/draft/...`  as part of the "Specification" section.

**Does this PR introduce a breaking change?**
No