### PR TITLE
fix: scroll to top on blog pagination (#2121)

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -195,9 +195,8 @@ export default function StaticMarkdownPage({
   const POSTS_PER_PAGE = 10;
   const [currentPage, setCurrentPage] = useState(1);
   useEffect(() => {
-  window.scrollTo({ top: 0, behavior: 'smooth' });
-}, [currentPage]);
-
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [currentPage]);
 
   const totalPages = Math.ceil(sortedFilteredPosts.length / POSTS_PER_PAGE);
 


### PR DESCRIPTION
Fixes #2121

**Test demo video**


https://github.com/user-attachments/assets/7c379256-509e-4376-885b-6a359e86ff8f




**What I changed**
       I updated the blog pagination behavior to reset the scroll position.
       When clicking Next or Previous, the page now automatically scrolls to the top.
      

**Why this change**
   Earlier, when navigating between blog pages, the scroll position stayed at the bottom.
    Users had to manually scroll up to read new posts.
    This created a poor reading experience, especially for long pages.


