### PR TITLE
Fix/blog preview img

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -317,7 +317,7 @@ export default function StaticMarkdownPage({
                         src={frontmatter.cover}
                         alt={frontmatter.title}
                         fill
-                        className='object-cover'
+                        className='object-fill'
                         loading={idx < 10 ? 'eager' : 'lazy'}
                         priority={idx < 10}
                         quality={75}

--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -385,7 +385,7 @@ const BowtieReportBadge = ({ uri }: { uri: string }) => {
         <Image
           src={`https://img.shields.io/endpoint?url=${encodeURIComponent(uri)}`}
           alt='Bowtie Badge'
-          className='my-1 h-[20px] w-auto'
+          className='my-1'
           width={100}
           height={20}
         />

--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -385,10 +385,9 @@ const BowtieReportBadge = ({ uri }: { uri: string }) => {
         <Image
           src={`https://img.shields.io/endpoint?url=${encodeURIComponent(uri)}`}
           alt='Bowtie Badge'
-          className='my-1'
+          className='my-1 h-[20px] w-auto'
           width={100}
           height={20}
-          style={{ width: 'auto', height: '20px', objectFit: 'contain' }}
         />
       )}
       {error && (

--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -388,6 +388,7 @@ const BowtieReportBadge = ({ uri }: { uri: string }) => {
           className='my-1'
           width={100}
           height={20}
+          style={{ width: 'auto', height: '20px', objectFit: 'contain' }}
         />
       )}
       {error && (


### PR DESCRIPTION


**What kind of change does this PR introduce?**
A Bugfix

**Issue Number:**
Closes #1755


**Screenshots/videos:**
![object-contain](https://github.com/user-attachments/assets/1c06d7c5-b68b-47ad-b90c-aa78666a6f2f)
Adding object contain will make other blog images not fit in properly
![object-fill](https://github.com/user-attachments/assets/3564ef77-9413-4b57-98c6-08d1c6f386d5)
adding object fill will do the job

**Summary**
the suggested solution was to use object-contain but that makes other images not fit in properly, instead using object-fill will do the work properly

**Does this PR introduce a breaking change?**
NO

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x ] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).