### PR TITLE
fix: replace array index keys with stable identifiers in ToolingTable

### DIFF
--- a/pages/tools/components/ToolingTable.tsx
+++ b/pages/tools/components/ToolingTable.tsx
@@ -80,18 +80,6 @@ const ToolingTable = ({
 
   const groups = Object.keys(toolsByGroup);
 
-  const generateToolKey = (tool: JSONSchemaTool, group: string): string => {
-    const parts = [group];
-    if (tool.source) parts.push(tool.source);
-    if (tool.name) parts.push(tool.name);
-    if (tool.homepage && tool.homepage !== tool.source)
-      parts.push(tool.homepage);
-    if (tool.license) parts.push(tool.license);
-    if (tool.status) parts.push(tool.status);
-    if (tool.lastUpdated) parts.push(tool.lastUpdated);
-    return parts.join('|');
-  };
-
   const openModal = (tool: JSONSchemaTool) => {
     setSelectedTool(tool);
     postAnalytics({
@@ -195,10 +183,9 @@ const ToolingTable = ({
                   if (bowtieData) {
                     tool.bowtie = bowtieData;
                   }
-                  const toolKey = generateToolKey(tool, group);
                   return (
                     <tr
-                      key={toolKey}
+                      key={`${group}-${tool.name}-${tool.source || tool.homepage || ''}-${tool.toolingTypes?.join(',') || ''}-${tool.status || ''}`}
                       className='flex w-full hover:bg-gray-100 dark:hover:bg-slate-700 cursor-pointer'
                       onClick={() => openModal(tool)}
                     >
@@ -293,10 +280,9 @@ const ToolingTable = ({
                   if (bowtieData) {
                     tool.bowtie = bowtieData;
                   }
-                  const toolKey = generateToolKey(tool, group);
                   return (
                     <tr
-                      key={toolKey}
+                      key={`${group}-${tool.name}-${tool.source || tool.homepage || ''}-${tool.toolingTypes?.join(',') || ''}-${tool.status || ''}`}
                       className='border-b border-gray-200 hover:bg-gray-100 dark:hover:bg-slate-700 cursor-pointer'
                       onClick={() => openModal(tool)}
                     >


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- This PR fixes a React anti-pattern in `ToolingTable` where the array index was used as the `key` prop for table rows.

Using array indices as keys can cause incorrect component reconciliation, UI inconsistencies, and stale renders when the list is sorted, filtered, or updated. This PR replaces index-based keys with stable, unique identifiers derived from the tool data itself, ensuring predictable behavior and better performance.

**Issue Number:**
- Closes #2027

**Screenshots/videos:**
- Not applicable (no UI changes)

**If relevant, did you update the documentation?**
- Not required


**Does this PR introduce a breaking change?**
- No

# Checklist
- [x] Read, understood, and followed the contributing guidelines
