### PR TITLE
enchance the Bowtie Column Icon

### DIFF
--- a/pages/tools/components/ToolingTable.tsx
+++ b/pages/tools/components/ToolingTable.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 
 import { Headline2 } from '~/components/Headlines';
-import CancelIcon from '~/public/icons/cancel.svg';
+import InfoIcon from '~/public/icons/icons8-info.svg';
 import OutLinkIcon from '~/public/icons/outlink.svg';
 
 import toTitleCase from '../lib/toTitleCase';
@@ -259,7 +259,7 @@ const ToolingTable = ({
                                 <OutLinkIcon className='fill-none stroke-current w-5 h-5 stroke-2' />
                               </a>
                             ) : (
-                              <CancelIcon className='fill-current stroke-current w-4 h-4' />
+                              <InfoIcon className='fill-none stroke-current w-5 h-5 stroke-2' />
                             )}
                           </div>
                         )}

--- a/public/icons/icons8-info.svg
+++ b/public/icons/icons8-info.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"></circle>
+  <line x1="12" y1="16" x2="12" y2="12"></line>
+  <line x1="12" y1="8" x2="12.01" y2="8"></line>
+</svg>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

## Enhancement: Bowtie Cross Column Icon

**Issue Number:**

-  Closes #1640 

![image](https://github.com/user-attachments/assets/9908f665-e883-41dc-825e-b81a1321419e)
![image](https://github.com/user-attachments/assets/034b1cb4-df0b-4fd3-ae55-2dbf53120d29)

**Summary**
Before: Tools without Bowtie integration showed a cross (❌) icon, suggesting an error or problem. After: These tools now show an information (ℹ️) icon, indicating that additional information is available.

**Does this PR introduce a breaking change?**
No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).