### PR TITLE
Remove duplicate definition of primaryKey from example in a case study

### DIFF
--- a/pages/blog/posts/rxdb-case-study.md
+++ b/pages/blog/posts/rxdb-case-study.md
@@ -53,7 +53,6 @@ Below is a sample RxDB schema that demonstrates how standard JSON Schema vocabul
 
 ```ts
 const mySchema = {
-    primaryKey: 'id',
     type: 'object',
     properties: {
         id: {


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Docs
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Others? <!-- Add any additional notes or references here --> Found this while browsing the website. I do not have an Issue Number.

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
In the example json schema, the primaryKey is defined twice. Retained the second instance, as it is after the appropriate comment.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No
# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [ x ] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).