### PR TITLE
fix: use parity-aware regex to handle escaped backslashes in JSON str…

### DIFF
--- a/lib/getPartsOfJson.ts
+++ b/lib/getPartsOfJson.ts
@@ -6,10 +6,10 @@ const regexObject =
 const regexArray =
   /^\s*(?<arrayStartBracket>\[)(?<arrayContent>.*)(?<arrayEndBracket>\])\s*$/g;
 const regexNumber = /^\s*(?<number>-?\d+(\.\d+)?([Ee][+-]?\d+)?)\s*$/g;
-const regexString = /^\s*(?<string>"(\\"|[^"])*")\s*$/g;
+const regexString = /^\s*(?<string>"(?:[^"\\]|\\.)*")\s*$/g;
 const regexBoolean = /^\s*(?<boolean>true|false)\s*$/g;
 const regexNull = /^\s*(?<null>null)\s*$/g;
-const regexDoubleQuote = /(?<!\\)"/g;
+const regexDoubleQuote = /(?<=(^|[^\\])(?:\\\\)*)"/g;
 const regexCommaOrEndOfLine = /,/g;
 
 export type SyntaxPart = {


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
Bugfix / Refactoring.

**Issue Number:**
Closes #2013

**Summary:** 
This PR provides a robust, performance-optimized fix for the JSON string parsing issue where trailing escaped backslashes (e.g., "\\\\") break the editor's syntax highlighting.

**Technical Advantage over other proposals:** 
Unlike solutions using manual character-counting loops, this PR implements a parity-aware regex lookbehind: (?<=(^|[^\])(?:\\)*)".

**Efficiency:** 
It leverages the native V8/C++ regex engine, which is more performant than manual JavaScript loops for large payloads.

**Maintainability:** 
It solves the problem at the regex definition level, keeping the core parsing logic clean and declarative.

**Improved Coverage:** 
It also updates regexString to ensure that full-string matches are correctly identified when they contain escaped backslashes.