### PR TITLE
fix: add missing space in sponsor section

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -582,7 +582,7 @@ const Home = (props: any) => {
                 className='border-b border-black dark:border-white'
               >
                 sponsor
-              </a>
+              </a>{' '}
               or a{' '}
               <a
                 href='https://json-schema.org/overview/sponsors#benefits-of-being-an-individual-backer'
@@ -592,6 +592,7 @@ const Home = (props: any) => {
               </a>{' '}
               .
             </p>
+
             <p className='w-5/6 lg:w-3/5 mx-auto'>
               <a
                 href='https://opencollective.com/json-schema'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR fixes a minor spacing issue in the sponsor section text. Previously, the text appeared as "sponsoror a" due to a missing space after the sponsor link. 

### Fix:
- Added a space after the `</a>` tag to correctly separate the words.

This is a minor text fix to improve readability. 🚀

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1553  <!-- Replace ___ with the issue number this PR resolves -->





**Does this PR introduce a breaking change?**
NO
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).