### PR TITLE
Make Tools page filter sidebar sticky on desktop

### DIFF
--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -171,7 +171,7 @@ export default function ToolingPage({
             `}
           >
             {/* Inner wrapper: sticky on desktop to keep filters visible */}
-            <div className='lg:sticky lg:top-[4.5rem] lg:max-h-[calc(100vh-5rem)] lg:overflow-y-auto scrollbar-hidden'>
+            <div className='lg:sticky lg:top-[4.5rem] lg:max-h-[calc(100vh-4.5rem)] lg:overflow-y-auto scrollbar-hidden'>
               <div className='px-2 lg:px-0 pb-2'>
                 <div className='hidden lg:block pt-8'>
                   <h1 className='text-h1mobile md:text-h1 font-bold lg:ml-4'>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Enhancement (UX improvement)

**Issue Number:**

Closes #2105

**Summary**

This PR improves the usability of the Tools page by keeping the left-hand
filter sidebar accessible while scrolling long tool lists on desktop screens.

The sidebar now uses a sticky layout on larger viewports, allowing users to
adjust filters at any point while browsing results. Existing mobile and
small-screen behavior is unchanged.

**Screenshots / Videos**
Video of sidebar issue:

https://github.com/user-attachments/assets/0a2848c1-854f-407c-b1bb-4fecc3ae5ed3

Video of sidebar fixed issue:

https://github.com/user-attachments/assets/26e8d4c0-2c86-413a-9a3b-272b31cf11d2

Included in issue #2105.

**Does this PR introduce a breaking change?**

No





