### PR TITLE
Add @hyperjump/Json-schema-coverage to the tooling page

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -448,6 +448,23 @@
   toolingListingNotes: 'Built for Node.js and browsers. Includes support for custom vocabularies.'
   lastUpdated: '2024-09-04'
 
+- name: json-schema.hyperjump.io
+  description: 'Validate JSON Schema documents online using @hyperjump/json-schema'
+  toolingTypes: ['validator']
+  environments: ['Web (Online)']
+  dependsOnValidators: ['https://github.com/hyperjump-io/json-schema']
+  maintainers:
+    - name: 'Jason Desrosiers'
+      username: 'jdesrosiers'
+      platform: 'github'
+  license: 'MIT'
+  source: 'https://github.com/hyperjump-io/json-schema.hyperjump.io'
+  homepage: 'https://json-schema.hyperjump.io'
+  supportedDialects:
+    draft: ['4', '6', '7', '2019-09', '2020-12']
+  toolingListingNotes: 'Supports multiple schemas and multiple instances; client-side validation'
+  lastUpdated: '2022-08-31'
+
 - name: '@hyperjump/json-schema-coverage'
   description: >
     Generate test coverage reports for the JSON Schemas in your codebase.
@@ -888,23 +905,6 @@
   homepage: 'https://www.apiseven.com/'
   supportedDialects:
     draft: ['4', '6', '7']
-  lastUpdated: '2022-08-31'
-
-- name: json-schema.hyperjump.io
-  description: 'Validate JSON Schema documents online using @hyperjump/json-schema'
-  toolingTypes: ['validator']
-  environments: ['Web (Online)']
-  dependsOnValidators: ['https://github.com/hyperjump-io/json-schema']
-  maintainers:
-    - name: 'Jason Desrosiers'
-      username: 'jdesrosiers'
-      platform: 'github'
-  license: 'MIT'
-  source: 'https://github.com/hyperjump-io/json-schema.hyperjump.io'
-  homepage: 'https://json-schema.hyperjump.io'
-  supportedDialects:
-    draft: ['4', '6', '7', '2019-09', '2020-12']
-  toolingListingNotes: 'Supports multiple schemas and multiple instances; client-side validation'
   lastUpdated: '2022-08-31'
 
 - name: json-everything

--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -448,6 +448,26 @@
   toolingListingNotes: 'Built for Node.js and browsers. Includes support for custom vocabularies.'
   lastUpdated: '2024-09-04'
 
+- name: '@hyperjump/json-schema-coverage'
+  description: >
+    Generate test coverage reports for the JSON Schemas in your codebase.
+    Supports JSON and YAML. Integrates with Vitest.
+  toolingTypes: ['util-testing']
+  languages: ['JavaScript']
+  maintainers:
+    - name: 'Jason Desrosiers'
+      username: 'jdesrosiers'
+      platform: 'github'
+  license: 'MIT'
+  source: 'https://github.com/hyperjump-io/json-schema-coverage'
+  supportedDialects:
+    draft: ['4', '6', '7', '2019-09', '2020-12']
+  toolingListingNotes: >
+    Designed to be used with or without Vitest. Coverage data uses the istanbul
+    coverage format. @hyperjump/json-schema is used for validation and
+    instrumentation.
+  lastUpdated: '2025-07-21'
+
 - name: '@exodus/schemasafe'
   description: 'A reasonably safe JSON Schema validator with draft-04/06/07/2019-09/2020-12 support.'
   toolingTypes: ['validator']


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This adds [@hyperjump/json-schema-coverage](https://github.com/hyperjump-io/json-schema-coverage) to the tooling page.

**Does this PR introduce a breaking change?**

No

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).