### PR TITLE
Enhancement: Added Hover States to “GROUP BY” Filter Buttons

### DIFF
--- a/pages/tools/components/GroupByMenu.tsx
+++ b/pages/tools/components/GroupByMenu.tsx
@@ -45,7 +45,7 @@ const GroupByMenu = ({ transform, setTransform }: GroupByMenuProps) => {
             value={group.accessorKey}
             onClick={setGroupBy}
             variant={groupedBy === group.accessorKey ? 'default' : 'outline'}
-            className={`${groupedBy === group.accessorKey ? 'text-white dark:text-slate-900 dark:bg-[#bfdbfe]' : 'dark:bg-[#0f172a] text-black dark:text-slate-300 dark:border-transparent'}`}
+            className={`${groupedBy === group.accessorKey ? 'text-white dark:text-slate-900 dark:bg-[#bfdbfe] hover:scale-105 hover:shadow-lg' : 'dark:bg-[#0f172a] text-black dark:text-slate-300 dark:border-transparent hover:bg-slate-200 hover:border-slate-300 dark:hover:bg-slate-700 dark:hover:border-slate-600 hover:scale-105 hover:shadow-md'} transition-all duration-200`}
           >
             {group.label}
           </Button>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR adds hover effects to the **None**, **Tooling Type**, and **Language** filter buttons on the Tools page.  
The new hover states provide clear visual feedback and enhance overall interactivity.

- Added distinct background hover states for all filter buttons  
- Implemented smooth transitions aligned with the existing design system  
- Ensured hover states remain visually different from the active/selected state


<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1935  <!-- Replace ___ with the issue number this PR resolves -->


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**
- Improved user experience with immediate visual feedback  
- More intuitive and interactive interface  
- Better design consistency across the page

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).