### PR TITLE
Remove Background Image from Oracle Case Study Blog Post

### DIFF
--- a/pages/blog/posts/oracle-case-study.md
+++ b/pages/blog/posts/oracle-case-study.md
@@ -5,7 +5,6 @@ tags:
   - database
   - relational
 type: Case Study
-cover: /img/posts/2025/oracle-case-study/banner.webp
 authors:
   - name: Loïc Lefèvre
     photo: /img/avatars/loiclefevre.webp


### PR DESCRIPTION
## Description

This PR removes the background/cover image from the Oracle case study blog post header because it's the image was overlapping with the text and because of the text was not readable.

## Changes Made

- **File Modified:** `pages/blog/posts/oracle-case-study.md`
- **Change:** Removed the `cover` property from the frontmatter

### Before
```yaml
type: Case Study
cover: /img/posts/2025/oracle-case-study/banner.webp
authors:
```
<img width="1507" height="815" alt="Screenshot 2025-12-21 at 12 32 32 AM" src="https://github.com/user-attachments/assets/5aac266f-8462-4b30-a46d-7a2d2c260fe0" />


### After
```yaml
type: Case Study
authors:
```
<img width="1503" height="809" alt="Screenshot 2025-12-21 at 12 30 53 AM" src="https://github.com/user-attachments/assets/72d8fc1d-cb98-4cfc-abf3-ff7f44d46de6" />


## Reason for Change

Removed the background image behind the heading "How Oracle is Bridging the Gap Between JSON Schema and Relational Databases" as requested.

