### PR TITLE
Update tooling-data.yaml by adding 2 tools

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3486,3 +3486,33 @@
   supportedDialects:
     draft: ['2020-12']
   toolingListingNotes: 'SJF4J has passed Bowtie evaluation and provides full Draft 2020-12 support. Validates native Java objects directly without JSON serialization.'
+
+- name: 'json-schema-utils'
+  description: 'Random utilities to analyze and manipulate JSON Schema'
+  toolingTypes: ['validation', 'linter', 'schema-to-types', 'util-general-processing']
+  languages: ['Python']
+  maintainers:
+    - username: 'zx80'
+      platform: 'github'
+    - username: 'clairey-zx81'
+      platform: 'github'
+  license: 'Public Domain'
+  source: 'https://github.com/zx80/json-schema-utils'
+  homepage: 'https://github.com/zx80/json-schema-utils'
+  supportedDialects:
+    draft: [1, 2, 3, 4, 5, 6, 7, '2019-09', '2020-12']
+
+- name: 'json-model'
+  description: 'JSON Model Tools: compilers (C, Python, JavaScript, PL/pgSQL, Java) and exporters (JSON Schema, Pydantic)'
+  toolingTypes: 'model-to-schema'
+  languages: ['Python']
+  maintainers:
+    - username: 'clairey-zx81'
+      platform: 'github'
+    - username: 'zx80'
+      platform: 'github'
+  license: 'Public Domain'
+  source: 'https://github.com/clairey-zx81/json-model'
+  homepage: 'https://github.com/clairey-zx81/json-model'
+  supportedDialects:
+    draft: ['2020-12']

--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3489,7 +3489,7 @@
 
 - name: 'json-schema-utils'
   description: 'Random utilities to analyze and manipulate JSON Schema'
-  toolingTypes: ['validation', 'linter', 'schema-to-types', 'util-general-processing']
+  toolingTypes: ['validator', 'linter', 'schema-to-types', 'util-general-processing']
   languages: ['Python']
   maintainers:
     - username: 'zx80'
@@ -3500,11 +3500,11 @@
   source: 'https://github.com/zx80/json-schema-utils'
   homepage: 'https://github.com/zx80/json-schema-utils'
   supportedDialects:
-    draft: [1, 2, 3, 4, 5, 6, 7, '2019-09', '2020-12']
+    draft: ['1', '2', '3', '4', '5', '6', '7', '2019-09', '2020-12']
 
 - name: 'json-model'
   description: 'JSON Model Tools: compilers (C, Python, JavaScript, PL/pgSQL, Java) and exporters (JSON Schema, Pydantic)'
-  toolingTypes: 'model-to-schema'
+  toolingTypes: ['model-to-schema']
   languages: ['Python']
   maintainers:
     - username: 'clairey-zx81'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It adds to tools which are related to JSON Schema: a set of JSON Schema utils and a compiler which can export type description to JSON Schema.

**Issue Number:**

Closes #1831.

**Screenshots/videos:**

NA.

**If relevant, did you update the documentation?**

NA.

**Summary**

It adds new tools in the long list of available tools.

It is a re-submission of #1636 that I thought had been merged, but I was wrong.
I have removed the mention of the `next` version as it seemed to generate some concerns.

The combination of the two tools constitute a viable and  rather fast JSON Schema compiler by using the schema-to-model converter of the first tool and the model compiler from the second tool.

**Does this PR introduce a breaking change?**

No.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).