### PR TITLE
fix: improve the readablity of text in Boolean reference page

### DIFF
--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -417,7 +417,7 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
                         {label}
                       </div>
                     )}
-                    <div className='flex flex-row items-center mb-6 bg-amber-50 px-6 py-4 border border-amber-100 rounded text-slate-600 leading-7'>
+                    <div className='flex flex-row items-center mb-6 bg-amber-100 px-6 py-4 border border-amber-100 rounded text-slate-500 leading-7'>
                       <Image
                         src='/icons/info-yellow.svg'
                         className='h-7 w-7 mr-3'


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Improve the readablity of text in [Boolean reference page](https://json-schema.org/understanding-json-schema/reference/combining).

**Issue Number:**
Closes #1564 


**Screenshots/videos:**

![image](https://github.com/user-attachments/assets/d14137f6-2038-4a79-a318-c930010fc14e)


**If relevant, did you update the documentation?**
No


**Does this PR introduce a breaking change?**
No

# Checklist

- [ y ] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).