### PR TITLE
fix: use unique stable keys for ToolingTable rows to improve reconcil…

### DIFF
--- a/pages/tools/components/ToolingTable.tsx
+++ b/pages/tools/components/ToolingTable.tsx
@@ -183,9 +183,10 @@ const ToolingTable = ({
                   if (bowtieData) {
                     tool.bowtie = bowtieData;
                   }
+                  const toolKey = `${tool.name}-${tool.source || tool.homepage || index}`;
                   return (
                     <tr
-                      key={index}
+                      key={toolKey}
                       className='flex w-full hover:bg-gray-100 dark:hover:bg-slate-700 cursor-pointer'
                       onClick={() => openModal(tool)}
                     >
@@ -280,9 +281,10 @@ const ToolingTable = ({
                   if (bowtieData) {
                     tool.bowtie = bowtieData;
                   }
+                  const toolKey = `${tool.name}-${tool.source || tool.homepage || index}`;
                   return (
                     <tr
-                      key={index}
+                      key={toolKey}
                       className='border-b border-gray-200 hover:bg-gray-100 dark:hover:bg-slate-700 cursor-pointer'
                       onClick={() => openModal(tool)}
                     >


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
Bugfix / Refactoring.

**Issue Number:**
Closes #2027

**Summary** 
This PR fixes the "index as key" anti-pattern in the ToolingTable component. Using indices as keys causes React to incorrectly reuse component instances during filtering and sorting, leading to stale UI states and performance issues.

**My solution** implements a composite stable key using the tool's name and its source/homepage URL. I have applied this fix to both the Desktop and Mobile table views to ensure a consistent experience across all devices.