### PR TITLE
Filter for tools supporting bowtie

### DIFF
--- a/pages/tools/components/Sidebar.tsx
+++ b/pages/tools/components/Sidebar.tsx
@@ -70,6 +70,10 @@ export default function Sidebar({
           (formData.get('showObsolete') as string) === 'showObsolete'
             ? 'true'
             : 'false',
+        supportsBowtie:
+          (formData.get('supportsBowtie') as string) === 'supportsBowtie'
+            ? 'true'
+            : 'false',
       } satisfies Transform;
       postAnalytics({ eventType: 'query', eventPayload: newTransform });
       return newTransform;
@@ -123,7 +127,12 @@ export default function Sidebar({
           name='showObsolete'
           checked={transform['showObsolete'] === 'true'}
         />
-
+        <Checkbox
+          label='Support Bowtie'
+          value='supportsBowtie'
+          name='supportsBowtie'
+          checked={transform['supportsBowtie'] === 'true'}
+        />
         <div className='w-full flex items-center justify-between mt-4 gap-2'>
           <button
             type='submit'

--- a/pages/tools/hooks/useToolsTransform.tsx
+++ b/pages/tools/hooks/useToolsTransform.tsx
@@ -16,6 +16,7 @@ export interface Transform {
   toolingTypes: string[];
   environments: string[];
   showObsolete: 'true' | 'false';
+  supportsBowtie: 'true' | 'false';
 }
 
 export type TransformUpdate =
@@ -38,6 +39,7 @@ const buildQueryString = (transform: Transform) => {
     toolingTypes: transform.toolingTypes.join(','),
     environments: transform.environments.join(','),
     showObsolete: transform.showObsolete,
+    supportsBowtie: transform.supportsBowtie,
   }).toString();
 };
 
@@ -56,6 +58,7 @@ export default function useToolsTransform(tools: JSONSchemaTool[]) {
     toolingTypes: [],
     environments: [],
     showObsolete: 'false',
+    supportsBowtie: 'false',
   });
 
   useEffect(() => {
@@ -89,6 +92,8 @@ export default function useToolsTransform(tools: JSONSchemaTool[]) {
       ) as Transform['environments'],
       showObsolete:
         (query.showObsolete as Transform['showObsolete']) || 'false',
+      supportsBowtie:
+        (query.supportsBowtie as Transform['supportsBowtie']) || 'false',
     } satisfies Transform;
 
     const queryString = buildQueryString(updatedTransform);
@@ -137,6 +142,7 @@ export default function useToolsTransform(tools: JSONSchemaTool[]) {
       toolingTypes: [],
       environments: [],
       showObsolete: 'false',
+      supportsBowtie: 'false',
     };
 
     const queryString = buildQueryString(initialTransform);
@@ -193,6 +199,9 @@ const filterTools = (
   transform: Transform,
 ): JSONSchemaTool[] => {
   const filteredTools = tools.filter((tool) => {
+    if (transform.supportsBowtie === 'true' && !tool.bowtie?.id) {
+      return false;
+    }
     if (transform.showObsolete === 'false' && tool.status === 'obsolete')
       return false;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR adds a new filter option on the tools page that allows users to display only tools supporting Bowtie.

**Issue Number:**

-  Closes #1550


**Screenshots/videos:**

![image](https://github.com/user-attachments/assets/17041563-abd0-45e4-b94d-e94b7a3c2721)

**Summary**

- Introduces a new checkbox labeled “Support Bowtie” in the sidebar filter.
- Updates the filtering logic and transform hook to include Bowtie support.
- Enables users to quickly find tools that are compatible with or validated by Bowtie.


**Does this PR introduce a breaking change?**

no

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [ x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).