### PR TITLE
fix: correct JSON formatting for "country" property

### DIFF
--- a/pages/understanding-json-schema/about.md
+++ b/pages/understanding-json-schema/about.md
@@ -113,7 +113,7 @@ explained in subsequent chapters.
          "street_address": { "type": "string" },
          "city": { "type": "string" },
          "state": { "type": "string" },
-         "country": { "type" : "string" }
+         "country": { "type": "string" }
        }
     }
   }


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

- Bugfix: Corrected JSON formatting in the `country` property to ensure valid JSON.

**Screenshots/videos:**

- Before
 
<img width="1903" height="842" alt="Screenshot 2025-10-18 041013" src="https://github.com/user-attachments/assets/6232dc07-cf9f-4e5d-a535-43ecb2b798fc" />


- Now
<img width="1736" height="800" alt="Screenshot 2025-10-18 041051newww" src="https://github.com/user-attachments/assets/bcdf91bd-0c48-44d7-988a-f56c14e7f8fa" />


**If relevant, did you update the documentation?**

- No documentation changes required.

**Summary**

The country property in the JSON schema contained a formatting issue (an extra space before the colon), which caused parsing errors during the build process. This PR corrects the formatting to comply with valid JSON standards, ensuring consistent parsing, proper validation, and a successful build.

**Does this PR introduce a breaking change?**

- No, this is a non-breaking fix.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
