### PR TITLE
Bug: Remove duplicate lang javasrcipt in Tools filter drop down

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -543,7 +543,7 @@
 - name: json-schema-library
   description: 'Customizable and hackable json-validator and json-schema utilities for traversal, data generation and validation'
   toolingTypes: ['validator', 'util-general-processing', 'schema-to-data']
-  languages: ['Javascript', 'TypeScript']
+  languages: ['JavaScript', 'TypeScript']
   maintainers:
     - name: 'Sascha Goldhofer'
       username: 'sagold'


### PR DESCRIPTION
**What kind of change does this PR introduce?**
   Bug fix

**Issue Number:**
- Closes #1887 

**Screenshots/videos:**

**Before Changes**
<img src="https://github.com/user-attachments/assets/73b6535c-6bea-484b-9a23-7591e2183baa" width="300" alt="Before Screenshot" />

**After Changes**
<img src="https://github.com/user-attachments/assets/5478a260-68e6-4cd8-9daf-7f2110f78b12" width="300" alt="After Screenshot" />


**Summary**
This PR resolves the bug where both “JavaScript” and “Javascript” appeared under the Tools → Language section.
The issue was caused by inconsistent casing in tooling-data.yaml, which has now been corrected so only “JavaScript” appears.

**Does this PR introduce a breaking change?**
No
# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).