### PR TITLE
fix: normalize badge height for all tool reports (#1753)

### DIFF
--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -388,6 +388,7 @@ const BowtieReportBadge = ({ uri }: { uri: string }) => {
           className='my-1'
           width={100}
           height={20}
+          style={{ width: 'auto', height: '20px', objectFit: 'contain' }}
         />
       )}
       {error && (


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix — it ensures that all dynamically generated badge images render at a consistent height/size.

**Issue Number:**

-  Closes #1753 



**Screenshots/videos:**
![large devices](https://github.com/user-attachments/assets/6871f928-6076-406c-b69b-0d5a30a1c235)
![small devices](https://github.com/user-attachments/assets/d177bb8c-f051-403f-af96-0fa321dfcd92)


**If relevant, did you update the documentation?**
NO


**Summary**
The issue was to make all the badges of same height, first I tried to see if there's any way to fix the size of badges by changing
shield.io endpoint URL by adding certain queries, as it was not possible to do so written in their QnA in github, i manually added styles to the image to keep the height same for all badges


**Does this PR introduce a breaking change?**
NO


# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).