### PR TITLE
Fix docs typo: replace "string" with "type" fixes #1860

### DIFF
--- a/pages/understanding-json-schema/reference/type.md
+++ b/pages/understanding-json-schema/reference/type.md
@@ -129,7 +129,7 @@ The `type` keyword can take two forms:
 
 1. **A single string**. When it is a single string, it must be one of the types mentioned above (`array`, `boolean`, `integer`, `number`, `null`, `object`, `regular expressions`, or `string`). This specifies that the instance data is only valid when it matches that specific type. 
 
-Here is an example of using the `string` keyword as a single string:
+Here is an example of using the `type` keyword as a single string:
 
 ```json
 // props { "isSchema": true }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixed misleading title from “string” → “number”

**Issue Number:**
-  Closes #1860 

**Summary**

This pull request corrects the typo and inconsistency in the installation guide.
The section previously stated “Here is an example of using the string keyword” while it should be type keyword.
The heading and example text have been updated for accuracy and clarity.

**Does this PR introduce a breaking change?**

No