### PR TITLE
fixing blog banner

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -198,7 +198,7 @@ export default function StaticMarkdownPage({
       </Head>
       <div className='max-w-[1400px] mx-auto overflow-x-hidden flex flex-col items-center mt-0 sm:mt-10'>
         {recentBlog[0] && (
-          <div className='relative w-full aspect-[16/9] bg-black clip-bottom mt-1.5 flex flex-col items-center justify-start dark:bg-slate-700'>
+          <div className='relative w-full h-[500px] sm:h-[400px] bg-black clip-bottom mt-1.5 flex flex-col items-center justify-start dark:bg-slate-700'>
             <div className='absolute w-full h-full dark:bg-[#282d6a]' />
             <Image
               src={recentBlog[0].frontmatter.cover}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix - reduces the height of the banner on the blog page

**Issue Number:**

-  Closes #1780 

**Screenshots/videos:**

<img width="1888" height="838" alt="image" src="https://github.com/user-attachments/assets/4b108095-fecb-4542-873a-d40735eaf001" />

**Summary**

The current blog page banner takes up too much vertical space. This PR adjusts the banner's height and padding.

**Does this PR introduce a breaking change?**

no

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).