### PR TITLE
Migrate AmbassadorsCard, AmbassadorsBanner and AmbassadorsList to ShadCN  +2 issues resolved

### DIFF
--- a/components/AmbassadorsBanner.tsx
+++ b/components/AmbassadorsBanner.tsx
@@ -28,7 +28,7 @@ const AmbassadorBanner: React.FC = () => {
           <div className='w-full grid grid-cols-1 sm:grid-cols-2 gap-4 my-4 mx-auto'>
             <Button
               asChild
-              className='px-6 py-3 bg-blue-600 hover:bg-blue-700 transition duration-300'
+              className='px-6 py-3 bg-blue-600 hover:bg-blue-700 transition duration-300 text-white'
             >
               <Link href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors#become-a-json-schema-ambassador'>
                 Become Ambassador

--- a/components/AmbassadorsBanner.tsx
+++ b/components/AmbassadorsBanner.tsx
@@ -1,33 +1,51 @@
 import Link from 'next/link';
 import React from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
 const AmbassadorBanner: React.FC = () => {
   return (
     <div className='flex justify-center mx-4 sm:mx-6 md:mx-10 my-8 w-full'>
-      <div className='group relative h-auto w-full sm:w-5/6 md:w-4/5 lg:w-2/3 xl:w-1/2 rounded-lg border border-gray-200 bg-white p-6 sm:p-8 shadow-3xl dark:shadow-2xl dark:shadow-slate-900 transition-colors ease-in-out hover:bg-slate-100 dark:bg-slate-800 hover:dark:bg-slate-900/30'>
-        <h3 className='text-xl sm:text-2xl md:text-3xl font-bold mb-4 text-gray-800 dark:text-slate-100 text-center'>
-          Become a JSON Schema Ambassador
-        </h3>
-        <p className='text-sm sm:text-base md:text-lg text-gray-600 dark:text-slate-100 mb-6 text-center'>
-          The JSON Schema Ambassador program is now open for applications! If
-          you're selected, you'll join JSON Schema's mission of helping
-          community members all over the world build the future of JSON Schema.
-        </p>
-        <div className='w-full grid grid-cols-1 sm:grid-cols-2 gap-4 my-4 mx-auto'>
-          <Link
-            href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors#become-a-json-schema-ambassador'
-            className='inline-block px-6 py-3 bg-blue-600 text-white font-semibold text-center rounded hover:bg-blue-700 transition duration-300'
-          >
-            Become Ambassador
-          </Link>
-          <Link
-            href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors'
-            className='inline-block bg-gray-300 text-slate-700 text-center px-6 py-3 rounded-md shadow hover:bg-gray-400 transition'
-          >
-            Learn More
-          </Link>
-        </div>
-      </div>
+      <Card className='group relative h-auto w-full sm:w-5/6 md:w-4/5 lg:w-2/3 xl:w-1/2 rounded-lg border border-gray-200 bg-white p-6 sm:p-8 shadow-3xl dark:shadow-2xl dark:shadow-slate-900 transition-colors ease-in-out hover:bg-slate-100 dark:bg-slate-800 hover:dark:bg-slate-900/30'>
+        <CardHeader className='p-0 mb-4'>
+          <CardTitle className='text-xl sm:text-2xl md:text-3xl font-bold mb-4 text-gray-800 dark:text-slate-100 text-center'>
+            Become a JSON Schema Ambassador
+          </CardTitle>
+          <CardDescription className='text-sm sm:text-base md:text-lg text-gray-600 dark:text-slate-100 mb-6 text-center'>
+            The JSON Schema Ambassador program is now open for applications! If
+            you're selected, you'll join JSON Schema's mission of helping
+            community members all over the world build the future of JSON
+            Schema.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className='p-0'>
+          <div className='w-full grid grid-cols-1 sm:grid-cols-2 gap-4 my-4 mx-auto'>
+            <Button
+              asChild
+              className='px-6 py-3 bg-blue-600 hover:bg-blue-700 transition duration-300'
+            >
+              <Link href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors#become-a-json-schema-ambassador'>
+                Become Ambassador
+              </Link>
+            </Button>
+            <Button
+              asChild
+              variant='secondary'
+              className='px-6 py-3 bg-gray-300 text-slate-700 hover:bg-gray-400 transition'
+            >
+              <Link href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors'>
+                Learn More
+              </Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/components/AmbassadorsBanner.tsx
+++ b/components/AmbassadorsBanner.tsx
@@ -30,7 +30,11 @@ const AmbassadorBanner: React.FC = () => {
               asChild
               className='px-6 py-3 bg-blue-600 hover:bg-blue-700 transition duration-300 text-white'
             >
-              <Link href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors#become-a-json-schema-ambassador'>
+              <Link
+                href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors#become-a-json-schema-ambassador'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
                 Become Ambassador
               </Link>
             </Button>
@@ -39,7 +43,11 @@ const AmbassadorBanner: React.FC = () => {
               variant='secondary'
               className='px-6 py-3 bg-gray-300 text-slate-700 hover:bg-gray-400 transition'
             >
-              <Link href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors'>
+              <Link
+                href='https://github.com/json-schema-org/community/tree/main/programs/ambassadors'
+                target='_blank'
+                rel='noopener noreferrer'
+              >
                 Learn More
               </Link>
             </Button>

--- a/components/AmbassadorsCard.tsx
+++ b/components/AmbassadorsCard.tsx
@@ -133,10 +133,10 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
   return (
     <Card className='py-0 relative max-w-md md:max-w-lg lg:max-w-xl mx-auto bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden my-4 h-full border-0'>
       {/* Decorative corner elements */}
-      <div className='absolute top-0 right-0 w-1 h-20 bg-black dark:bg-gray-400'></div>
-      <div className='absolute top-0 right-0 w-20 h-1 bg-black dark:bg-gray-400'></div>
-      <div className='absolute bottom-0 left-0 w-1 h-20 bg-black dark:bg-gray-400'></div>
-      <div className='absolute bottom-0 left-0 w-20 h-1 bg-black dark:bg-gray-400'></div>
+      <div className='absolute top-0 right-0 w-1 h-20 bg-gray-400'></div>
+      <div className='absolute top-0 right-0 w-20 h-1 bg-gray-400'></div>
+      <div className='absolute bottom-0 left-0 w-1 h-20 bg-gray-400'></div>
+      <div className='absolute bottom-0 left-0 w-20 h-1 bg-gray-400'></div>
 
       {/* Image section */}
       <div className='p-5'>

--- a/components/AmbassadorsCard.tsx
+++ b/components/AmbassadorsCard.tsx
@@ -114,14 +114,7 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
     ambassador.img || '/api/placeholder/400/320',
   );
 
-  const {
-    name = 'Ambassador',
-    title,
-    bio,
-    company,
-    country,
-    contributions = [],
-  } = ambassador;
+  const { name, title, bio, company, country, contributions = [] } = ambassador;
 
   const SocialIcons: SocialIcons[] = [
     'github',

--- a/components/AmbassadorsCard.tsx
+++ b/components/AmbassadorsCard.tsx
@@ -202,8 +202,8 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
           <Button
             onClick={() => setShowContributions(!showContributions)}
             className={`w-full bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-400 text-white dark:text-slate-100 font-semibold py-2 px-4 rounded transition-all duration-300 transform ${
-              showContributions 
-                ? 'scale-105 shadow-lg shadow-blue-500/50' 
+              showContributions
+                ? 'scale-105 shadow-lg shadow-blue-500/50'
                 : 'scale-100 shadow-md'
             }`}
             variant='default'
@@ -213,7 +213,7 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
         )}
 
         {/* Contributions list with animation */}
-        <div 
+        <div
           className={`overflow-hidden transition-all duration-500 ease-in-out ${
             showContributions ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
           }`}
@@ -225,15 +225,15 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
               </h4>
               <ul className='text-gray-600 dark:text-slate-100 text-sm space-y-2'>
                 {contributions.map((contribution, index) => (
-                  <li 
-                    key={index} 
+                  <li
+                    key={index}
                     className={`transform transition-all duration-300 ease-out ${
-                      showContributions 
-                        ? 'translate-y-0 opacity-100' 
+                      showContributions
+                        ? 'translate-y-0 opacity-100'
                         : 'translate-y-4 opacity-0'
                     }`}
                     style={{
-                      transitionDelay: `${index * 100}ms`
+                      transitionDelay: `${index * 100}ms`,
                     }}
                   >
                     <strong>{contribution.title}</strong>

--- a/components/AmbassadorsCard.tsx
+++ b/components/AmbassadorsCard.tsx
@@ -202,7 +202,9 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
           <Button
             onClick={() => setShowContributions(!showContributions)}
             className={`w-full bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-400 text-white dark:text-slate-100 font-semibold py-2 px-4 rounded transition-all duration-300 transform ${
-              showContributions ? 'rotate' : ''
+              showContributions 
+                ? 'scale-105 shadow-lg shadow-blue-500/50' 
+                : 'scale-100 shadow-md'
             }`}
             variant='default'
           >
@@ -210,32 +212,48 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
           </Button>
         )}
 
-        {/* Contributions list */}
-        {showContributions && contributions.length > 0 && (
-          <div className='mt-4'>
-            <h4 className='text-lg font-semibold mb-2 text-gray-900 dark:text-white'>
-              Contributions
-            </h4>
-            <ul className='text-gray-600 dark:text-slate-100 text-sm'>
-              {contributions.map((contribution, index) => (
-                <li key={index} className='mb-2'>
-                  <strong>{contribution.title}</strong>
-                  {contribution.date &&
-                    ` (${contribution.date.month} ${contribution.date.year})`}{' '}
-                  -
-                  <a
-                    href={contribution.link}
-                    className='text-blue-600 dark:text-blue-400 ml-1 hover:underline'
-                    target='_blank'
-                    rel='noopener noreferrer'
+        {/* Contributions list with animation */}
+        <div 
+          className={`overflow-hidden transition-all duration-500 ease-in-out ${
+            showContributions ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+          }`}
+        >
+          {contributions.length > 0 && (
+            <div className='mt-4 pt-4 border-t border-gray-200 dark:border-gray-700'>
+              <h4 className='text-lg font-semibold mb-2 text-gray-900 dark:text-white'>
+                Contributions
+              </h4>
+              <ul className='text-gray-600 dark:text-slate-100 text-sm space-y-2'>
+                {contributions.map((contribution, index) => (
+                  <li 
+                    key={index} 
+                    className={`transform transition-all duration-300 ease-out ${
+                      showContributions 
+                        ? 'translate-y-0 opacity-100' 
+                        : 'translate-y-4 opacity-0'
+                    }`}
+                    style={{
+                      transitionDelay: `${index * 100}ms`
+                    }}
                   >
-                    {contribution.type}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
+                    <strong>{contribution.title}</strong>
+                    {contribution.date &&
+                      ` (${contribution.date.month} ${contribution.date.year})`}{' '}
+                    -
+                    <a
+                      href={contribution.link}
+                      className='text-blue-600 dark:text-blue-400 ml-1 hover:underline transition-colors duration-200'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
+                      {contribution.type}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/components/AmbassadorsCard.tsx
+++ b/components/AmbassadorsCard.tsx
@@ -1,5 +1,14 @@
+/* eslint-disable linebreak-style */
 import React, { useState } from 'react';
 import Image from 'next/image';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 
 interface Contribution {
   title: string;
@@ -122,33 +131,45 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
   ];
 
   return (
-    <div className='relative flex flex-col max-w-sm md:max-w-md lg:max-w-lg mx-auto bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden my-4 h-full'>
+    <Card className='py-0 relative max-w-md md:max-w-lg lg:max-w-xl mx-auto bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden my-4 h-full border-0'>
+      {/* Decorative corner elements */}
       <div className='absolute top-0 right-0 w-1 h-20 bg-black dark:bg-gray-400'></div>
-      <div className='absolute bottom-100 right-0 w-20 h-1 bg-black dark:bg-gray-400'></div>
+      <div className='absolute top-0 right-0 w-20 h-1 bg-black dark:bg-gray-400'></div>
       <div className='absolute bottom-0 left-0 w-1 h-20 bg-black dark:bg-gray-400'></div>
       <div className='absolute bottom-0 left-0 w-20 h-1 bg-black dark:bg-gray-400'></div>
 
-      <Image
-        className='w-full object-cover p-5 rounded-3xl'
-        src={imgSrc}
-        alt={`${name} profile`}
-        width={400}
-        height={320}
-        onError={() => setImgSrc(`/img/ambassadors/${name}.jpg`)}
-      />
+      {/* Image section */}
+      <div className='p-5'>
+        <div className='w-full h-80 relative overflow-hidden rounded-2xl'>
+          <Image
+            className='w-full h-full object-cover'
+            src={imgSrc}
+            alt={`${name} profile`}
+            fill
+            sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+            onError={() => setImgSrc(`/img/ambassadors/${name}.jpg`)}
+          />
+        </div>
+      </div>
 
-      <div className='flex flex-col flex-grow p-6'>
-        <h3 className='text-xl font-semibold mb-2 text-gray-900 dark:text-white'>
-          {name}
-        </h3>
-        {title && (
-          <p className='text-gray-500 dark:text-slate-100 mb-1'>{title}</p>
-        )}
+      <CardContent className='flex flex-col flex-grow p-6 pt-0'>
+        <CardHeader className='p-0 mb-4'>
+          <CardTitle className='text-xl font-semibold mb-2 text-gray-900 dark:text-white'>
+            {name}
+          </CardTitle>
+          {title && (
+            <CardDescription className='text-gray-500 dark:text-slate-100 mb-1'>
+              {title}
+            </CardDescription>
+          )}
+        </CardHeader>
+
         {bio && (
           <p className='text-gray-700 dark:text-slate-100 text-sm mb-4'>
             {bio}
           </p>
         )}
+
         {(company || country) && (
           <p className='text-gray-500 dark:text-slate-100 mb-4'>
             {company}
@@ -157,6 +178,7 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
           </p>
         )}
 
+        {/* Social icons */}
         <div className='flex justify-center mb-4 mt-auto'>
           {SocialIcons.map((platform) => {
             const username = ambassador[platform];
@@ -175,17 +197,20 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
           })}
         </div>
 
+        {/* Contributions button */}
         {contributions.length > 0 && (
-          <button
+          <Button
             onClick={() => setShowContributions(!showContributions)}
             className={`w-full bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-400 text-white dark:text-slate-100 font-semibold py-2 px-4 rounded transition-all duration-300 transform ${
               showContributions ? 'rotate' : ''
             }`}
+            variant='default'
           >
             {showContributions ? 'Hide Details' : 'Show Full Details'}
-          </button>
+          </Button>
         )}
 
+        {/* Contributions list */}
         {showContributions && contributions.length > 0 && (
           <div className='mt-4'>
             <h4 className='text-lg font-semibold mb-2 text-gray-900 dark:text-white'>
@@ -211,8 +236,8 @@ const AmbassadorCard = ({ ambassador }: { ambassador: Ambassador }) => {
             </ul>
           </div>
         )}
-      </div>
-    </div>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/components/AmbassadorsList.tsx
+++ b/components/AmbassadorsList.tsx
@@ -1,4 +1,11 @@
 import React from 'react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from '@/components/ui/card';
 
 interface AmbassadorsLink {
   title: string;
@@ -18,20 +25,26 @@ const AmbassadorList = ({ ambassadorList }: AmbassadorsListProps) => {
       {ambassadorList.contents.map((link) => (
         <li
           key={link.title}
-          className='flex flex-col items-center text-center p-5 bg-white dark:bg-gray-800 rounded-lg shadow-lg transform transition hover:scale-105'
+          className='flex flex-col items-center text-center'
           data-testid='Ambassadors-list'
         >
-          <img
-            src={link.icon}
-            alt={link.title}
-            className='w-[150px] h-auto object-contain mb-5'
-          />
-          <h2 className='text-lg md:text-xl font-semibold text-gray-900 dark:text-white mb-3'>
-            {link.title}
-          </h2>
-          <p className='text-sm md:text-base text-gray-700 dark:text-slate-100 leading-relaxed'>
-            {link.details}
-          </p>
+          <Card className='dark:border-gray-700 w-full h-full p-5 bg-white dark:bg-gray-800 rounded-lg shadow-lg transform transition hover:scale-105'>
+            <CardContent className='p-0'>
+              <img
+                src={link.icon}
+                alt={link.title}
+                className='w-[150px] h-auto object-contain mb-5 mx-auto'
+              />
+              <CardHeader className='p-0 mb-3'>
+                <CardTitle className='text-lg md:text-xl font-semibold text-gray-900 dark:text-white'>
+                  {link.title}
+                </CardTitle>
+              </CardHeader>
+              <CardDescription className='text-sm md:text-base text-gray-700 dark:text-slate-100 leading-relaxed'>
+                {link.details}
+              </CardDescription>
+            </CardContent>
+          </Card>
         </li>
       ))}
     </ul>

--- a/cypress/components/AmbassadorsBanner.cy.tsx
+++ b/cypress/components/AmbassadorsBanner.cy.tsx
@@ -1,0 +1,204 @@
+/* eslint-disable quotes */
+import React from 'react';
+import AmbassadorBanner from '../../components/AmbassadorsBanner';
+
+describe('AmbassadorBanner Component', () => {
+  beforeEach(() => {
+    // Mock window.open for external links
+    cy.window().then((win) => {
+      cy.stub(win, 'open').as('windowOpen');
+    });
+  });
+
+  it('should render the banner with correct content', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check main heading
+    cy.contains('Become a JSON Schema Ambassador').should('exist');
+
+    // Check description text
+    cy.contains(
+      'The JSON Schema Ambassador program is now open for applications',
+    ).should('exist');
+    cy.contains(
+      "you'll join JSON Schema's mission of helping community members",
+    ).should('exist');
+
+    // Check buttons
+    cy.contains('Become Ambassador').should('exist');
+    cy.contains('Learn More').should('exist');
+  });
+
+  it('should have proper link functionality', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check Become Ambassador link
+    cy.get('a[href*="become-a-json-schema-ambassador"]')
+      .should('exist')
+      .and('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer');
+
+    // Check Learn More link
+    cy.get('a[href*="programs/ambassadors"]')
+      .should('exist')
+      .and('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer');
+  });
+
+  it('should have proper styling and layout', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check card container
+    cy.get('[data-slot="card"]').should('exist');
+
+    // Check responsive classes
+    cy.get('[data-slot="card"]').should('have.class', 'w-full');
+    cy.get('[data-slot="card"]').should('have.class', 'sm:w-5/6');
+    cy.get('[data-slot="card"]').should('have.class', 'md:w-4/5');
+    cy.get('[data-slot="card"]').should('have.class', 'lg:w-2/3');
+    cy.get('[data-slot="card"]').should('have.class', 'xl:w-1/2');
+
+    // Check hover effects (these are custom classes, not shadcn defaults)
+    cy.get('[data-slot="card"]').should('have.class', 'hover:bg-slate-100');
+    cy.get('[data-slot="card"]')
+      .invoke('attr', 'class')
+      .should('include', 'hover:dark:bg-slate-900/30');
+  });
+
+  it('should have proper button styling', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check Become Ambassador button styling (renders as anchor with button classes)
+    cy.get('a[href*="become-a-json-schema-ambassador"]').should(
+      'have.class',
+      'bg-blue-600',
+    );
+    cy.get('a[href*="become-a-json-schema-ambassador"]').should(
+      'have.class',
+      'hover:bg-blue-700',
+    );
+    cy.get('a[href*="become-a-json-schema-ambassador"]').should(
+      'have.class',
+      'text-white',
+    );
+
+    // Check Learn More button styling (renders as anchor with secondary variant)
+    cy.get('a[href*="programs/ambassadors"]').should(
+      'have.class',
+      'bg-gray-300',
+    );
+    cy.get('a[href*="programs/ambassadors"]').should(
+      'have.class',
+      'hover:bg-gray-400',
+    );
+    cy.get('a[href*="programs/ambassadors"]').should(
+      'have.class',
+      'text-slate-700',
+    );
+  });
+
+  it('should have proper grid layout for buttons', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check button container grid
+    cy.get('a[href*="become-a-json-schema-ambassador"]')
+      .parent()
+      .should('have.class', 'grid');
+    cy.get('a[href*="become-a-json-schema-ambassador"]')
+      .parent()
+      .should('have.class', 'grid-cols-1');
+    cy.get('a[href*="become-a-json-schema-ambassador"]')
+      .parent()
+      .should('have.class', 'sm:grid-cols-2');
+    cy.get('a[href*="become-a-json-schema-ambassador"]')
+      .parent()
+      .should('have.class', 'gap-4');
+  });
+
+  it('should have proper accessibility attributes', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check that links have proper attributes (Button with asChild renders as anchor)
+    cy.get('a[href*="become-a-json-schema-ambassador"]').should(
+      'have.attr',
+      'target',
+      '_blank',
+    );
+    cy.get('a[href*="become-a-json-schema-ambassador"]').should(
+      'have.attr',
+      'rel',
+      'noopener noreferrer',
+    );
+    cy.get('a[href*="programs/ambassadors"]').should(
+      'have.attr',
+      'target',
+      '_blank',
+    );
+    cy.get('a[href*="programs/ambassadors"]').should(
+      'have.attr',
+      'rel',
+      'noopener noreferrer',
+    );
+  });
+
+  it('should have proper dark mode support', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check dark mode classes
+    cy.get('[data-slot="card"]').should('have.class', 'dark:bg-slate-800');
+    cy.get('[data-slot="card"]').should('have.class', 'dark:shadow-slate-900');
+
+    // Check text colors for dark mode
+    cy.get('[data-slot="card-title"]').should(
+      'have.class',
+      'dark:text-slate-100',
+    );
+    cy.get('[data-slot="card-description"]').should(
+      'have.class',
+      'dark:text-slate-100',
+    );
+  });
+
+  it('should have proper text sizing and responsive design', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check responsive text sizing
+    cy.get('[data-slot="card-title"]').should('have.class', 'text-xl');
+    cy.get('[data-slot="card-title"]').should('have.class', 'sm:text-2xl');
+    cy.get('[data-slot="card-title"]').should('have.class', 'md:text-3xl');
+
+    cy.get('[data-slot="card-description"]').should('have.class', 'text-sm');
+    cy.get('[data-slot="card-description"]').should(
+      'have.class',
+      'sm:text-base',
+    );
+    cy.get('[data-slot="card-description"]').should('have.class', 'md:text-lg');
+  });
+
+  it('should have proper spacing and margins', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check container spacing - target the component's outer container
+    cy.get('[data-slot="card"]').parent().should('have.class', 'mx-4');
+    cy.get('[data-slot="card"]').parent().should('have.class', 'sm:mx-6');
+    cy.get('[data-slot="card"]').parent().should('have.class', 'md:mx-10');
+    cy.get('[data-slot="card"]').parent().should('have.class', 'my-8');
+
+    // Check card padding
+    cy.get('[data-slot="card"]').should('have.class', 'p-6');
+    cy.get('[data-slot="card"]').should('have.class', 'sm:p-8');
+  });
+
+  it('should have proper border and shadow styling', () => {
+    cy.mount(<AmbassadorBanner />);
+
+    // Check border
+    cy.get('[data-slot="card"]').should('have.class', 'border');
+    cy.get('[data-slot="card"]').should('have.class', 'border-gray-200');
+    cy.get('[data-slot="card"]').should('have.class', 'rounded-lg');
+
+    // Check shadows
+    cy.get('[data-slot="card"]').should('have.class', 'shadow-3xl');
+    cy.get('[data-slot="card"]').should('have.class', 'dark:shadow-2xl');
+  });
+});

--- a/cypress/components/AmbassadorsCard.cy.tsx
+++ b/cypress/components/AmbassadorsCard.cy.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import AmbassadorCard, { Ambassador } from '../../components/AmbassadorsCard';
+
+const mockAmbassador: Ambassador = {
+  img: '/img/ambassadors/test-ambassador.jpg',
+  name: 'John Doe',
+  title: 'Senior Developer',
+  bio: 'Passionate about JSON Schema and open source development.',
+  company: 'Tech Corp',
+  country: 'United States',
+  github: 'johndoe',
+  twitter: 'johndoe_twitter',
+  linkedin: 'johndoe-linkedin',
+  mastodon: 'johndoe@mastodon.social',
+  contributions: [
+    {
+      title: 'JSON Schema Documentation',
+      date: { month: 'January', year: 2024 },
+      link: 'https://example.com/doc',
+      type: 'Documentation',
+    },
+    {
+      title: 'Schema Validation Tool',
+      date: { month: 'March', year: 2024 },
+      link: 'https://example.com/tool',
+      type: 'Tool',
+    },
+  ],
+};
+
+const minimalAmbassador: Ambassador = {
+  name: 'Jane Smith',
+};
+
+describe('AmbassadorCard Component', () => {
+  beforeEach(() => {
+    // Mock Next.js Image component
+    cy.intercept('GET', '/api/placeholder/400/320', {
+      statusCode: 200,
+      body: 'mocked-image-data',
+    }).as('placeholderImage');
+  });
+
+  it('should debug the rendered structure', () => {
+    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
+    cy.get('body').then(($body) => {
+      cy.log('Full HTML:', $body.html());
+    });
+  });
+
+  it('should render ambassador card with all information', () => {
+    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
+    
+    // Check basic information - using more flexible selectors
+    cy.contains(mockAmbassador.name).should('exist');
+    cy.contains(mockAmbassador.title).should('exist');
+    cy.contains(mockAmbassador.bio).should('exist');
+    cy.contains(`${mockAmbassador.company}, ${mockAmbassador.country}`).should('exist');
+    
+    // Check image
+    cy.get('img').should('have.attr', 'alt', `${mockAmbassador.name} profile`);
+    
+    // Check social media links
+    cy.get('a[href*="github.com/johndoe"]').should('exist');
+    cy.get('a[href*="twitter.com/johndoe_twitter"]').should('exist');
+    cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should('exist');
+    cy.get('a[href*="fosstodon.org/johndoe"]').should('exist');
+    
+    // Check contributions button
+    cy.get('button').should('contain.text', 'Show Full Details');
+  });
+
+  it('should render ambassador card with minimal information', () => {
+    cy.mount(<AmbassadorCard ambassador={minimalAmbassador} />);
+    
+    // Check default name
+    cy.contains('Jane Smith').should('exist');
+    
+    // Check that optional elements are not present
+    cy.contains('Senior Developer').should('not.exist');
+    cy.contains('Passionate about JSON Schema').should('not.exist');
+    
+    // Check that social media links are not present
+    cy.get('a[href*="github.com"]').should('not.exist');
+    cy.get('a[href*="twitter.com"]').should('not.exist');
+    
+    // Check that contributions button is not present
+    cy.get('button').should('not.exist');
+  });
+
+  it('should toggle contributions visibility when button is clicked', () => {
+    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
+    
+    // Initially contributions should be hidden
+    cy.contains('Contributions').should('not.exist');
+    
+    // Click the button to show contributions
+    cy.get('button').click();
+    
+    // Check that contributions are now visible
+    cy.contains('Contributions').should('exist');
+    cy.contains('JSON Schema Documentation').should('exist');
+    cy.contains('Schema Validation Tool').should('exist');
+    
+    // Check that button text changed
+    cy.get('button').should('contain.text', 'Hide Details');
+    
+    // Click the button again to hide contributions
+    cy.get('button').click();
+    
+    // Check that contributions are hidden again
+    cy.contains('Contributions').should('not.exist');
+    cy.get('button').should('contain.text', 'Show Full Details');
+  });
+
+  it('should handle image error and fallback to local image', () => {
+    // Mock image error
+    cy.intercept('GET', '/img/ambassadors/test-ambassador.jpg', {
+      statusCode: 404,
+    }).as('imageError');
+    
+    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
+    
+    // Wait for image error and check fallback
+    cy.wait('@imageError');
+    cy.get('img').should('have.attr', 'src').and('match', /John%20Doe/);
+  });
+
+  it('should render ambassador with only some social media links', () => {
+    const partialSocialAmbassador: Ambassador = {
+      ...mockAmbassador,
+      twitter: undefined,
+      mastodon: undefined,
+    };
+    
+    cy.mount(<AmbassadorCard ambassador={partialSocialAmbassador} />);
+    
+    // Check that only available social links are rendered
+    cy.get('a[href*="github.com/johndoe"]').should('exist');
+    cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should('exist');
+    cy.get('a[href*="twitter.com"]').should('not.exist');
+    cy.get('a[href*="fosstodon.org"]').should('not.exist');
+  });
+
+  it('should render ambassador with only company or only country', () => {
+    const companyOnly: Ambassador = {
+      ...mockAmbassador,
+      country: undefined,
+    };
+    
+    cy.mount(<AmbassadorCard ambassador={companyOnly} />);
+    cy.contains('Tech Corp').should('exist');
+    cy.contains('United States').should('not.exist');
+    
+    const countryOnly: Ambassador = {
+      ...mockAmbassador,
+      company: undefined,
+    };
+    
+    cy.mount(<AmbassadorCard ambassador={countryOnly} />);
+    cy.contains('United States').should('exist');
+    cy.contains('Tech Corp').should('not.exist');
+  });
+
+  it('should render contributions without dates', () => {
+    const contributionsWithoutDates: Ambassador = {
+      ...mockAmbassador,
+      contributions: [
+        {
+          title: 'Test Contribution',
+          link: 'https://example.com/test',
+          type: 'Test',
+        },
+      ],
+    };
+    
+    cy.mount(<AmbassadorCard ambassador={contributionsWithoutDates} />);
+    cy.get('button').click();
+    cy.contains('Test Contribution').should('exist');
+    cy.contains('January 2024').should('not.exist');
+  });
+
+  it('should have proper accessibility attributes', () => {
+    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
+    
+    // Check image alt text
+    cy.get('img').should('have.attr', 'alt', `${mockAmbassador.name} profile`);
+    
+    // Check social media link aria-labels
+    cy.get('a[href*="github.com"]').should('have.attr', 'aria-label', `${mockAmbassador.name}'s github profile`);
+    cy.get('a[href*="twitter.com"]').should('have.attr', 'aria-label', `${mockAmbassador.name}'s twitter profile`);
+    
+    // Check external link attributes
+    cy.get('a[href*="github.com"]').should('have.attr', 'target', '_blank');
+    cy.get('a[href*="github.com"]').should('have.attr', 'rel', 'noopener noreferrer');
+  });
+
+  it('should have proper CSS classes for styling', () => {
+    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
+    
+    // Check card container classes
+    cy.get('[data-slot="card"]').should('have.class', 'max-w-md');
+    cy.get('[data-slot="card"]').should('have.class', 'bg-white');
+    cy.get('[data-slot="card"]').should('have.class', 'dark:bg-gray-800');
+    
+    // Check image container classes
+    cy.get('img').parent().should('have.class', 'h-80');
+    cy.get('img').parent().should('have.class', 'rounded-2xl');
+    
+    // Check button classes
+    cy.get('button').should('have.class', 'bg-blue-600');
+    cy.get('button').should('have.class', 'hover:bg-blue-700');
+  });
+
+  it('should handle empty contributions array', () => {
+    const ambassadorWithoutContributions: Ambassador = {
+      ...mockAmbassador,
+      contributions: [],
+    };
+    
+    cy.mount(<AmbassadorCard ambassador={ambassadorWithoutContributions} />);
+    
+    // Check that contributions button is not rendered
+    cy.get('button').should('not.exist');
+  });
+}); 

--- a/cypress/components/AmbassadorsCard.cy.tsx
+++ b/cypress/components/AmbassadorsCard.cy.tsx
@@ -125,27 +125,29 @@ describe('AmbassadorCard Component', () => {
 
   it('should handle ambassador with no image', () => {
     cy.mount(<AmbassadorCard ambassador={ambassadorWithNoImage} />);
-    
+
     // Should use placeholder image
     cy.get('img').should('have.attr', 'src').and('include', '/api/placeholder');
   });
 
   it('should render all social media platforms', () => {
     cy.mount(<AmbassadorCard ambassador={ambassadorWithAllSocialMedia} />);
-    
+
     // Check all social media links are present
     cy.get('a[href*="github.com/socialuser"]').should('exist');
     cy.get('a[href*="twitter.com/socialuser_twitter"]').should('exist');
     cy.get('a[href*="linkedin.com/in/socialuser-linkedin"]').should('exist');
-    cy.get('a[href*="fosstodon.org/socialuser@mastodon.social"]').should('exist');
-    
+    cy.get('a[href*="fosstodon.org/socialuser@mastodon.social"]').should(
+      'exist',
+    );
+
     // Check all social media icons are rendered
     cy.get('svg').should('have.length', 4);
   });
 
   it('should handle ambassador with only company', () => {
     cy.mount(<AmbassadorCard ambassador={ambassadorWithOnlyCompany} />);
-    
+
     cy.contains('Big Corp').should('exist');
     cy.contains('Canada').should('not.exist');
     cy.contains(',').should('not.exist'); // No comma when only company
@@ -153,7 +155,7 @@ describe('AmbassadorCard Component', () => {
 
   it('should handle ambassador with only country', () => {
     cy.mount(<AmbassadorCard ambassador={ambassadorWithOnlyCountry} />);
-    
+
     cy.contains('Canada').should('exist');
     cy.contains('Big Corp').should('not.exist');
     cy.contains(',').should('not.exist'); // No comma when only country
@@ -161,7 +163,7 @@ describe('AmbassadorCard Component', () => {
 
   it('should handle long bio text', () => {
     cy.mount(<AmbassadorCard ambassador={ambassadorWithLongBio} />);
-    
+
     cy.contains('This is a very long bio').should('exist');
     cy.contains('multiple sentences').should('exist');
   });
@@ -226,7 +228,7 @@ describe('AmbassadorCard Component', () => {
     cy.intercept('GET', '/img/ambassadors/test-ambassador.jpg', {
       statusCode: 404,
     }).as('originalImageError');
-    
+
     cy.intercept('GET', '/img/ambassadors/John%20Doe.jpg', {
       statusCode: 404,
     }).as('fallbackImageError');
@@ -236,7 +238,7 @@ describe('AmbassadorCard Component', () => {
     // Wait for both image errors
     cy.wait('@originalImageError');
     cy.wait('@fallbackImageError');
-    
+
     // Check that image still has a src (even if it's the fallback)
     cy.get('img').should('have.attr', 'src');
   });
@@ -349,7 +351,9 @@ describe('AmbassadorCard Component', () => {
       contributions: undefined,
     };
 
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithUndefinedContributions} />);
+    cy.mount(
+      <AmbassadorCard ambassador={ambassadorWithUndefinedContributions} />,
+    );
 
     // Check that contributions button is not rendered
     cy.get('button').should('not.exist');
@@ -417,75 +421,8 @@ describe('AmbassadorCard Component', () => {
     cy.get('a[href*="twitter.com"]').should('not.exist');
     cy.get('a[href*="linkedin.com"]').should('not.exist');
     cy.get('a[href*="fosstodon.org"]').should('not.exist');
-    
+
     // Check that no social media icons are rendered
     cy.get('svg').should('not.exist');
-  });
-
-  it('should test responsive design classes', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check responsive width classes
-    cy.get('[data-slot="card"]').should('have.class', 'max-w-md');
-    cy.get('[data-slot="card"]').should('have.class', 'md:max-w-lg');
-    cy.get('[data-slot="card"]').should('have.class', 'lg:max-w-xl');
-  });
-
-  it('should test image sizing and optimization', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check image sizing classes
-    cy.get('img').should('have.class', 'w-full');
-    cy.get('img').should('have.class', 'h-full');
-    cy.get('img').should('have.class', 'object-cover');
-    
-    // Check image container classes
-    cy.get('img').parent().should('have.class', 'w-full');
-    cy.get('img').parent().should('have.class', 'h-80');
-    cy.get('img').parent().should('have.class', 'relative');
-    cy.get('img').parent().should('have.class', 'overflow-hidden');
-    cy.get('img').parent().should('have.class', 'rounded-2xl');
-  });
-
-  it('should test dark mode support', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check dark mode classes
-    cy.get('[data-slot="card"]').should('have.class', 'dark:bg-gray-800');
-    cy.get('[data-slot="card-title"]').should('have.class', 'dark:text-white');
-    cy.get('[data-slot="card-description"]').should('have.class', 'dark:text-slate-100');
-  });
-
-  it('should test contribution link functionality', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Show contributions
-    cy.get('button').click();
-
-    // Check contribution links
-    cy.get('a[href="https://example.com/doc"]').should('exist');
-    cy.get('a[href="https://example.com/tool"]').should('exist');
-    
-    // Check that contribution links have proper attributes
-    cy.get('a[href="https://example.com/doc"]').should('have.attr', 'target', '_blank');
-    cy.get('a[href="https://example.com/doc"]').should('have.attr', 'rel', 'noopener noreferrer');
-  });
-
-  it('should test component state management', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Test initial state
-    cy.get('button').should('contain.text', 'Show Full Details');
-    cy.contains('Contributions').should('not.be.visible');
-
-    // Test state after first click
-    cy.get('button').click();
-    cy.get('button').should('contain.text', 'Hide Details');
-    cy.contains('Contributions').should('be.visible');
-
-    // Test state after second click
-    cy.get('button').click();
-    cy.get('button').should('contain.text', 'Show Full Details');
-    cy.contains('Contributions').should('not.be.visible');
   });
 });

--- a/cypress/components/AmbassadorsCard.cy.tsx
+++ b/cypress/components/AmbassadorsCard.cy.tsx
@@ -32,397 +32,108 @@ const minimalAmbassador: Ambassador = {
   name: 'Jane Smith',
 };
 
-const ambassadorWithNoImage: Ambassador = {
-  name: 'No Image Ambassador',
-  title: 'Developer',
-  bio: 'No image provided',
-};
-
-const ambassadorWithAllSocialMedia: Ambassador = {
-  name: 'Social Media Ambassador',
-  github: 'socialuser',
-  twitter: 'socialuser_twitter',
-  linkedin: 'socialuser-linkedin',
-  mastodon: 'socialuser@mastodon.social',
-};
-
-const ambassadorWithOnlyCompany: Ambassador = {
-  name: 'Company Only',
-  company: 'Big Corp',
-};
-
-const ambassadorWithOnlyCountry: Ambassador = {
-  name: 'Country Only',
-  country: 'Canada',
-};
-
-const ambassadorWithLongBio: Ambassador = {
-  name: 'Long Bio Ambassador',
-  bio: 'This is a very long bio that should test how the component handles longer text content. It should wrap properly and not break the layout. The bio contains multiple sentences to ensure proper text rendering.',
-};
-
 describe('AmbassadorCard Component', () => {
   beforeEach(() => {
-    // Mock Next.js Image component
     cy.intercept('GET', '/api/placeholder/400/320', {
       statusCode: 200,
       body: 'mocked-image-data',
     }).as('placeholderImage');
   });
 
-  it('should debug the rendered structure', () => {
+  it('renders with all information', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-    cy.get('body').then(($body) => {
-      cy.log('Full HTML:', $body.html());
-    });
-  });
-
-  it('should render ambassador card with all information', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check basic information - using more flexible selectors
     cy.contains(mockAmbassador.name || 'Ambassador').should('exist');
     cy.contains(mockAmbassador.title || '').should('exist');
     cy.contains(mockAmbassador.bio || '').should('exist');
     cy.contains(
       `${mockAmbassador.company || ''}, ${mockAmbassador.country || ''}`,
     ).should('exist');
-
-    // Check image
     cy.get('img').should(
       'have.attr',
       'alt',
       `${mockAmbassador.name || 'Ambassador'} profile`,
     );
-
-    // Check social media links
     cy.get('a[href*="github.com/johndoe"]').should('exist');
     cy.get('a[href*="twitter.com/johndoe_twitter"]').should('exist');
     cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should('exist');
     cy.get('a[href*="fosstodon.org/johndoe@mastodon.social"]').should('exist');
-
-    // Check contributions button
     cy.get('button').should('contain.text', 'Show Full Details');
   });
 
-  it('should render ambassador card with minimal information', () => {
+  it('renders with minimal information', () => {
     cy.mount(<AmbassadorCard ambassador={minimalAmbassador} />);
-
-    // Check default name
     cy.contains('Jane Smith').should('exist');
-
-    // Check that optional elements are not present
-    cy.contains('Senior Developer').should('not.exist');
-    cy.contains('Passionate about JSON Schema').should('not.exist');
-
-    // Check that social media links are not present
     cy.get('a[href*="github.com"]').should('not.exist');
     cy.get('a[href*="twitter.com"]').should('not.exist');
-
-    // Check that contributions button is not present
     cy.get('button').should('not.exist');
   });
 
-  it('should handle ambassador with no image', () => {
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithNoImage} />);
-
-    // Should use placeholder image
-    cy.get('img').should('have.attr', 'src').and('include', '/api/placeholder');
-  });
-
-  it('should render all social media platforms', () => {
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithAllSocialMedia} />);
-
-    // Check all social media links are present
-    cy.get('a[href*="github.com/socialuser"]').should('exist');
-    cy.get('a[href*="twitter.com/socialuser_twitter"]').should('exist');
-    cy.get('a[href*="linkedin.com/in/socialuser-linkedin"]').should('exist');
-    cy.get('a[href*="fosstodon.org/socialuser@mastodon.social"]').should(
-      'exist',
-    );
-
-    // Check all social media icons are rendered
-    cy.get('svg').should('have.length', 4);
-  });
-
-  it('should handle ambassador with only company', () => {
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithOnlyCompany} />);
-
-    cy.contains('Big Corp').should('exist');
-    cy.contains('Canada').should('not.exist');
-    cy.contains(',').should('not.exist'); // No comma when only company
-  });
-
-  it('should handle ambassador with only country', () => {
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithOnlyCountry} />);
-
-    cy.contains('Canada').should('exist');
-    cy.contains('Big Corp').should('not.exist');
-    cy.contains(',').should('not.exist'); // No comma when only country
-  });
-
-  it('should handle long bio text', () => {
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithLongBio} />);
-
-    cy.contains('This is a very long bio').should('exist');
-    cy.contains('multiple sentences').should('exist');
-  });
-
-  it('should toggle contributions visibility when button is clicked', () => {
+  it('renders social links with correct URLs and attributes', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
+    cy.get('a[href*="github.com/johndoe"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer');
+    cy.get('a[href*="twitter.com/johndoe_twitter"]').should(
+      'have.attr',
+      'target',
+      '_blank',
+    );
+    cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should(
+      'have.attr',
+      'target',
+      '_blank',
+    );
+    cy.get('a[href*="fosstodon.org/johndoe@mastodon.social"]').should(
+      'have.attr',
+      'target',
+      '_blank',
+    );
+    cy.get('a[href*="github.com"]').should(
+      'have.attr',
+      'aria-label',
+      `${mockAmbassador.name}'s github profile`,
+    );
+  });
 
-    // Initially contributions should be hidden (but exist in DOM)
+  it('toggles contributions and displays content', () => {
+    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
     cy.contains('Contributions').should('not.be.visible');
-
-    // Click the button to show contributions
     cy.get('button').click();
-
-    // Check that contributions are now visible
     cy.contains('Contributions').should('be.visible');
     cy.contains('JSON Schema Documentation').should('be.visible');
     cy.contains('Schema Validation Tool').should('be.visible');
-
-    // Check that button text changed
     cy.get('button').should('contain.text', 'Hide Details');
-
-    // Click the button again to hide contributions
     cy.get('button').click();
-
-    // Check that contributions are hidden again
     cy.contains('Contributions').should('not.be.visible');
-    cy.get('button').should('contain.text', 'Show Full Details');
   });
 
-  it('should handle image error and fallback to local image', () => {
-    // Mock image error
+  it('handles image fallback logic', () => {
     cy.intercept('GET', '/img/ambassadors/test-ambassador.jpg', {
       statusCode: 404,
     }).as('imageError');
-
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Wait for image error and check fallback
     cy.wait('@imageError');
     cy.get('img')
       .should('have.attr', 'src')
       .and('match', /John%20Doe/);
   });
 
-  it('should handle placeholder image fallback', () => {
-    // Mock placeholder image error
-    cy.intercept('GET', '/api/placeholder/400/320', {
-      statusCode: 404,
-    }).as('placeholderError');
-
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithNoImage} />);
-
-    // Wait for placeholder error and check fallback
-    cy.wait('@placeholderError');
-    cy.get('img')
-      .should('have.attr', 'src')
-      .and('match', /No%20Image%20Ambassador/);
-  });
-
-  it('should handle multiple image fallbacks', () => {
-    // Mock both original image and fallback image errors
-    cy.intercept('GET', '/img/ambassadors/test-ambassador.jpg', {
-      statusCode: 404,
-    }).as('originalImageError');
-
-    cy.intercept('GET', '/img/ambassadors/John%20Doe.jpg', {
-      statusCode: 404,
-    }).as('fallbackImageError');
-
+  it('has proper accessibility attributes', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Wait for both image errors
-    cy.wait('@originalImageError');
-    cy.wait('@fallbackImageError');
-
-    // Check that image still has a src (even if it's the fallback)
-    cy.get('img').should('have.attr', 'src');
-  });
-
-  it('should render ambassador with only some social media links', () => {
-    const partialSocialAmbassador: Ambassador = {
-      ...mockAmbassador,
-      twitter: undefined,
-      mastodon: undefined,
-    };
-
-    cy.mount(<AmbassadorCard ambassador={partialSocialAmbassador} />);
-
-    // Check that only available social links are rendered
-    cy.get('a[href*="github.com/johndoe"]').should('exist');
-    cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should('exist');
-    cy.get('a[href*="twitter.com"]').should('not.exist');
-    cy.get('a[href*="fosstodon.org"]').should('not.exist');
-  });
-
-  it('should render contributions without dates', () => {
-    const contributionsWithoutDates: Ambassador = {
-      ...mockAmbassador,
-      contributions: [
-        {
-          title: 'Test Contribution',
-          link: 'https://example.com/test',
-          type: 'Test',
-        },
-      ],
-    };
-
-    cy.mount(<AmbassadorCard ambassador={contributionsWithoutDates} />);
-    cy.get('button').click();
-    cy.contains('Test Contribution').should('exist');
-    cy.contains('January 2024').should('not.exist');
-  });
-
-  it('should have proper accessibility attributes', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check image alt text
     cy.get('img').should(
       'have.attr',
       'alt',
       `${mockAmbassador.name || 'Ambassador'} profile`,
     );
-
-    // Check social media link aria-labels
     cy.get('a[href*="github.com"]').should(
       'have.attr',
       'aria-label',
-      `${mockAmbassador.name || 'Ambassador'}'s github profile`,
+      `${mockAmbassador.name}'s github profile`,
     );
     cy.get('a[href*="twitter.com"]').should(
       'have.attr',
       'aria-label',
-      `${mockAmbassador.name || 'Ambassador'}'s twitter profile`,
+      `${mockAmbassador.name}'s twitter profile`,
     );
-
-    // Check external link attributes
-    cy.get('a[href*="github.com"]').should('have.attr', 'target', '_blank');
-    cy.get('a[href*="github.com"]').should(
-      'have.attr',
-      'rel',
-      'noopener noreferrer',
-    );
-  });
-
-  it('should have proper CSS classes for styling', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check card container classes
-    cy.get('[data-slot="card"]').should('have.class', 'max-w-md');
-    cy.get('[data-slot="card"]').should('have.class', 'bg-white');
-    cy.get('[data-slot="card"]').should('have.class', 'dark:bg-gray-800');
-
-    // Check image container classes
-    cy.get('img').parent().should('have.class', 'h-80');
-    cy.get('img').parent().should('have.class', 'rounded-2xl');
-
-    // Check button classes
-    cy.get('button').should('have.class', 'bg-blue-600');
-    cy.get('button').should('have.class', 'hover:bg-blue-700');
-  });
-
-  it('should have decorative corner elements', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check that decorative elements are present
-    cy.get('div').should('have.class', 'absolute');
-    cy.get('div').should('have.class', 'bg-gray-400');
-  });
-
-  it('should handle empty contributions array', () => {
-    const ambassadorWithoutContributions: Ambassador = {
-      ...mockAmbassador,
-      contributions: [],
-    };
-
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithoutContributions} />);
-
-    // Check that contributions button is not rendered
-    cy.get('button').should('not.exist');
-  });
-
-  it('should handle undefined contributions', () => {
-    const ambassadorWithUndefinedContributions: Ambassador = {
-      ...mockAmbassador,
-      contributions: undefined,
-    };
-
-    cy.mount(
-      <AmbassadorCard ambassador={ambassadorWithUndefinedContributions} />,
-    );
-
-    // Check that contributions button is not rendered
-    cy.get('button').should('not.exist');
-  });
-
-  it('should test button animation states', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check initial button state
-    cy.get('button').should('have.class', 'scale-100');
-    cy.get('button').should('have.class', 'shadow-md');
-
-    // Click button to show contributions
-    cy.get('button').click();
-
-    // Check expanded button state
-    cy.get('button').should('have.class', 'scale-105');
-    cy.get('button').should('have.class', 'shadow-lg');
-    cy.get('button').should('have.class', 'shadow-blue-500/50');
-
-    // Click button again to hide contributions
-    cy.get('button').click();
-
-    // Check button returned to initial state
-    cy.get('button').should('have.class', 'scale-100');
-    cy.get('button').should('have.class', 'shadow-md');
-  });
-
-  it('should test contribution animation timing', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Click button to show contributions
-    cy.get('button').click();
-
-    // Check that contributions container has animation classes
-    cy.get('div').should('have.class', 'overflow-hidden');
-    cy.get('div').should('have.class', 'transition-all');
-    cy.get('div').should('have.class', 'duration-500');
-    cy.get('div').should('have.class', 'ease-in-out');
-  });
-
-  it('should test social media URL generation', () => {
-    cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-
-    // Check that all social media URLs are correctly generated
-    cy.get('a[href*="github.com/johndoe"]').should('exist');
-    cy.get('a[href*="twitter.com/johndoe_twitter"]').should('exist');
-    cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should('exist');
-    cy.get('a[href*="fosstodon.org/johndoe@mastodon.social"]').should('exist');
-  });
-
-  it('should handle undefined social media usernames', () => {
-    const ambassadorWithUndefinedSocial: Ambassador = {
-      name: 'No Social Media',
-      github: undefined,
-      twitter: undefined,
-      linkedin: undefined,
-      mastodon: undefined,
-    };
-
-    cy.mount(<AmbassadorCard ambassador={ambassadorWithUndefinedSocial} />);
-
-    // Check that no social media links are rendered
-    cy.get('a[href*="github.com"]').should('not.exist');
-    cy.get('a[href*="twitter.com"]').should('not.exist');
-    cy.get('a[href*="linkedin.com"]').should('not.exist');
-    cy.get('a[href*="fosstodon.org"]').should('not.exist');
-
-    // Check that no social media icons are rendered
-    cy.get('svg').should('not.exist');
   });
 });

--- a/cypress/components/AmbassadorsCard.cy.tsx
+++ b/cypress/components/AmbassadorsCard.cy.tsx
@@ -91,16 +91,16 @@ describe('AmbassadorCard Component', () => {
   it('should toggle contributions visibility when button is clicked', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
     
-    // Initially contributions should be hidden
-    cy.contains('Contributions').should('not.exist');
+    // Initially contributions should be hidden (but exist in DOM)
+    cy.contains('Contributions').should('not.be.visible');
     
     // Click the button to show contributions
     cy.get('button').click();
     
     // Check that contributions are now visible
-    cy.contains('Contributions').should('exist');
-    cy.contains('JSON Schema Documentation').should('exist');
-    cy.contains('Schema Validation Tool').should('exist');
+    cy.contains('Contributions').should('be.visible');
+    cy.contains('JSON Schema Documentation').should('be.visible');
+    cy.contains('Schema Validation Tool').should('be.visible');
     
     // Check that button text changed
     cy.get('button').should('contain.text', 'Hide Details');
@@ -109,7 +109,7 @@ describe('AmbassadorCard Component', () => {
     cy.get('button').click();
     
     // Check that contributions are hidden again
-    cy.contains('Contributions').should('not.exist');
+    cy.contains('Contributions').should('not.be.visible');
     cy.get('button').should('contain.text', 'Show Full Details');
   });
 

--- a/cypress/components/AmbassadorsCard.cy.tsx
+++ b/cypress/components/AmbassadorsCard.cy.tsx
@@ -50,64 +50,70 @@ describe('AmbassadorCard Component', () => {
 
   it('should render ambassador card with all information', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-    
+
     // Check basic information - using more flexible selectors
-    cy.contains(mockAmbassador.name).should('exist');
-    cy.contains(mockAmbassador.title).should('exist');
-    cy.contains(mockAmbassador.bio).should('exist');
-    cy.contains(`${mockAmbassador.company}, ${mockAmbassador.country}`).should('exist');
-    
+    cy.contains(mockAmbassador.name || 'Ambassador').should('exist');
+    cy.contains(mockAmbassador.title || '').should('exist');
+    cy.contains(mockAmbassador.bio || '').should('exist');
+    cy.contains(
+      `${mockAmbassador.company || ''}, ${mockAmbassador.country || ''}`,
+    ).should('exist');
+
     // Check image
-    cy.get('img').should('have.attr', 'alt', `${mockAmbassador.name} profile`);
-    
+    cy.get('img').should(
+      'have.attr',
+      'alt',
+      `${mockAmbassador.name || 'Ambassador'} profile`,
+    );
+
     // Check social media links
     cy.get('a[href*="github.com/johndoe"]').should('exist');
     cy.get('a[href*="twitter.com/johndoe_twitter"]').should('exist');
     cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should('exist');
     cy.get('a[href*="fosstodon.org/johndoe"]').should('exist');
-    
+
     // Check contributions button
     cy.get('button').should('contain.text', 'Show Full Details');
   });
 
   it('should render ambassador card with minimal information', () => {
     cy.mount(<AmbassadorCard ambassador={minimalAmbassador} />);
-    
+
     // Check default name
     cy.contains('Jane Smith').should('exist');
-    
+
     // Check that optional elements are not present
     cy.contains('Senior Developer').should('not.exist');
     cy.contains('Passionate about JSON Schema').should('not.exist');
-    
+
     // Check that social media links are not present
     cy.get('a[href*="github.com"]').should('not.exist');
     cy.get('a[href*="twitter.com"]').should('not.exist');
-    
+
     // Check that contributions button is not present
     cy.get('button').should('not.exist');
   });
 
   it('should toggle contributions visibility when button is clicked', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-    
+
     // Initially contributions should be hidden (but exist in DOM)
     cy.contains('Contributions').should('not.be.visible');
-    
+
     // Click the button to show contributions
     cy.get('button').click();
-    
+
     // Check that contributions are now visible
     cy.contains('Contributions').should('be.visible');
     cy.contains('JSON Schema Documentation').should('be.visible');
     cy.contains('Schema Validation Tool').should('be.visible');
-    
+
     // Check that button text changed
     cy.get('button').should('contain.text', 'Hide Details');
-    
+
     // Click the button again to hide contributions
     cy.get('button').click();
-    
+
     // Check that contributions are hidden again
     cy.contains('Contributions').should('not.be.visible');
     cy.get('button').should('contain.text', 'Show Full Details');
@@ -118,12 +124,14 @@ describe('AmbassadorCard Component', () => {
     cy.intercept('GET', '/img/ambassadors/test-ambassador.jpg', {
       statusCode: 404,
     }).as('imageError');
-    
+
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-    
+
     // Wait for image error and check fallback
     cy.wait('@imageError');
-    cy.get('img').should('have.attr', 'src').and('match', /John%20Doe/);
+    cy.get('img')
+      .should('have.attr', 'src')
+      .and('match', /John%20Doe/);
   });
 
   it('should render ambassador with only some social media links', () => {
@@ -132,9 +140,9 @@ describe('AmbassadorCard Component', () => {
       twitter: undefined,
       mastodon: undefined,
     };
-    
+
     cy.mount(<AmbassadorCard ambassador={partialSocialAmbassador} />);
-    
+
     // Check that only available social links are rendered
     cy.get('a[href*="github.com/johndoe"]').should('exist');
     cy.get('a[href*="linkedin.com/in/johndoe-linkedin"]').should('exist');
@@ -147,16 +155,16 @@ describe('AmbassadorCard Component', () => {
       ...mockAmbassador,
       country: undefined,
     };
-    
+
     cy.mount(<AmbassadorCard ambassador={companyOnly} />);
     cy.contains('Tech Corp').should('exist');
     cy.contains('United States').should('not.exist');
-    
+
     const countryOnly: Ambassador = {
       ...mockAmbassador,
       company: undefined,
     };
-    
+
     cy.mount(<AmbassadorCard ambassador={countryOnly} />);
     cy.contains('United States').should('exist');
     cy.contains('Tech Corp').should('not.exist');
@@ -173,7 +181,7 @@ describe('AmbassadorCard Component', () => {
         },
       ],
     };
-    
+
     cy.mount(<AmbassadorCard ambassador={contributionsWithoutDates} />);
     cy.get('button').click();
     cy.contains('Test Contribution').should('exist');
@@ -182,31 +190,47 @@ describe('AmbassadorCard Component', () => {
 
   it('should have proper accessibility attributes', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-    
+
     // Check image alt text
-    cy.get('img').should('have.attr', 'alt', `${mockAmbassador.name} profile`);
-    
+    cy.get('img').should(
+      'have.attr',
+      'alt',
+      `${mockAmbassador.name || 'Ambassador'} profile`,
+    );
+
     // Check social media link aria-labels
-    cy.get('a[href*="github.com"]').should('have.attr', 'aria-label', `${mockAmbassador.name}'s github profile`);
-    cy.get('a[href*="twitter.com"]').should('have.attr', 'aria-label', `${mockAmbassador.name}'s twitter profile`);
-    
+    cy.get('a[href*="github.com"]').should(
+      'have.attr',
+      'aria-label',
+      `${mockAmbassador.name || 'Ambassador'}'s github profile`,
+    );
+    cy.get('a[href*="twitter.com"]').should(
+      'have.attr',
+      'aria-label',
+      `${mockAmbassador.name || 'Ambassador'}'s twitter profile`,
+    );
+
     // Check external link attributes
     cy.get('a[href*="github.com"]').should('have.attr', 'target', '_blank');
-    cy.get('a[href*="github.com"]').should('have.attr', 'rel', 'noopener noreferrer');
+    cy.get('a[href*="github.com"]').should(
+      'have.attr',
+      'rel',
+      'noopener noreferrer',
+    );
   });
 
   it('should have proper CSS classes for styling', () => {
     cy.mount(<AmbassadorCard ambassador={mockAmbassador} />);
-    
+
     // Check card container classes
     cy.get('[data-slot="card"]').should('have.class', 'max-w-md');
     cy.get('[data-slot="card"]').should('have.class', 'bg-white');
     cy.get('[data-slot="card"]').should('have.class', 'dark:bg-gray-800');
-    
+
     // Check image container classes
     cy.get('img').parent().should('have.class', 'h-80');
     cy.get('img').parent().should('have.class', 'rounded-2xl');
-    
+
     // Check button classes
     cy.get('button').should('have.class', 'bg-blue-600');
     cy.get('button').should('have.class', 'hover:bg-blue-700');
@@ -217,10 +241,10 @@ describe('AmbassadorCard Component', () => {
       ...mockAmbassador,
       contributions: [],
     };
-    
+
     cy.mount(<AmbassadorCard ambassador={ambassadorWithoutContributions} />);
-    
+
     // Check that contributions button is not rendered
     cy.get('button').should('not.exist');
   });
-}); 
+});

--- a/cypress/components/AmbassadorsList.cy.tsx
+++ b/cypress/components/AmbassadorsList.cy.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import AmbassadorList from '../../components/AmbassadorsList';
+
+const mockAmbassadorList = {
+  contents: [
+    {
+      title: 'Community Building',
+      icon: '/img/community/community-icon.svg',
+      details:
+        'Help build and grow the JSON Schema community through events, meetups, and online engagement.',
+    },
+    {
+      title: 'Documentation',
+      icon: '/img/community/docs-icon.svg',
+      details:
+        'Contribute to documentation, tutorials, and educational content to help others learn JSON Schema.',
+    },
+    {
+      title: 'Technical Support',
+      icon: '/img/community/support-icon.svg',
+      details:
+        'Provide technical support and guidance to community members on JSON Schema implementation.',
+    },
+  ],
+};
+
+const singleAmbassadorList = {
+  contents: [
+    {
+      title: 'Single Ambassador',
+      icon: '/img/community/single-icon.svg',
+      details: 'This is a single ambassador test item.',
+    },
+  ],
+};
+
+describe('AmbassadorList Component', () => {
+  beforeEach(() => {
+    // Mock image loading
+    cy.intercept('GET', '/img/community/*', {
+      statusCode: 200,
+      body: 'mocked-image-data',
+    }).as('imageLoad');
+  });
+
+  it('should render the ambassador list with correct content', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check that all ambassador items are rendered
+    cy.contains('Community Building').should('exist');
+    cy.contains('Documentation').should('exist');
+    cy.contains('Technical Support').should('exist');
+
+    // Check details text
+    cy.contains('Help build and grow the JSON Schema community').should(
+      'exist',
+    );
+    cy.contains('Contribute to documentation, tutorials').should('exist');
+    cy.contains('Provide technical support and guidance').should('exist');
+  });
+
+  it('should render images with correct attributes', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check that images are rendered
+    cy.get('img').should('have.length', 3);
+
+    // Check image attributes
+    cy.get('img')
+      .first()
+      .should('have.attr', 'src', '/img/community/community-icon.svg');
+    cy.get('img').first().should('have.attr', 'alt', 'Community Building');
+    cy.get('img').first().should('have.class', 'w-[150px]');
+    cy.get('img').first().should('have.class', 'object-contain');
+  });
+
+  it('should have proper grid layout', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check grid container
+    cy.get('ul').should('have.class', 'grid');
+    cy.get('ul').should('have.class', 'grid-cols-1');
+    cy.get('ul').should('have.class', 'sm:grid-cols-2');
+    cy.get('ul').should('have.class', 'lg:grid-cols-3');
+    cy.get('ul').should('have.class', 'xl:grid-cols-3');
+    cy.get('ul').should('have.class', 'gap-8');
+  });
+
+  it('should have proper card styling', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check card elements
+    cy.get('[data-slot="card"]').should('have.length', 3);
+    cy.get('[data-slot="card"]').first().should('have.class', 'w-full');
+    cy.get('[data-slot="card"]').first().should('have.class', 'h-full');
+    cy.get('[data-slot="card"]').first().should('have.class', 'bg-white');
+    cy.get('[data-slot="card"]')
+      .first()
+      .should('have.class', 'dark:bg-gray-800');
+    cy.get('[data-slot="card"]').first().should('have.class', 'rounded-lg');
+    cy.get('[data-slot="card"]').first().should('have.class', 'shadow-lg');
+  });
+
+  it('should have proper hover animations', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check hover effects
+    cy.get('[data-slot="card"]').first().should('have.class', 'transform');
+    cy.get('[data-slot="card"]').first().should('have.class', 'transition');
+    cy.get('[data-slot="card"]')
+      .first()
+      .should('have.class', 'hover:scale-105');
+  });
+
+  it('should have proper text styling', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check title styling
+    cy.get('[data-slot="card-title"]').first().should('have.class', 'text-lg');
+    cy.get('[data-slot="card-title"]')
+      .first()
+      .should('have.class', 'md:text-xl');
+    cy.get('[data-slot="card-title"]')
+      .first()
+      .should('have.class', 'font-semibold');
+    cy.get('[data-slot="card-title"]')
+      .first()
+      .should('have.class', 'text-gray-900');
+    cy.get('[data-slot="card-title"]')
+      .first()
+      .should('have.class', 'dark:text-white');
+
+    // Check description styling
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'text-sm');
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'md:text-base');
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'text-gray-700');
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'dark:text-slate-100');
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'leading-relaxed');
+  });
+
+  it('should have proper spacing and layout', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check container spacing
+    cy.get('ul').should('have.class', 'mt-10');
+    cy.get('ul').should('have.class', 'px-5');
+
+    // Check card padding
+    cy.get('[data-slot="card"]').first().should('have.class', 'p-5');
+
+    // Check content spacing
+    cy.get('[data-slot="card-content"]').first().should('have.class', 'p-0');
+  });
+
+  it('should have proper accessibility attributes', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check test ID
+    cy.get('[data-testid="Ambassadors-list"]').should('have.length', 3);
+
+    // Check image alt text
+    cy.get('img').first().should('have.attr', 'alt', 'Community Building');
+    cy.get('img').eq(1).should('have.attr', 'alt', 'Documentation');
+    cy.get('img').last().should('have.attr', 'alt', 'Technical Support');
+  });
+
+  it('should handle single ambassador item', () => {
+    cy.mount(<AmbassadorList ambassadorList={singleAmbassadorList} />);
+
+    // Check single item rendering
+    cy.contains('Single Ambassador').should('exist');
+    cy.contains('This is a single ambassador test item.').should('exist');
+
+    // Check that only one card is rendered
+    cy.get('[data-slot="card"]').should('have.length', 1);
+    cy.get('img').should('have.length', 1);
+  });
+
+  it('should have proper dark mode support', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check dark mode classes
+    cy.get('[data-slot="card"]')
+      .first()
+      .should('have.class', 'dark:bg-gray-800');
+    cy.get('[data-slot="card"]')
+      .first()
+      .should('have.class', 'dark:border-gray-700');
+
+    // Check text colors for dark mode
+    cy.get('[data-slot="card-title"]')
+      .first()
+      .should('have.class', 'dark:text-white');
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'dark:text-slate-100');
+  });
+
+  it('should have proper responsive design', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check responsive grid classes
+    cy.get('ul').should('have.class', 'grid-cols-1');
+    cy.get('ul').should('have.class', 'sm:grid-cols-2');
+    cy.get('ul').should('have.class', 'lg:grid-cols-3');
+    cy.get('ul').should('have.class', 'xl:grid-cols-3');
+
+    // Check responsive text sizing
+    cy.get('[data-slot="card-title"]').first().should('have.class', 'text-lg');
+    cy.get('[data-slot="card-title"]')
+      .first()
+      .should('have.class', 'md:text-xl');
+
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'text-sm');
+    cy.get('[data-slot="card-description"]')
+      .first()
+      .should('have.class', 'md:text-base');
+  });
+
+  it('should have proper image sizing and positioning', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check image container
+    cy.get('img').first().should('have.class', 'w-[150px]');
+    cy.get('img').first().should('have.class', 'h-auto');
+    cy.get('img').first().should('have.class', 'object-contain');
+    cy.get('img').first().should('have.class', 'mb-5');
+    cy.get('img').first().should('have.class', 'mx-auto');
+  });
+
+  it('should have proper list item structure', () => {
+    cy.mount(<AmbassadorList ambassadorList={mockAmbassadorList} />);
+
+    // Check list item structure
+    cy.get('li').should('have.length', 3);
+    cy.get('li').first().should('have.class', 'flex');
+    cy.get('li').first().should('have.class', 'flex-col');
+    cy.get('li').first().should('have.class', 'items-center');
+    cy.get('li').first().should('have.class', 'text-center');
+  });
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Adapted 3 components to use the ShadCN library.
- Created and adjusted Cypress test files for these 3 components 
- Added animation to the ambassador card when pressing on the 'full details' button.
- standardized all the image sizes on the ambassadors card

**Issue Number:**

- Closes #1478 
- Closes #1556 
- Related to #1657 

**Screenshots/videos:**


https://github.com/user-attachments/assets/7f569de0-56cb-4f15-83fe-da88c2175762


> The banner and list components look completely the same.

**Summary**

This PR:
- Migrated the existing `AmbassadorsCard.tsx`, `AmbassadorsBanner .tsx`, and `AmbassadorsList ` components to the ShadCN library.
- Enhanced the overall styling (mainly small color theme and light mode changes).
- Added Cypress tests for all implemented components to ensure reliability and behavior coverage.
- solved 2 issues as related to phase 2:
  - animations on the 'full details' button.
  - standardized all the image sizes on the ambassadors card


**Does this PR introduce a breaking change?**

no

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
