### PR TITLE
fix: keep overview section open when user click on pro-help in docs

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -111,6 +111,7 @@ const getDocsPath = [
   '/overview/code-of-conduct',
   '/overview/faq',
   '/overview/roadmap',
+  '/overview/pro-help'
 ];
 const getStartedPath = [
   '/learn',

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -111,7 +111,7 @@ const getDocsPath = [
   '/overview/code-of-conduct',
   '/overview/faq',
   '/overview/roadmap',
-  '/overview/pro-help'
+  '/overview/pro-help',
 ];
 const getStartedPath = [
   '/learn',


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Keep overview section open when user click on pro-help in docs.

**Issue Number:**
-  Closes #1416

**Screenshots/videos:**
![image](https://github.com/user-attachments/assets/53c3f3cc-eb1c-4ca2-a93c-b59f57c3c0ad)


**If relevant, did you update the documentation?**
No

**Summary**
Keep overview section open when user click on pro-help in docs just like all other links in docs

**Does this PR introduce a breaking change?**
No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [ y ] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).