### PR TITLE
fix: correct LinkedIn capitalization

### DIFF
--- a/pages/blog/posts/hello-2023--hello-json-schema-community.md
+++ b/pages/blog/posts/hello-2023--hello-json-schema-community.md
@@ -14,7 +14,7 @@ authors:
 excerpt: "I am excited to announce that I am joining as Developer Advocate with a focus on serving the Community"
 ---
 
-Since Ben Hutton joined Postman to work full-time on JSON Schema [the past year](https://blog.postman.com/ben-hutton-joins-postman-to-lead-json-schema-strategy/), other top contributors like Jason Desrosiers, Julian Berman, and Greg Dennis have joined, and now all are full-time supporting JSON Schema. So today, I am excited to announce that I am joining as Developer Advocate with a focus on serving the Community, nurturing relationships with other organizations, launching programs to support and grow the Community, and increasing awareness through content, public speaking, and discussions in X, Linkedin, Stackoverflow or Reddit.
+Since Ben Hutton joined Postman to work full-time on JSON Schema [the past year](https://blog.postman.com/ben-hutton-joins-postman-to-lead-json-schema-strategy/), other top contributors like Jason Desrosiers, Julian Berman, and Greg Dennis have joined, and now all are full-time supporting JSON Schema. So today, I am excited to announce that I am joining as Developer Advocate with a focus on serving the Community, nurturing relationships with other organizations, launching programs to support and grow the Community, and increasing awareness through content, public speaking, and discussions in X, LinkedIn, Stackoverflow or Reddit.
 
 ## Who is this guy?
 
@@ -36,7 +36,7 @@ If you like to know more about me, check out [this intro post](https://www.twili
 
 >* Email: benjamin.granados@postman.com
 >* Twitter: [@benjagm](https://www.x.com/benjagm)
->* Linkedin: [benjagranados](https://www.linkedin.com/in/benjagranados/)
+>* LinkedIn: [benjagranados](https://www.linkedin.com/in/benjagranados/)
 >* Github: [benjagm](https://github.com/benjagm)
 
 Cover photo by [Jai Cano](https://www.jaicano.com/redes) on [Instagram](https://www.instagram.com/jaicano).


### PR DESCRIPTION

## Issue
Fixes #2015

## Description
This PR corrects the capitalization of "Linkedin" to "LinkedIn" (with capital 'I') in the blog post `hello-2023--hello-json-schema-community.md`.

## Changes Made
- **File:** `pages/blog/posts/hello-2023--hello-json-schema-community.md`
- Changed `Linkedin` → `LinkedIn` in two locations:
  1. In the body text: "discussions in X, LinkedIn, Stackoverflow or Reddit"
  2. In the contact list: "LinkedIn: [benjagranados](...)"

## Why This Change?
"LinkedIn" is a proper noun and trademark that should always be capitalized with both 'L' and 'I' uppercase.

