### PR TITLE
feat: Add interactive hover effects to homepage feature cards

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -262,7 +262,7 @@ const Home = (props: any) => {
           </div>
           {/* Feature 4 section*/}
           <div className='w-5/6 lg:w-3/5 grid grid-cols-1 md:grid-cols-2 gap-6   my-[85px] mx-auto '>
-            <div className='w-full  shadow-3xl  rounded-[10px] p-[20px] dark:shadow-slate-700'>
+            <div className='w-full shadow-3xl rounded-[10px] p-[20px] dark:shadow-slate-700 transition-all duration-300 ease-in-out hover:scale-[1.03] hover:shadow-[0_10px_40px_rgba(0,44,196,0.15)] dark:hover:shadow-[0_10px_40px_rgba(84,104,255,0.2)]'>
               <h3 className='text-h5mobile md:text-h5 font-semibold mb-6 dark:text-slate-200'>
                 Streamline testing and validation
               </h3>
@@ -273,7 +273,7 @@ const Home = (props: any) => {
                 invalid data.
               </p>
             </div>
-            <div className='w-full  shadow-3xl  rounded-[10px] p-[20px] dark:shadow-slate-700'>
+            <div className='w-full shadow-3xl rounded-[10px] p-[20px] dark:shadow-slate-700 transition-all duration-300 ease-in-out hover:scale-[1.03] hover:shadow-[0_10px_40px_rgba(0,44,196,0.15)] dark:hover:shadow-[0_10px_40px_rgba(84,104,255,0.2)]'>
               <h3 className='text-h5mobile md:text-h5 font-semibold mb-6 dark:text-slate-200'>
                 Exchange data seamlessly
               </h3>
@@ -285,7 +285,7 @@ const Home = (props: any) => {
                 platforms.
               </p>
             </div>
-            <div className='w-full  shadow-3xl  rounded-[10px] p-[20px] dark:shadow-slate-700'>
+            <div className='w-full shadow-3xl rounded-[10px] p-[20px] dark:shadow-slate-700 transition-all duration-300 ease-in-out hover:scale-[1.03] hover:shadow-[0_10px_40px_rgba(0,44,196,0.15)] dark:hover:shadow-[0_10px_40px_rgba(84,104,255,0.2)]'>
               <h3 className='text-h5mobile md:text-h5 font-semibold mb-6 dark:text-slate-200 '>
                 Document your data
               </h3>
@@ -295,7 +295,7 @@ const Home = (props: any) => {
                 stakeholders, and collaborators.
               </p>
             </div>
-            <div className='w-full  shadow-3xl  rounded-[10px] p-[20px] dark:shadow-slate-700'>
+            <div className='w-full shadow-3xl rounded-[10px] p-[20px] dark:shadow-slate-700 transition-all duration-300 ease-in-out hover:scale-[1.03] hover:shadow-[0_10px_40px_rgba(0,44,196,0.15)] dark:hover:shadow-[0_10px_40px_rgba(84,104,255,0.2)]'>
               <h3 className='text-h5mobile md:text-h5 font-semibold mb-6 dark:text-slate-200'>
                 Vibrant tooling ecosystem
               </h3>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adds subtle and smooth hover effects to the four feature cards on the homepage to improve user experience and visual feedback. #1883 

## Changes
- Added transition animations to all four feature cards in the "Why JSON Schema?" section
- Implemented a 3% scale-up effect on hover
- Added themed shadow/glow effects (blue for light mode, purple for dark mode)
- Cleaned up class name formatting (removed extra whitespace)

## Visual Effects
- **Transform:** Slight scale-up (`scale(1.03)`) for a lift effect
- **Shadow:** Soft blue glow in light mode, purple glow in dark mode
- **Transition:** Smooth 300ms animation for all properties

## Benefits
-  Improves visual feedback for users
-  Enhances modern and dynamic appearance of the website
-  Maintains consistency with existing button hover effects
- Works seamlessly in both light and dark modes

## Testing
- [x] Tested in light mode
- [x] Tested in dark mode
- [x] Verified smooth transitions
- [x] Confirmed no layout shifts

## Related Issue
Closes #1883


**Screenshots/videos:**

https://github.com/user-attachments/assets/37d186ef-3729-44e1-b5af-c7807cab3b3e


# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).