### PR TITLE
feat: add pagination to blog page (10 posts per page)

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -316,37 +316,8 @@ export default function StaticMarkdownPage({
           </span>
         </div>
 
-        {/* pagination control */}
-        <div className='flex justify-center items-center gap-4 my-5'>
-          <button
-            className={`px-4 py-2 rounded-md font-semibold ${
-              currentPage === 1
-                ? 'bg-gray-300 dark:bg-slate-600 cursor-not-allowed'
-                : 'bg-blue-600 text-white hover:bg-blue-700'
-            }`}
-            disabled={currentPage === 1}
-            onClick={() => setCurrentPage((p) => p - 1)}
-          >
-            Previous
-          </button>
-          <span className='text-lg font-medium dark:text-white'>
-            Page {currentPage} of {totalPages}
-          </span>
-          <button
-            className={`px-4 py-2 rounded-md font-semibold ${
-              currentPage === totalPages
-                ? 'bg-gray-300 dark:bg-slate-600 cursor-not-allowed'
-                : 'bg-blue-600 text-white hover:bg-blue-700'
-            }`}
-            disabled={currentPage === totalPages}
-            onClick={() => setCurrentPage((p) => p + 1)}
-          >
-            Next
-          </button>
-        </div>
-
         {/* Blog Posts Grid */}
-        <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-6 grid-flow-row mb-20 bg-white dark:bg-slate-800 mx-auto p-4'>
+        <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-6 grid-flow-row mb-16 bg-white dark:bg-slate-800 mx-auto p-4'>
           {currentPagePosts.map((blogPost: any, idx: number) => {
             const { frontmatter, content } = blogPost;
             const date = new Date(frontmatter.date);
@@ -476,6 +447,34 @@ export default function StaticMarkdownPage({
               </section>
             );
           })}
+        </div>
+        {/* pagination control */}
+        <div className='flex justify-center items-center gap-4'>
+          <button
+            className={`px-4 py-2 rounded-md font-semibold ${
+              currentPage === 1
+                ? 'bg-gray-300 dark:bg-slate-600 cursor-not-allowed'
+                : 'bg-blue-600 text-white hover:bg-blue-700'
+            }`}
+            disabled={currentPage === 1}
+            onClick={() => setCurrentPage((p) => p - 1)}
+          >
+            Previous
+          </button>
+          <span className='text-lg font-medium dark:text-white'>
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            className={`px-4 py-2 rounded-md font-semibold ${
+              currentPage === totalPages
+                ? 'bg-gray-300 dark:bg-slate-600 cursor-not-allowed'
+                : 'bg-blue-600 text-white hover:bg-blue-700'
+            }`}
+            disabled={currentPage === totalPages}
+            onClick={() => setCurrentPage((p) => p + 1)}
+          >
+            Next
+          </button>
         </div>
       </div>
     </SectionContext.Provider>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR introduces a new feature -> **_Pagination for the Blog page_**

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1946 


**Screenshots/videos:**


https://github.com/user-attachments/assets/addf90e8-6ca4-41bd-92cd-f79113ea821e



**If relevant, did you update the documentation?**

Not applicable.

**Summary**

This PR adds pagination to the blog listing page to improve performance and user experience.  
The blog previously displayed *all posts on a single page*, creating long scrolls and slow load times.

Key changes included:
- Added **pagination with 10 posts per page**, arranged visually in **two rows of 5 cards each**.
- Implemented 'Previous' and 'Next' button for navigation controls.
- Ensured pagination state resets correctly when filters change.
- Added safe fallback to auto-reset to Page 1 if the filtered result has fewer pages.

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No.  
The existing blog structure remains unchanged. Pagination only enhances the UX.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).