### PR TITLE
Fix: Sidebar Filter UI Clipping on Tools Page

### DIFF
--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -156,54 +156,46 @@ export default function ToolingPage({
         <div className='w-full grid grid-cols-1 lg:grid-cols-4 px-4 md:px-12 min-h-screen overflow-x-hidden'>
           <div
             className={`
-              lg:fixed absolute top-0 lg:top-0 left-0 lg:left-auto
+              lg:relative absolute top-0 lg:top-0 left-0 lg:left-auto
               mt-0 lg:mt-20
               w-full max-w-full lg:w-auto overflow-x-hidden
               bg-white dark:bg-slate-800 lg:bg-transparent
               transition-transform lg:transform-none duration-300 lg:duration-0 ease-in-out
               z-5
-              ${isSidebarOpen ? '-translate-x-0' : '-translate-x-full'}
-              ${isMobile && isSidebarOpen ? 'overflow-hidden' : 'overflow-y-auto lg:overflow-y-hidden'}
+              ${isSidebarOpen ? '-translate-x-0' : '-translate-x-full lg:translate-x-0'}
+              ${isMobile && isSidebarOpen ? 'overflow-hidden' : ''}
             `}
             style={{
               height: isMobile
                 ? isSidebarOpen
                   ? 'calc(100vh - 4.5rem)'
                   : '0'
-                : 'calc(100vh - 4.5rem)',
-              maxHeight: 'calc(100vh - 4.5rem)',
-              bottom: 0,
-              scrollbarWidth: 'none',
-              position: 'sticky',
-              top: '4.5rem',
+                : 'auto',
             }}
           >
-            <div className='h-full flex flex-col'>
-              <div className='flex-1 overflow-y-auto scrollbar-hidden min-h-0 px-2 lg:px-0 pb-2'>
-                <div className='hidden lg:block pt-8'>
-                  <h1 className='text-h1mobile md:text-h1 font-bold lg:ml-4'>
-                    {numberOfTools}
-                  </h1>
-                  <div className='text-xl text-slate-900 dark:text-slate-300 font-bold lg:ml-6 mb-4'>
-                    Tools
-                  </div>
+            <div className='px-2 lg:px-0 pb-2'>
+              <div className='hidden lg:block pt-8'>
+                <h1 className='text-h1mobile md:text-h1 font-bold lg:ml-4'>
+                  {numberOfTools}
+                </h1>
+                <div className='text-xl text-slate-900 dark:text-slate-300 font-bold lg:ml-6 mb-4'>
+                  Tools
                 </div>
-
-                <Sidebar
-                  filterCriteria={filterCriteria}
-                  transform={transform}
-                  setTransform={setTransform}
-                  resetTransform={resetTransform}
-                  setIsSidebarOpen={setIsSidebarOpen}
-                />
               </div>
+
+              <Sidebar
+                filterCriteria={filterCriteria}
+                transform={transform}
+                setTransform={setTransform}
+                resetTransform={resetTransform}
+                setIsSidebarOpen={setIsSidebarOpen}
+              />
             </div>
           </div>
 
           <main
-            className={`md:col-span-3 lg:mt-20 lg:w-full mx-4 md:mx-0 lg:!ml-[20px] ${
-              isSidebarOpen ? 'hidden lg:block' : ''
-            }`}
+            className={`md:col-span-3 lg:mt-20 lg:w-full mx-4 md:mx-0 lg:!ml-[20px] ${isSidebarOpen ? 'hidden lg:block' : ''
+              }`}
           >
             <Headline1>JSON Schema Tooling</Headline1>
             <p className='text-slate-600 block leading-7 pb-1 dark:text-slate-300'>

--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -194,8 +194,9 @@ export default function ToolingPage({
           </div>
 
           <main
-            className={`md:col-span-3 lg:mt-20 lg:w-full mx-4 md:mx-0 lg:!ml-[20px] ${isSidebarOpen ? 'hidden lg:block' : ''
-              }`}
+            className={`md:col-span-3 lg:mt-20 lg:w-full mx-4 md:mx-0 lg:!ml-[20px] ${
+              isSidebarOpen ? 'hidden lg:block' : ''
+            }`}
           >
             <Headline1>JSON Schema Tooling</Headline1>
             <p className='text-slate-600 block leading-7 pb-1 dark:text-slate-300'>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix – fixes the sidebar filter panel so that the “Apply Filters” and “Clear Filters” buttons remain visible when multiple filter categories are expanded.

**Problem**
The sidebar filter on the Tools page had a UI clipping issue where the "Apply Filters" and "Clear Filters" buttons became inaccessible when multiple filter categories were expanded.

**Root Cause**
The sidebar container had:
- Fixed height (`calc(100vh - 4.5rem)`) with sticky positioning
- Overflow hidden on desktop (`lg:overflow-y-hidden`), which prevented scrolling
- An independent scroll area that conflicted with the fixed height constraint

When users expanded multiple filter dropdowns (Language, Tooling Type, Environment, etc.), the content exceeded the container height, pushing the action buttons out of view with no way to access them.

**User Impact**
- Users couldn't apply filter selections when multiple categories were expanded.
- Users couldn't clear filters.
- Frustrating UX on desktop with standard viewport heights (1080p and below).

**Solution**
Changed the sidebar to scroll naturally with the entire page instead of having independent sticky positioning with its own scroll area.

**Changes Made**
File modified:
- `pages/tools/index.page.tsx`

Closes #2159
