### PR TITLE
fix(ci): skip PR body validation for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-body-validation.yml
+++ b/.github/workflows/pr-body-validation.yml
@@ -20,6 +20,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
+            const isBot = pr.user.login === 'dependabot[bot]';
+            if (isBot) {
+              return;
+            }
             const prBody = pr.body || '';
             
             let missingItems = [];


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR introduces a bug fix to the CI workflow by updating the PR body validation logic to skip validation for Dependabot-generated pull requests, while keeping the validation intact for human contributors.


**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2057 <!-- Replace ___ with the issue number this PR resolves -->


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

This PR fixes an issue where the PR body validation workflow blocks Dependabot-generated pull requests.

Dependabot PRs are automatically created and do not follow the repository’s PR template, causing the PR body validation check to fail. This makes routine dependency updates unnecessarily tedious, as maintainers must manually edit PR descriptions to pass CI.

The workflow is now updated to skip PR body validation when the PR author is dependabot[bot], while keeping the validation unchanged for human contributors.

This preserves the intended PR quality checks and restores a smooth, fully automated dependency update flow.

**Does this PR introduce a breaking change?**

NO

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).