### PR TITLE
 Fix Extra Punctuation in "Still Need Help?" Section

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -395,7 +395,7 @@ export function DocsHelp({
           <div className='my-6 text-[14px]'>
             <p data-test='additional-help-description'>
               Learning JSON Schema is often confusing, but don't worry, we are
-              here to help!.
+              here to help!
             </p>
           </div>
 


### PR DESCRIPTION
## Issue
Fixes #2016

## Description
This PR removes the extra period after the exclamation mark in the "Still Need Help?" section of the DocsHelp component.

## Changes Made
- **File:** `components/DocsHelp.tsx`
- Changed `here to help!.` → `here to help!`

### Before
```tsx
<p data-test='additional-help-description'>
  Learning JSON Schema is often confusing, but don't worry, we are
  here to help!.
</p>
```

### After
```tsx
<p data-test='additional-help-description'>
  Learning JSON Schema is often confusing, but don't worry, we are
  here to help!
</p>
```

## Why This Change?
Having both an exclamation mark and a period (`!.`) is a punctuation error. The exclamation mark alone is sufficient to end the sentence.
