### PR TITLE
test: added unit tests for markdownUtils hiddenElements

### DIFF
--- a/cypress/components/lib/markdownUtils.cy.ts
+++ b/cypress/components/lib/markdownUtils.cy.ts
@@ -1,0 +1,45 @@
+import { hiddenElements } from '~/lib/markdownUtils';
+
+type HiddenComponents = Record<string, { component: () => null }>;
+
+// Describe what we're testing
+describe('hiddenElements', () => {
+  // Test 1: Basic functionality
+  it('creates an object with a component for each element name', () => {
+    // Arrange: What we're testing with
+    const elementNames = ['Header', 'Footer', 'Sidebar'];
+
+    // Act: Call the function
+    const result = hiddenElements(...elementNames) as HiddenComponents;
+
+    // Assert: Check the result
+    // Should have 3 keys
+    expect(Object.keys(result)).to.have.length(3);
+
+    // Each key should exist
+    expect(result).to.have.property('Header');
+    expect(result).to.have.property('Footer');
+    expect(result).to.have.property('Sidebar');
+
+    // Each value should have a component function
+    expect(result.Header).to.have.property('component');
+    expect(result.Header.component).to.be.a('function');
+
+    // Component should return null
+    expect(result.Header.component()).to.be.null;
+  });
+
+  it('returns empty object when no elements provided', () => {
+    const result = hiddenElements();
+    expect(result).to.deep.equal({});
+  });
+
+  it('handles single element', () => {
+    const result = hiddenElements('Navbar') as Record<
+      string,
+      { component: () => null }
+    >;
+    expect(Object.keys(result)).to.have.length(1);
+    expect(result.Navbar.component()).to.be.null;
+  });
+});


### PR DESCRIPTION
### **What kind of change does this PR introduce?**
- Adds Cypress component tests for the `hiddenElements` utility function from `lib/markdownUtils.ts`.

### **Issue Number:**
- Closes #1995 

### **Changes**
Created `cypress/components/lib/markdownUtils.cy.ts` with 3 test cases:

1. Multiple elements: hiddenElements('Header', 'Footer', 'Sidebar')
2. Empty input: hiddenElements()
3. Single element: hiddenElements('Navbar')

**Document on how you can check the code without testing (Just for documentation and clarity)**
```
const hiddenElements = (...elements) => {
  return elements.reduce((acc, element) => {
    return {
      ...acc,
      [element]: { component: () => null },
    };
  }, {});
};

console.log('Test 1:', hiddenElements('A', 'B', 'C'));
console.log('Test 2:', hiddenElements());
console.log('Test 3:', hiddenElements('Single'));
```
This is going to show an output like 
```
'Test 1:' {
  A: { component: [Function: component] },
  B: { component: [Function: component] },
  C: { component: [Function: component] }
}
'Test 2:' {}
'Test 3:' { Single: { component: [Function: component] } }
```

### **Test Results**
<img width="1014" height="643" alt="image" src="https://github.com/user-attachments/assets/09add61e-cf6d-4861-a3fc-81bf36dad94d" />

### **Testing**
```
# Run the specific test file
yarn cypress run --component --spec "cypress/components/lib/markdownUtils.cy.ts"

# Or run all component tests
yarn cypress run --component
```

**Also, note on pre-commit hook failure -**
The pre-commit hook failed due to existing build issues **unrelated to this PR:**
- JSON parsing error in `/ambassadors` page
- Missing file: `_includes/community/programs/contractors/contractors.json`
I thought not to touch the `main ` branch without permission, so I left that.

**Verification steps (I've tested them all manually before commit)**
Verification Steps
1. TypeScript compiles: `yarn typecheck`
2. Linting passes: `yarn lint`
3. Tests pass: `yarn cypress run --component --spec "cypress/components/lib/markdownUtils.cy.ts"`
4.  No production code changes: Only test file added.

### **Future Work**
This PR establishes a testing pattern for markdownUtils.ts. Future PRs can add tests for:
- transformMarkdownLinks
- checkHasContent
- parseTabsFromMarkdown

**Adds test coverage without modifying production code, using the project's existing testing infrastructure.**