### PR TITLE
fix: Add target="_blank" and security attributes to footer external links

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -353,6 +353,8 @@ const Footer = () => (
         <div className='flex flex-col text-center sm:text-left'>
           <a
             href='https://opencollective.com/json-schema'
+            target='_blank'
+            rel='noopener noreferrer'
             className='text-white mb-2 transition-transform duration-300 ease-out hover:scale-105 hover:-translate-y-[2px]'
           >
             Open Collective
@@ -371,6 +373,8 @@ const Footer = () => (
         <div className=''>
           <a
             href='https://json-schema.org/slack'
+            target='_blank'
+            rel='noopener noreferrer'
             className='flex items-center text-white group transition-transform duration-300 ease-out hover:scale-105 hover:-translate-y-[2px]'
           >
             <Image
@@ -386,6 +390,8 @@ const Footer = () => (
         <div className=''>
           <a
             href='https://x.com/jsonschema'
+            target='_blank'
+            rel='noopener noreferrer'
             className='flex items-center text-white group transition-transform duration-300 ease-out hover:scale-105 hover:-translate-y-[2px]'
           >
             <Image
@@ -401,6 +407,8 @@ const Footer = () => (
         <div className=''>
           <a
             href='https://linkedin.com/company/jsonschema/'
+            target='_blank'
+            rel='noopener noreferrer'
             className='flex items-center text-white group transition-transform duration-300 ease-out hover:scale-105 hover:-translate-y-[2px]'
           >
             <Image
@@ -416,6 +424,8 @@ const Footer = () => (
         <div className=''>
           <a
             href='https://www.youtube.com/@JSONSchemaOrgOfficial'
+            target='_blank'
+            rel='noopener noreferrer'
             className='flex items-center text-white group transition-transform duration-300 ease-out hover:scale-105 hover:-translate-y-[2px]'
           >
             <Image
@@ -431,6 +441,8 @@ const Footer = () => (
         <div className=''>
           <a
             href='https://github.com/json-schema-org'
+            target='_blank'
+            rel='noopener noreferrer'
             className='flex items-center text-white group transition-transform duration-300 ease-out hover:scale-105 hover:-translate-y-[2px]'
           >
             <Image


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR improves user experience and security by ensuring that all external links in the footer open in a new browser tab instead of replacing the current page.

Opening external links in the same tab can unintentionally navigate users away from the site. This PR updates all footer external links to open in new tabs and adds appropriate security attributes to prevent potential security issues.

**Issue Number:**
- Closes #2066

**Screenshots/videos:**

https://github.com/user-attachments/assets/ccf38314-d889-4e6f-bd4b-a4fc6994202e

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR fixes a bug where external links in the footer (Open Collective, Slack, X, LinkedIn, YouTube, and GitHub) were opening in the same tab, causing users to navigate away from the JSON Schema website.

**Changes:**
- Added `target="_blank"` to all footer external links
- Added `rel="noopener noreferrer"` for improved security when opening links in new tabs

**Does this PR introduce a breaking change?**

No

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).

