### PR TITLE
Fixing the Navigation is not working in the blog in Japanese

### DIFF
--- a/lib/slugifyMarkdownHeadline.ts
+++ b/lib/slugifyMarkdownHeadline.ts
@@ -6,7 +6,7 @@ export default function slugifyMarkdownHeadline(
   const FRAGMENT_REGEX = /\[#(?<slug>(\w|-|_)*)\]/g;
   if (!markdownChildren) return '';
   if (typeof markdownChildren === 'string')
-    return slugify(markdownChildren, { lower: true, trim: true });
+    return slugify(markdownChildren, { lower: true, trim: true, remove: /[*+~.()'"!:@]/g, });
   const metaSlug = markdownChildren.reduce((acc, child) => {
     if (acc) return acc;
     if (typeof child !== 'string') return null;
@@ -21,6 +21,8 @@ export default function slugifyMarkdownHeadline(
     .filter((child) => typeof child === 'string')
     .map((string) => string.replace(FRAGMENT_REGEX, ''))
     .join(' ');
-  const slug = slugify(joinedChildren, { lower: true, trim: true });
+  const slug = slugify(joinedChildren, { lower: true, trim: true, remove: /[*+~.()'"!:@]/g, });
   return slug;
 }
+
+


### PR DESCRIPTION
Close https://github.com/json-schema-org/website/issues/1614

Fixes Issue: #1614

This PR fixes a bug where in-page navigation (e.g., table of contents or anchor links) was not working in the Japanese version of the blog. The root cause was that the slugifyMarkdownHeadline function did not correctly handle non-Latin characters like Japanese, resulting in empty or malformed slugs.

Changes Made:
Updated slugifyMarkdownHeadline to support Unicode characters by customizing the slugify options.
Ensured that heading slugs in Japanese retain readable or valid anchor IDs.
Avoided removing non-Latin characters by disabling unnecessary regex filters that stripped them out.