### PR TITLE
fix: ensure Media Partner image renders consistently across themes

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -164,6 +164,7 @@ const Home = (props: any) => {
       setSourcemeta_logo('/img/logos/sponsors/sourcemeta-logo-dark.svg');
       setSupadata_logo('/img/logos/sponsors/supadata-logo-dark.svg');
       setDottxt_logo('/img/logos/sponsors/dottxt-logo-dark.svg');
+      setDevevents_logo('/img/logos/dark-mode/dev_events_logo.png');
     }
   }, [resolvedTheme]);
   return (


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix — ensures the "Dev Events" Media Partner image loads properly in both light and dark modes, including after page reloads.

**Issue Number:**
Closes #1925 

**Screenshots/videos:**
<img width="1282" height="634" alt="Screenshot 2025-11-17 at 10 00 41 AM" src="https://github.com/user-attachments/assets/d01e6f7a-ca77-4511-a665-2e53a499eb78" />
<img width="1222" height="587" alt="Screenshot 2025-11-17 at 4 40 24 PM" src="https://github.com/user-attachments/assets/d5262a61-fc82-4dfc-a23a-ede72e4ac587" />

**If relevant, did you update the documentation?**
Not needed — no documentation changes required.

**Summary**
This PR fixes an issue where the “Dev Events” image under the Media Partner section failed to render in light mode after a page reload, despite displaying correctly in dark mode.

**Does this PR introduce a breaking change?**
No — this fix is fully backward-compatible.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.
* [x] I have read, understood, and followed the [[contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md)](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
* [x] I have tested the fix in both light and dark modes.
* [x] I have verified that the image renders correctly after a page reload.
* [x] I have added screenshots where applicable.
