### PR TITLE
Fix supportedDialects for v8r

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -2410,7 +2410,7 @@
   license: 'MIT'
   source: 'https://github.com/chris48s/v8r'
   supportedDialects:
-    draft: ['4', '6', '7']
+    draft: ['4', '6', '7', '2019-09', '2020-12']
   lastUpdated: '2024-09-03'
 
 - name: justinrainbow/json-schema


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Update tooling data file

**Issue Number:**

n/a

**Screenshots/videos:**

n/a

**If relevant, did you update the documentation?**

n/a

**Summary**

Fix the `supportedDialects` value for v8r. Source:
https://chris48s.github.io/v8r/faq/#-what-json-schema-versions-are-compatible

This data was correct in https://github.com/json-schema-org/website/blob/f83ccfe47f34e2b403c2b1662d3268b357199381/data/validator-libraries-modern.yml#L574-L575

It looks like this may have been migrated incorrectly in https://github.com/json-schema-org/website/commit/33dbd28267eeca782fbacc8fa69c9113b09ee03c

I've not really dug into it, but having cherry-picked a few examples, it does look like there are other projects where the content from the `date-draft` field was lost :grimacing: 

**Does this PR introduce a breaking change?**

no

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).