### PR TITLE
fix: position of the github logo

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -279,7 +279,7 @@ const MainNavigation = () => {
           >
             <span className='inline-block mr-1'>
               <svg
-                className='inline-block -mt-1 w-6 h-6 size-7'
+                className='inline-block mt-0.5 w-6 h-6 size-7'
                 fill='currentColor'
                 viewBox='0 0 24 24'
               >


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR fixes the position of the Github logo 

**Issue Number:**

 Closes #2073


**Screenshots/videos:**

Before:

<img width="1919" height="869" alt="Screenshot 2026-01-08 141945" src="https://github.com/user-attachments/assets/b36a3ba3-30c6-42f2-964a-8b82e12435d4" />


After:

<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/fcfc5d98-d78d-45da-b128-da603f61b95c" />



**If relevant, did you update the documentation?**

No.

**Summary**

The Github logo is perfectly positioned after implementing the change.

**Does this PR introduce a breaking change?**

No.
