### PR TITLE
fix: sidebar filter buttons cutting off on desktop screens

### DIFF
--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -171,9 +171,7 @@ export default function ToolingPage({
                   ? 'calc(100vh - 4.5rem)'
                   : '0'
                 : 'auto',
-              maxHeight: isMobile 
-              ? 'calc(100vh - 4.5rem)' 
-               : 'none',
+              maxHeight: isMobile ? 'calc(100vh - 4.5rem)' : 'none',
               bottom: 0,
               scrollbarWidth: 'none',
               position: 'sticky',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**
-  Closes #2159 

(Omitted)

**If relevant, did you update the documentation?**

No

**Summary**

This PR addresses a layout bug on the Tools page where the filter sidebar action buttons ("Apply Filters" and "Clear Filters") were cut off and inaccessible on desktop and laptop displays.

The issue was caused by a fixed height constraint (`calc(100vh - 4.5rem)`) and `overflow-y-hidden` on the sidebar container. When multiple filter categories were expanded, the container failed to grow or scroll, clipping the bottom action buttons.
**What kind of change does this PR introduce?**



- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).