### PR TITLE
fix: Revamped navbar and fixed icons on mobile 

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -13,6 +13,7 @@ import DarkModeToggle from './DarkModeToggle';
 import ScrollButton from './ScrollButton';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
+import { Menu, X } from 'lucide-react';
 
 type Props = {
   children: React.ReactNode;
@@ -154,7 +155,7 @@ const MainNavLink = ({
       href={uri}
       className={classnames(
         className,
-        'font-semibold p-2 md:p-4',
+        'font-semibold p-2 md:p-4 rounded',
         // `${
         //   router.asPath === uri
         //     ? 'text-primary hover:text-primary'
@@ -236,8 +237,9 @@ const MainNavigation = () => {
         isActive={section === 'community'}
       />
 
-      <div className='flex items-center max-sm:ml-4 mr-8 gap-6 md:gap-4 dark:bg-slate-800'>
+      <div className='flex items-center mx-2 max-md:mr-4 gap-4 max-md:gap-2 dark:bg-slate-800'>
         <div
+          data-testid='search-container'
           className={`rounded-md dark:hover:bg-gray-700 hover:bg-gray-100 focus:bg-gray-100 focus:outline-none transition duration-150  md:block border-gray-100 ml-0  ${icon}`}
           onClick={() => {
             window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -249,11 +251,12 @@ const MainNavigation = () => {
           <DarkModeToggle />
         </div>
         {showMobileNav === false ? (
-          <div onClick={() => useStore.setState({ overlayNavigation: 'docs' })}>
+          <div
+            onClick={() => useStore.setState({ overlayNavigation: 'docs' })}
+            data-testid='mobile-menu-trigger'
+          >
             <div className='block lg:hidden space-y-2  items-center'>
-              <div className={`w-6 h-1 ${menu} rounded`}></div>
-              <div className={`w-6 h-1 ${menu} rounded`}></div>
-              <div className={`w-6 h-1 ${menu} rounded`}></div>
+              <Menu size={26} />
             </div>
           </div>
         ) : (
@@ -261,16 +264,19 @@ const MainNavigation = () => {
             style={{
               backgroundImage: closeMenu,
             }}
-            className='h-6 w-6 lg:hidden bg-center bg-[length:22px_22px] bg-no-repeat  transition-all cursor-pointer dark:text-slate-300'
+            data-testid='mobile-menu-close'
+            className='lg:hidden px-[5px] bg-center bg-no-repeat transition-all cursor-pointer'
             onClick={() => useStore.setState({ overlayNavigation: null })}
-          />
+          >
+            <X size={16} />
+          </div>
         )}
       </div>
       <div className='flex items-center justify-end mr-8'>
         <Button
           asChild
           data-testid='Button-link'
-          className='cursor-pointer hidden lg:flex bg-primary hover:bg-blue-700 text-white transition-all duration-500 ease-in-out rounded-md px-3 text-sm font-medium tracking-heading py-2.5 ml-2'
+          className='cursor-pointer h-10 hidden lg:flex bg-primary hover:bg-blue-700 text-white transition-all duration-500 ease-in-out rounded-md px-3 text-sm font-medium tracking-heading py-2.5'
         >
           <a
             target='_blank'
@@ -279,7 +285,7 @@ const MainNavigation = () => {
           >
             <span className='inline-block mr-1'>
               <svg
-                className='inline-block -mt-1 w-6 h-6 size-7'
+                className='inline-block mt-0.5 size-7'
                 fill='currentColor'
                 viewBox='0 0 24 24'
               >
@@ -290,7 +296,9 @@ const MainNavigation = () => {
                 ></path>
               </svg>
             </span>
-            <span className='inline-block'>Star on GitHub</span>
+            <p className='inline-block text-[15px] mt-1 font-semibold'>
+              Star on GitHub
+            </p>
           </a>
         </Button>
       </div>
@@ -302,28 +310,41 @@ const MobileNav = () => {
   const section = useContext(SectionContext);
 
   return (
-    <div className='flex flex-col lg:hidden shadow-xl justify-end fixed bg-white w-full  z-[190] top-16 left-0 pl-8 dark:bg-slate-800'>
+    <div
+      className='flex flex-col lg:hidden justify-end fixed bg-white 
+      dark:bg-slate-900 max-lg:w-[80%] max-sm:w-[90%] z-[190] 
+      top-[72px] left-1/2 -translate-x-1/2 p-2 gap-1 rounded shadow-2xl'
+    >
       <MainNavLink
         uri='/specification'
         label='Specification'
         isActive={section === 'specification'}
+        className='border border-slate-300 dark:border-slate-700'
       />
       <MainNavLink
         uri='/learn/getting-started-step-by-step'
         label='Docs'
         isActive={section === 'docs'}
+        className='border border-slate-300 dark:border-slate-700'
       />
 
       <MainNavLink
         uri='/tools?query=&sortBy=name&sortOrder=ascending&groupBy=toolingTypes&licenses=&languages=&drafts=&toolingTypes=&environments='
         label='Tools'
         isActive={section === 'tools'}
+        className='border border-slate-300 dark:border-slate-700'
       />
-      <MainNavLink uri='/blog' label='Blog' isActive={section === 'blog'} />
+      <MainNavLink
+        uri='/blog'
+        label='Blog'
+        isActive={section === 'blog'}
+        className='border border-slate-300 dark:border-slate-700'
+      />
       <MainNavLink
         uri='/community'
         label='Community'
         isActive={section === 'community'}
+        className='border border-slate-300 dark:border-slate-700'
       />
     </div>
   );

--- a/cypress/components/Layout.cy.tsx
+++ b/cypress/components/Layout.cy.tsx
@@ -38,12 +38,6 @@ describe('Layout Component', () => {
       cy.get('[data-testid="content"]').should('contain', 'Test content');
     });
 
-    // Skipping title test as Next.js Head component doesn't work reliably in Cypress component tests
-    // it('should render with custom meta title', () => {
-    //   mountLayout({ metaTitle: 'Test Page' });
-    //   cy.get('title').should('contain', 'JSON Schema - Test Page');
-    // });
-
     it('should render with white background when whiteBg is true', () => {
       mountLayout({ whiteBg: true });
       cy.get('main').parent().should('have.class', 'bg-white');
@@ -133,14 +127,13 @@ describe('Layout Component', () => {
   describe('Search Component', () => {
     it('should render the search component', () => {
       mountLayout();
-      // DocSearch component doesn't have a specific data-testid, so we check for the container
-      cy.get('header').find('.rounded-md').should('exist');
+      cy.get('[data-testid="search-container"]').should('exist');
     });
 
     it('should have correct styling for search container', () => {
       mountLayout();
-      cy.get('header')
-        .find('.rounded-md')
+      // UPDATED: Use data-testid (Fixes the ambiguity with .rounded-md)
+      cy.get('[data-testid="search-container"]')
         .should('have.class', 'dark:hover:bg-gray-700')
         .and('have.class', 'hover:bg-gray-100')
         .and('have.class', 'focus:bg-gray-100')
@@ -188,8 +181,6 @@ describe('Layout Component', () => {
         .find('[data-testid="Button-link"]')
         .find('svg')
         .should('exist')
-        .and('have.class', 'w-6')
-        .and('have.class', 'h-6')
         .and('have.class', 'size-7');
     });
 
@@ -215,8 +206,7 @@ describe('Layout Component', () => {
         .and('have.class', 'text-sm')
         .and('have.class', 'font-medium')
         .and('have.class', 'tracking-heading')
-        .and('have.class', 'py-2.5')
-        .and('have.class', 'ml-2');
+        .and('have.class', 'py-2.5');
     });
 
     it('should be hidden on mobile screens', () => {
@@ -237,13 +227,12 @@ describe('Layout Component', () => {
   describe('Mobile Navigation', () => {
     it('should render hamburger menu on mobile', () => {
       mountLayout();
-      cy.get('header').find('.block.lg\\:hidden').should('exist');
+      cy.get('[data-testid="mobile-menu-trigger"]').should('exist');
     });
 
     it('should show mobile navigation when hamburger is clicked', () => {
       mountLayout();
-      // Click hamburger menu
-      cy.get('header').find('.block.lg\\:hidden').click();
+      cy.get('[data-testid="mobile-menu-trigger"]').click();
 
       // Check if mobile nav is visible
       cy.get('.flex.flex-col.lg\\:hidden').should('be.visible');
@@ -252,19 +241,17 @@ describe('Layout Component', () => {
     it('should hide mobile navigation when close button is clicked', () => {
       mountLayout();
       // Open mobile nav
-      cy.get('header').find('.block.lg\\:hidden').click();
+      cy.get('[data-testid="mobile-menu-trigger"]').click();
 
-      // Click close button
-      cy.get('header').find('.h-6.w-6.lg\\:hidden').click();
+      cy.get('[data-testid="mobile-menu-close"]').click();
 
-      // Check if mobile nav is hidden - it should not exist in DOM when hidden
       cy.get('.flex.flex-col.lg\\:hidden').should('not.exist');
     });
 
     it('should render mobile navigation links', () => {
       mountLayout();
       // Open mobile nav
-      cy.get('header').find('.block.lg\\:hidden').click();
+      cy.get('[data-testid="mobile-menu-trigger"]').click();
 
       // Check mobile nav links
       cy.get('.flex.flex-col.lg\\:hidden')


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR fixes the navbar, padding and icons on mobile.
 
**Issue Number:**

Related to #2073 

**Screenshots/videos:**

<img width="1919" height="870" alt="Screenshot 2026-01-12 224341" src="https://github.com/user-attachments/assets/909f9ae2-d5a6-41c8-a2f8-5581d56d259f" />

<img width="453" height="779" alt="Screenshot 2026-01-12 224426" src="https://github.com/user-attachments/assets/ab6a62a5-61ae-4ab7-baa2-08768f29e2b3" />

<img width="454" height="779" alt="Screenshot 2026-01-12 224437" src="https://github.com/user-attachments/assets/6b271fc6-3736-40ef-835e-69721a306f4d" />

**If relevant, did you update the documentation?**

No.

**Summary**

The navbar has been revamped with correct padding and consistent breakpoint margin. 
The github button text and logo are fixed and now the button has perfect alignment.
Mobile alignment and height is fixed with proper partitioning.

**Does this PR introduce a breaking change?**

No.
