### PR TITLE
fix: Constraint Logo component dimensions to prevent overflow

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -467,8 +467,8 @@ const Logo = () => {
   }, [resolvedTheme]);
 
   return (
-    <div>
-      <Link href='/' className=''>
+    <div className='w-[170px] h-[48px] relative'>
+      <Link href='/' className='flex items-center'>
         <Image
           src={imageSrc}
           width={170}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix.  
Bug fix — brief description: Constrains the Logo component dimensions in the blog header so the JSON Schema logo does not overflow its container and aligns correctly with the navigation items.

**Issue Number:**

- Closes #2072

**Screenshots/videos:**
<img width="1899" height="1066" alt="Screenshot 2026-01-08 144928" src="https://github.com/user-attachments/assets/4be36fc6-abd5-4c84-b93d-5d6db3454d1f" />

Screenshots show:

- The previous behavior where the blog header logo could overflow its container and appear slightly misaligned with the top navigation bar.
- The updated behavior where the logo is fully contained within its box and vertically aligned with the navigation items after the dimension constraints are applied.

**If relevant, did you update the documentation?**

Not applicable. No documentation changes were required because this is a visual/styling bug fix limited to the blog header logo.

**Summary**

This pull request updates the BlogHeaderLogo component styling to constrain its width and height so that the JSON Schema logo no longer overflows or appears visually misaligned in the blog header.  
The change ensures consistent logo rendering across viewport sizes without impacting other layout elements or routes in the site.

**Does this PR introduce a breaking change?**

No, this PR does not introduce any breaking changes.  
It only adjusts styles for the blog header logo and does not modify any APIs, data models, or routing behavior.

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
