### PR TITLE
adapting json editor to shadcn 

### DIFF
--- a/components/JsonEditor.tsx
+++ b/components/JsonEditor.tsx
@@ -452,7 +452,16 @@ export default function JsonEditor({
           >
             {isJsonc ? (
               isPartialSchema ? (
-                <>partial schema</>
+                <>
+                  <Image
+                    src='/logo-white.svg'
+                    alt=' logo-white'
+                    width={16}
+                    height={16}
+                    className=' mr-1.5'
+                  />{' '}
+                  part of schema
+                </>
               ) : (
                 <>code</>
               )

--- a/components/JsonEditor.tsx
+++ b/components/JsonEditor.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 import React, { useContext } from 'react';
 import { BaseEditor, createEditor, Descendant, Text } from 'slate';
 import { Editable, ReactEditor, Slate, withReact } from 'slate-react';
@@ -104,7 +105,7 @@ const getTextPathIndexesFromNode = (
 // Function to create basic syntax highlighting for partial schemas
 const getBasicSyntaxParts = (serializedText: string): SyntaxPart[] => {
   const parts: SyntaxPart[] = [];
-  
+
   // Define patterns for basic syntax highlighting
   const patterns = [
     // Strings (including property names)
@@ -118,7 +119,7 @@ const getBasicSyntaxParts = (serializedText: string): SyntaxPart[] => {
     // Object brackets
     { regex: /[{}]/g, type: 'objectBracket' },
     // Array brackets
-    { regex: /[\[\]]/g, type: 'arrayBracket' },
+    { regex: /[[\]]/g, type: 'arrayBracket' },
     // Commas
     { regex: /,/g, type: 'comma' },
     // Property names (quoted strings followed by colon)
@@ -133,7 +134,7 @@ const getBasicSyntaxParts = (serializedText: string): SyntaxPart[] => {
         const fullMatch = match[0];
         const colonIndex = fullMatch.lastIndexOf(':');
         const propertyPart = fullMatch.substring(0, colonIndex);
-        
+
         // Add quotes
         parts.push({
           type: 'objectPropertyStartQuotes',
@@ -142,7 +143,7 @@ const getBasicSyntaxParts = (serializedText: string): SyntaxPart[] => {
           match: '"',
           jsonPath: '$',
         });
-        
+
         // Add property name
         parts.push({
           type: 'objectProperty',
@@ -151,7 +152,7 @@ const getBasicSyntaxParts = (serializedText: string): SyntaxPart[] => {
           match: propertyPart.slice(1, -1),
           jsonPath: '$',
         });
-        
+
         // Add closing quotes
         parts.push({
           type: 'objectPropertyEndQuotes',
@@ -164,13 +165,15 @@ const getBasicSyntaxParts = (serializedText: string): SyntaxPart[] => {
         // Map some types to match existing styling
         let mappedType = type;
         if (type === 'objectBracket') {
-          mappedType = match[0] === '{' ? 'objectStartBracket' : 'objectEndBracket';
+          mappedType =
+            match[0] === '{' ? 'objectStartBracket' : 'objectEndBracket';
         } else if (type === 'arrayBracket') {
-          mappedType = match[0] === '[' ? 'arrayStartBracket' : 'arrayEndBracket';
+          mappedType =
+            match[0] === '[' ? 'arrayStartBracket' : 'arrayEndBracket';
         } else if (type === 'comma') {
           mappedType = 'arrayComma';
         }
-        
+
         parts.push({
           type: mappedType,
           index: match.index,
@@ -186,12 +189,15 @@ const getBasicSyntaxParts = (serializedText: string): SyntaxPart[] => {
   return parts.sort((a, b) => a.index - b.index);
 };
 
-const calculateNewDecorationsMap = (value: CustomElement[], isPartialSchema: boolean = false) => {
+const calculateNewDecorationsMap = (
+  value: CustomElement[],
+  isPartialSchema: boolean = false,
+) => {
   const serializedText = serializeNodesWithoutLineBreaks(value);
   const textPathIndexes = getTextPathIndexesFromNodes(value);
-  
+
   let partsOfJson: SyntaxPart[];
-  
+
   if (isPartialSchema) {
     // Use basic syntax highlighting for partial schemas
     partsOfJson = getBasicSyntaxParts(serializedText);
@@ -199,7 +205,7 @@ const calculateNewDecorationsMap = (value: CustomElement[], isPartialSchema: boo
     // Use full JSON parsing for complete schemas
     partsOfJson = getPartsOfJson(serializedText);
   }
-  
+
   const multipathDecorations =
     getMultipathDecorationsByMatchesAndTextPathIndexes(
       partsOfJson,
@@ -275,10 +281,10 @@ const deserializeCode = (code: string): CustomElement[] => {
   return paragraphs;
 };
 
-export default function JsonEditor({ 
-  initialCode, 
-  isJsonc = false 
-}: { 
+export default function JsonEditor({
+  initialCode,
+  isJsonc = false,
+}: {
   initialCode: string;
   isJsonc?: boolean;
 }) {
@@ -296,11 +302,11 @@ export default function JsonEditor({
   })();
 
   const router = useRouter();
-  
+
   // Clean code and detect partial schema for JSONC
   const cleanedUpCode = React.useMemo(() => {
     let code = initialCode.replace(META_REGEX, '');
-    
+
     if (isJsonc) {
       // Remove partial schema comments for JSONC
       code = code
@@ -308,7 +314,7 @@ export default function JsonEditor({
         .replace(/\/\* partial schema \*\/\n?/g, '')
         .trim();
     }
-    
+
     return code;
   }, [initialCode, isJsonc]);
 
@@ -349,8 +355,10 @@ export default function JsonEditor({
   const isPartialSchema = React.useMemo(() => {
     if (!isJsonc) return false;
     const codeString = String(initialCode || '');
-    return codeString.includes('// partial schema') || 
-           codeString.includes('/* partial schema */');
+    return (
+      codeString.includes('// partial schema') ||
+      codeString.includes('/* partial schema */')
+    );
   }, [initialCode, isJsonc]);
 
   const isJsonSchema = React.useMemo(() => {
@@ -370,7 +378,7 @@ export default function JsonEditor({
         : 'invalid'
       : null;
   }, [meta]);
-  
+
   const caption: null | string = React.useMemo(() => {
     return meta?.caption || null;
   }, [meta]);
@@ -525,7 +533,8 @@ export default function JsonEditor({
                         JsonSchemaScope.TypeDefinition,
                     )
                     .map(
-                      (jsonPathsWithJsonScope) => jsonPathsWithJsonScope.jsonPath,
+                      (jsonPathsWithJsonScope) =>
+                        jsonPathsWithJsonScope.jsonPath,
                     )
                     .includes(leaf.syntaxPart?.parentJsonPath);
                   if (
@@ -561,7 +570,7 @@ export default function JsonEditor({
                   ].includes(leaf.syntaxPart?.type)
                 )
                   return 'text-lime-200';
-                
+
                 // Handle partial schema specific highlighting that might not match exactly
                 if (!leaf.syntaxPart?.type) {
                   // If no syntax part type, apply default white color for partial schemas

--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable react-hooks/rules-of-hooks */
+
 import React, { useContext, useEffect, useState } from 'react';
 import Markdown from 'markdown-to-jsx';
 import Link from 'next/link';
@@ -307,11 +310,11 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
               const isJsonCode = language === 'lang-json';
               const isJsoncCode = language === 'lang-jsonc';
               const code = children?.props?.children;
-              
+
               if (isJsonCode) {
                 return <JsonEditor initialCode={code} />;
               }
-              
+
               if (isJsoncCode) {
                 return <JsonEditor initialCode={code} isJsonc={true} />;
               }
@@ -731,7 +734,7 @@ export function TableOfContentMarkdown({
                       </a>
                     );
                   },
-                } /* eslint-enable */
+                }
               : { component: () => null },
           ...hiddenElements(
             'strong',

--- a/components/StyledMarkdown.tsx
+++ b/components/StyledMarkdown.tsx
@@ -9,6 +9,9 @@ import { atomOneDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 import Code from '~/components/Code';
 import { FullMarkdownContext } from '~/context';
 import Image from 'next/image';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 
 import {
   Headline1,
@@ -302,36 +305,94 @@ const StyledMarkdownBlock = ({ markdown }: { markdown: string }) => {
             pre: ({ children }) => {
               const language = children?.props?.className;
               const isJsonCode = language === 'lang-json';
+              const isJsoncCode = language === 'lang-jsonc';
               const code = children?.props?.children;
+              
               if (isJsonCode) {
                 return <JsonEditor initialCode={code} />;
               }
+              
+              if (isJsoncCode) {
+                return <JsonEditor initialCode={code} isJsonc={true} />;
+              }
+
+              // Copy functionality for regular code blocks
+              const [copied, setCopied] = React.useState(false);
+              const handleCopy = () => {
+                navigator.clipboard.writeText(code);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+              };
+
+              // Badge text logic
+              const getBadgeText = () => {
+                if (!language) return 'code';
+                const lang = language.replace('lang-', '');
+                return lang;
+              };
 
               return (
-                <div className='overflow-x-auto rounded-lg bg-gray-800 text-white'>
-                  <Highlight
-                    language={language}
-                    style={atomOneDark}
-                    showLineNumbers
-                    lineNumberStyle={{
-                      color: '#64748B',
-                      fontSize: '16px',
-                      paddingRight: '10px',
-                    }}
-                    customStyle={{
-                      padding: '12px',
-                      fontFamily: 'monospace',
-                      fontSize: '16px',
-                    }}
-                    codeTagProps={{
-                      style: {
-                        fontFamily: 'monospace',
-                      },
-                    }}
-                  >
-                    {code}
-                  </Highlight>
-                </div>
+                <Card className='relative font-mono bg-slate-800 border-slate-700 rounded-xl mt-1 overflow-hidden shadow-lg py-0'>
+                  <div className='flex flex-row absolute right-0 z-10'>
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className='mr-1.5 h-6 w-6 opacity-50 hover:opacity-90 duration-150'
+                      onClick={handleCopy}
+                    >
+                      {copied ? (
+                        <Image
+                          src='/icons/copied.svg'
+                          alt='Copied icon'
+                          width={20}
+                          height={20}
+                          title='Copied!'
+                        />
+                      ) : (
+                        <Image
+                          src='/icons/copy.svg'
+                          alt='Copy icon'
+                          title='Copy to clipboard'
+                          width={20}
+                          height={20}
+                        />
+                      )}
+                    </Button>
+                    <Badge
+                      variant='secondary'
+                      className='flex flex-row items-center text-white h-6 font-sans bg-white/20 text-xs px-3 rounded-bl-lg font-semibold border-0'
+                    >
+                      {getBadgeText()}
+                    </Badge>
+                  </div>
+                  <CardContent className='p-0'>
+                    <div className='overflow-x-auto'>
+                      <Highlight
+                        language={language}
+                        style={atomOneDark}
+                        showLineNumbers
+                        lineNumberStyle={{
+                          color: '#64748B',
+                          fontSize: '16px',
+                          paddingRight: '10px',
+                        }}
+                        customStyle={{
+                          padding: '12px',
+                          fontFamily: 'monospace',
+                          fontSize: '16px',
+                          backgroundColor: 'transparent',
+                        }}
+                        codeTagProps={{
+                          style: {
+                            fontFamily: 'monospace',
+                          },
+                        }}
+                      >
+                        {code}
+                      </Highlight>
+                    </div>
+                  </CardContent>
+                </Card>
               );
             },
             blockquote: {

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable linebreak-style */
+/* eslint-disable react/prop-types */
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  {
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot='alert'
+      role='alert'
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='alert-title'
+      className={cn(
+        'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='alert-description'
+      className={cn(
+        'text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription };

--- a/cypress/components/JsonEditor.cy.tsx
+++ b/cypress/components/JsonEditor.cy.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
 import JsonEditor from '~/components/JsonEditor';
 import React from 'react';
 import mockNextRouter, { MockRouter } from '../plugins/mockNextRouterUtils';
@@ -95,35 +96,34 @@ describe('JSON Editor Component', () => {
     // mount component
     cy.mount(<JsonEditor initialCode={JSON.stringify(initialCode, null, 2)} />);
 
-    // check if copy img is visible
+    // check if copy img is visible initially
     cy.get('[data-test="copy-clipboard-button"]')
       .children('img')
-      .should('have.length', 2)
-      .first()
+      .should('have.length', 1)
       .should('have.attr', 'src', '/icons/copy.svg')
       .should('be.visible');
 
-    // click on copy img
+    // click on copy button
     cy.get('[data-test="copy-clipboard-button"]').click();
 
-    // check if clipboard writeText is copied the correct code
+    // check if clipboard writeText is called with the correct code
     cy.get('@clipboardWriteText').should(
       'have.been.calledWith',
       JSON.stringify(initialCode, null, 2) + '\n',
     );
 
-    // check if copied img is visible
+    // check if copied img is visible after clicking
     cy.get('[data-test="copy-clipboard-button"]')
       .children('img')
-      .last()
+      .should('have.length', 1)
       .should('have.attr', 'src', '/icons/copied.svg')
       .should('be.visible');
 
     // after 2 seconds, check if copy img is visible again
+    cy.wait(2100); // Wait slightly longer than the 2000ms timeout
     cy.get('[data-test="copy-clipboard-button"]')
       .children('img')
-      .should('have.length', 2)
-      .first()
+      .should('have.length', 1)
       .should('have.attr', 'src', '/icons/copy.svg')
       .should('be.visible');
   });

--- a/pages/learn/getting-started-step-by-step/getting-started-step-by-step.md
+++ b/pages/learn/getting-started-step-by-step/getting-started-step-by-step.md
@@ -103,6 +103,7 @@ To add the `properties` object to the schema:
 1. Add the `properties` validation keyword to the end of the schema:
 
     ```jsonc
+    // partial schema
     ...
       "title": "Product",
       "description": "A product from Acme's catalog",
@@ -117,6 +118,7 @@ To add the `properties` object to the schema:
     * `type`: defines what kind of data is expected. For this example, since the product identifier is a numeric value, use `integer`.
 
       ```jsonc
+      // partial schema
       ...
         "properties": {
           "productId": {
@@ -177,6 +179,7 @@ To define a required property:
 1. Inside the `properties` object, add the `price` key. Include the usual schema annotations `description` and `type`, where `type` is a number:
 
     ```jsonc
+    // partial schema
       "properties": {
         ...
         "price": {
@@ -189,6 +192,7 @@ To define a required property:
 2. Add the `exclusiveMinimum` validation keyword and set the value to zero:
 
     ```jsonc
+    // partial schema
       "price": {
         "description": "The price of the product",
         "type": "number",
@@ -199,6 +203,7 @@ To define a required property:
 3. Add the `required` validation keyword to the end of the schema, after the `properties` object. Add `productID`, `productName`, and the new `price` key to the array:
 
     ```jsonc
+    // partial schema
     ...
       "properties": {
         ...
@@ -255,6 +260,7 @@ To define an optional property:
 1. Inside the `properties` object, add the `tags` keyword. Include the usual schema annotations `description` and `type`, and define `type` as an array:
 
     ```jsonc
+    // partial schema
     ...
       "properties": {
         ...
@@ -268,6 +274,7 @@ To define an optional property:
 2. Add a new validation keyword for `items` to define what appears in the array. For example, `string`:
 
     ```jsonc
+    // partial schema
     ...
         "tags": {
           "description": "Tags for the product",
@@ -281,6 +288,7 @@ To define an optional property:
 3. To make sure there is at least one item in the array, use the `minItems` validation keyword:
 
     ```jsonc
+    // partial schema
     ...
         "tags": {
           "description": "Tags for the product",
@@ -295,6 +303,7 @@ To define an optional property:
 4. To make sure that every item in the array is unique, use the `uniqueItems` validation keyword and set it to `true`:
 
     ```jsonc
+    // partial schema
     ...
         "tags": {
           "description": "Tags for the product",
@@ -357,6 +366,7 @@ To create a nested data structure:
 1. Inside the `properties` object, create a new key called `dimensions`:
 
     ```jsonc
+    // partial schema
     ...
       "properties": {
       ...
@@ -367,6 +377,7 @@ To create a nested data structure:
 2. Define the `type` validation keyword as `object`:
 
     ```jsonc
+    // partial schema
     ...
       "dimensions": {
         "type": "object"
@@ -376,6 +387,7 @@ To create a nested data structure:
 3. Add the `properties` validation keyword to contain the nested data structure. Inside the new `properties` keyword, add keywords for `length`, `width`, and `height` that all use the `number` type:
 
     ```jsonc
+    // partial schema
     ...
       "dimensions": {
         "type": "object",
@@ -396,6 +408,7 @@ To create a nested data structure:
 4. To make each of these properties required, add a `required` validation keyword inside the `dimensions` object:
 
     ```jsonc
+    // partial schema
     ...
       "dimensions": {
         "type": "object",
@@ -504,6 +517,7 @@ To reference this schema in the product catalog schema:
 1. Inside the `properties` object, add a key named `warehouseLocation`:
 
     ```jsonc
+    // partial schema
     ...
       "properties": {
       ...
@@ -514,6 +528,7 @@ To reference this schema in the product catalog schema:
 2. To link to the external geographical location schema, add the `$ref` schema keyword and the schema URL:
 
     ```jsonc
+    // partial schema
     ...
       "warehouseLocation": {
         "description": "Coordinates of the warehouse where the product is located.",

--- a/pages/understanding-json-schema/reference/non_json_data.md
+++ b/pages/understanding-json-schema/reference/non_json_data.md
@@ -79,7 +79,7 @@ To better understand how `contentEncoding` and `contentMediaType` are applied in
 ![Role of contentEncoding and contenMediaType keywords in the transmission of non-JSON data](/img/media-keywords.png)
 -->
 
-```mermaid
+```code
 block-beta
    columns 9
    A space B space C space D space E


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Adapted the JSON editor component to use ShadCN and updated the Cypress tests accordingly.

Now you can create partial schema JSON blocks using //partial schema at the top of the schema, instead of the default code blocks. Also, the default code block styling has been updated to match the JSON editor styling. also have fixed some bugs related the JSON editor inputs

**Issue Number:**

-  Closes #1613 
-  Related to #1657 


**Screenshots/videos:**

![Screenshot 2025-07-05 193237](https://github.com/user-attachments/assets/da15e94b-69e1-409f-a582-f839f1da5287)

![Screenshot 2025-07-05 193200](https://github.com/user-attachments/assets/c92579be-7383-4cfc-88d4-3c4172034157)


**Summary**

This PR improves the visual consistency and user experience of the JSON editor by integrating ShadCN components, enabling partial schema support via //partial schema, and refining the styling of code blocks to align with the editor. It also addresses several bugs related to input behavior.

**Does this PR introduce a breaking change?**

no

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [ ] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).