### PR TITLE
Add consistent borders to homepage cards in Light and Dark modes

### DIFF
--- a/pages/community/index.page.tsx
+++ b/pages/community/index.page.tsx
@@ -119,7 +119,12 @@ export default function communityPages(props: any) {
                       priority={index < 10}
                       loading={index < 10 ? 'eager' : 'lazy'}
                       quality={75}
-                      className='sm:w-[40px] md:w-[45px] lg:w-[50px] sm:h-[40px] md:h-[45px] lg:h-[50px] rounded-full border-black'
+                      className='
+sm:w-[40px] md:w-[45px] lg:w-[50px]
+sm:h-[40px] md:h-[45px] lg:h-[50px]
+rounded-full
+border border-black dark:border-gray-300
+'
                     />
                   ))}
               </div>

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -366,7 +366,7 @@ const Home = (props: any) => {
             </p>
           </div>
           <div className='grid grid-cols-1 lg:grid-cols-3 gap-6 mb-12 mx-auto w-5/6 md:w-3/5 lg:w-5/6'>
-            <div className='p-4 w-full mb-6 dark:shadow-2xl'>
+            <div className='p-4 w-full mb-6 shadow-2xl rounded-xl'>
               <Link href='https://json-schema.org/slack'>
                 <h3 className='mb-4 font-semibold flex items-center dark:text-slate-200'>
                   Join the JSON Schema Slack Workspace!
@@ -421,7 +421,7 @@ const Home = (props: any) => {
               </button>
             </div>
             {/* BlogPost Data */}
-            <div className='p-4 w-full mb-6 dark:shadow-2xl'>
+            <div className='p-4 w-full mb-6 shadow-2xl rounded-xl'>
               <Link href={`/blog/posts/${blogPosts[0].slug}`}>
                 <h3 className='mb-5 font-semibold pt-1 dark:text-slate-200'>
                   The JSON Schema Blog
@@ -505,7 +505,7 @@ const Home = (props: any) => {
               </div>
             </div>
             <div>
-              <div className='p-4 md:w-full mb-6 mr-4 dark:shadow-2xl'>
+              <div className='p-4 w-full mb-6 shadow-2xl rounded-xl'>
                 <h3 className='mb-2 font-semibold dark:text-slate-200'>
                   JSON Schema Community Meetings & Events
                 </h3>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- UI improvement / styling update  
- Added consistent borders to homepage card sections (Slack invite card, blog card, upcoming events card) in both Light and Dark modes.

**Issue Number:**
- Closes #1926

**Screenshots/videos:**

<!-- Example screenshots -->
<img width="1508" height="893" alt="Screenshot 2025-12-23 at 7 32 29 PM" src="https://github.com/user-attachments/assets/14f5f2e5-d67e-4cea-8b23-056040ece5cd" />


before:
<img width="1508" height="893" alt="Screenshot 2025-12-23 at 7 32 49 PM" src="https://github.com/user-attachments/assets/5c29df58-2271-43e8-be58-716293db2078" />


**If relevant, did you update the documentation?**

- No documentation changes required for UI styling updates

**Summary**

This PR fixes the visual inconsistency on the homepage where card sections (Slack invite, blog, upcoming events) had visible borders in Dark Mode but no borders in Light Mode.  

Changes made:  
- Added `border border-gray-300 dark:border-gray-700 dark:shadow-2xl rounded-xl` to all card containers  
- Ensures consistent visual separation in both Light and Dark modes, improving layout clarity and overall UI structure.

**Does this PR introduce a breaking change?**

- No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.  

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md)
