### PR TITLE
Fix chevron toggle in Guides section of Sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -357,6 +357,7 @@ export const DocsNav = ({
   const rotateG = active.getStarted ? 'rotate(180deg)' : 'rotate(0)';
   const rotateR = active.getReference ? 'rotate(180deg)' : 'rotate(0)';
   const rotateSpec = active.getSpecification ? 'rotate(180deg)' : 'rotate(0)';
+  const rotateGuides = active.getGuides ? 'rotate(180deg)' : 'rotate(0)';
 
   const { resolvedTheme } = useTheme();
 
@@ -590,7 +591,7 @@ export const DocsNav = ({
           </div>
           <svg
             style={{
-              transform: rotateG,
+              transform: rotateGuides,
               transition: 'all 0.2s linear',
               cursor: 'pointer',
             }}


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
bugfix : This PR fixes the toggle of Chevron in guides section of sidebar
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1559  <!-- Replace ___ with the issue number this PR resolves -->

**Screenshots/videos:**

https://github.com/user-attachments/assets/99ddc748-0851-419b-b0e8-3b980a63aaa4


<!--Add screenshots or videos wherever possible.-->

<!--Add link to it-->

**Summary**
This PR confirms that chevrons in guides section of sidebar gets perfectly toggled on click.
<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).