### PR TITLE
feat: Add Blaze4J tool to tooling data

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3422,3 +3422,26 @@
   source: 'https://github.com/gmr/jsonschema-models'
   supportedDialects:
     draft: ['2020-12']
+
+- name: 'Blaze4J'
+  description: 'Blaze4J is a high-performance Java wrapper for the Blaze JSON Schema validator,'
+  toolingTypes: ['validator']
+  languages: ['Java']
+  environments: ['Windows', 'Linux', 'macOS']
+  creators:
+    - name: 'Madhav Dhatrak (Contributor)'
+      username: 'MadhavDhatrak'
+      platform: 'github'
+    - name: 'Bence Eros (Mentor)'
+      username: 'erosb'
+      platform: 'github'
+  maintainers:
+    - name: 'Madhav Dhatrak'
+      username: 'MadhavDhatrak'
+      platform: 'github'
+  license: 'AGPL-3.0'
+  source: 'https://github.com/MadhavDhatrak/Blaze4J.git'
+  homepage: 'https://github.com/MadhavDhatrak/Blaze4J.git'
+  supportedDialects:
+    draft: ['4', '6', '7', '2019-09', '2020-12']
+  toolingListingNotes: 'Project built under GSoC "25. High-performance Java wrapper for Blaze JSON Schema validator using Java FFM API.'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR adds the Blaze4J tool to the tooling-data.yaml file. Blaze4J is a high-performance Java wrapper for the Blaze JSON Schema validator, built as part of GSoC '25.

**Issue Number:**

-  Closes #1836 


**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**
This PR adds the Blaze4J tool to the `tooling-data.yaml` file. Blaze4J is a high-performance Java wrapper for the Blaze JSON Schema validator, built as part of Google Summer of Code 2025 (GSoC '25).

**Key Highlights**
- Support for JSON Schema drafts: 2020-12, 2019-09, draft-07/06/04
- Custom resolvers: HTTP and classpath-based
- Cross-platform compatibility: Windows, Linux, macOS
- Detailed validation and rich error reporting
- Clean and intuitive Java API for seamless integration
- Cleaner result handling  automatic cleanup of finalized objects after validation
- Logging support via java.util.logging
- Full migration to Java 22 Foreign Function & Memory (FFM) API
- SchemaCompiler class  Introduced a new SchemaCompiler for faster and more reusable schema handling.
-  Pre-register feature  Preload schemas in advance for efficient, repeated validations.


**Does this PR introduce a breaking change?**
 No - This is an additive change to the tooling database

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).