### PR TITLE
Add missing light mode border in Community section

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -374,7 +374,7 @@ const Home = (props: any) => {
             </p>
           </div>
           <div className='grid grid-cols-1 lg:grid-cols-3 gap-6 mb-12 mx-auto w-5/6 md:w-3/5 lg:w-5/6'>
-            <div className='p-4 w-full mb-6 dark:shadow-2xl'>
+            <div className='p-4 w-full mb-6 border border-slate-300 rounded-lg dark:border-none dark:shadow-2xl'>
               <Link href='https://json-schema.org/slack'>
                 <h3 className='mb-4 font-semibold flex items-center dark:text-slate-200'>
                   Join the JSON Schema Slack Workspace!
@@ -429,7 +429,7 @@ const Home = (props: any) => {
               </button>
             </div>
             {/* BlogPost Data */}
-            <div className='p-4 w-full mb-6 dark:shadow-2xl'>
+            <div className='p-4 w-full mb-6 border border-slate-300 rounded-lg dark:border-none dark:shadow-2xl'>
               <Link href={`/blog/posts/${blogPosts[0].slug}`}>
                 <h3 className='mb-5 font-semibold pt-1 dark:text-slate-200'>
                   The JSON Schema Blog
@@ -513,7 +513,7 @@ const Home = (props: any) => {
               </div>
             </div>
             <div>
-              <div className='p-4 md:w-full mb-6 mr-4 dark:shadow-2xl'>
+              <div className='p-4 w-full mb-6 border border-slate-300 rounded-lg dark:border-none dark:shadow-2xl'>
                 <h3 className='mb-2 font-semibold dark:text-slate-200'>
                   JSON Schema Community Meetings & Events
                 </h3>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

A bugfix — added missing border for the Community section cards in Light Mode.

**Issue Number:**
- Closes #1926

**Screenshots/videos:**


<img width="1512" height="863" alt="Screenshot 2025-11-22 at 10 35 43 PM" src="https://github.com/user-attachments/assets/ea83ba78-bbe4-46c2-9a00-a3d452ad949f" />

**If relevant, did you update the documentation?**

Not applicable.

**Summary**

This PR fixes the missing border in Light Mode for the community cards (Slack, Blog, and GitHub links).  
Dark mode styles are untouched.  
This improves the visual consistency and UI clarity in Light Mode.

**Does this PR introduce a breaking change?**

No breaking changes introduced.

# Checklist

- [x] Read, understood, and followed the contributing guidelines.
