### PR TITLE
Fix(ui): mobile theme toggle failure when hamburger menu opened (#1991)

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -245,7 +245,9 @@ const MainNavigation = () => {
         >
           <Search />
         </div>
-        <DarkModeToggle />
+        <div onClick={() => useStore.setState({ overlayNavigation: null })}>
+          <DarkModeToggle />
+        </div>
         {showMobileNav === false ? (
           <div onClick={() => useStore.setState({ overlayNavigation: 'docs' })}>
             <div className='block lg:hidden space-y-2  items-center'>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
- Bug fix

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #1991  <!-- Replace ___ with the issue number this PR resolves -->


**Screenshots/videos:**
video of issue:
https://github.com/user-attachments/assets/87c14b13-a08e-4ac5-83c7-3c4dfcb9e93d

video after solving the issue:
https://github.com/user-attachments/assets/411cf24b-16ae-44f7-a090-3dfba19b836c

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
No

<!--Add link to it-->

**Summary**
This PR fixes the issue where the theme change (dark mode toggle) wasn't showing when the hamburger menu was open on mobile screens. The root cause was related to the overlay navigation state not being reset, preventing the toggle to not showing properly.
To resolve this, the `<DarkModeToggle/>` component is wrapped in a div that calls `useStore.setState({ overlayNavigation: null })` when clicked. This ensures that the overlay is closed and the theme change works as expected even when the menu is open.
<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).