### PR TITLE
fix(blog): fix blog pagination scroll

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable linebreak-style */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import fs from 'fs';
@@ -197,11 +197,19 @@ export default function StaticMarkdownPage({
 
   const totalPages = Math.ceil(sortedFilteredPosts.length / POSTS_PER_PAGE);
 
+  const blogPostsContainerRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (currentPage > totalPages) {
       setCurrentPage(1);
     }
   }, [totalPages]);
+
+  useEffect(() => {
+    if (blogPostsContainerRef.current) {
+      blogPostsContainerRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [currentPage]);
 
   const currentPagePosts = sortedFilteredPosts.slice(
     (currentPage - 1) * POSTS_PER_PAGE,
@@ -258,7 +266,7 @@ export default function StaticMarkdownPage({
             </div>
           </div>
         )}
-        <div className='w-full mx-auto my-5'>
+        <div ref={blogPostsContainerRef} className='w-full mx-auto my-5'>
           <div className='flex h-full flex-col justify-center items-center mb-3 my-2'>
             <h2 className='text-h3mobile md:text-h3 font-bold px-4 items-center text-center'>
               Welcome to the JSON Schema Blog!


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bug fix. This PR improves the blog pagination experience by automatically scrolling to the start of the blog content when navigating between pages.

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2121


**Screenshots/videos:**

- Mobile:
https://github.com/user-attachments/assets/4bc2ff95-17c6-48bd-bbd9-23208a3ca659



- Laptop:
https://github.com/user-attachments/assets/ea40bc4a-da66-4164-96f2-48e88192e5c7



**If relevant, did you update the documentation?**

- N/A

**Summary**

Previously, when navigating between pages on the JSON Schema Blog using the pagination controls, the page number updated correctly but the scroll position remained at the bottom of the page. This forced users to manually scroll back up to view the newly loaded blog posts.

This PR fixes the issue by using a ref to scroll the blog section into view whenever the page changes, ensuring that users always see the new content from the top of the blog section.

**Does this PR introduce a breaking change?**

- N/A

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).