### PR TITLE
fix: prevent empty feedback form submission (#1415)

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -86,8 +86,17 @@ export function DocsHelp({
   async function createFeedbackHandler(event: FormEvent) {
     event.preventDefault();
     const formData = new FormData(feedbackFormRef.current!);
+    const feedbackComment = formData.get('feedback-comment')?.toString().trim();
+
+    // Validate that feedback comment is not empty
+    if (!feedbackComment) {
+      setError('Feedback comment cannot be empty.');
+      return;
+    }
+
     formData.append('feedback-page', router.asPath);
     setIsSubmitting(true);
+    setError(''); // Clear any previous error
 
     try {
       const response = await fetch(
@@ -118,10 +127,19 @@ export function DocsHelp({
 
   const createGitHubIssueHandler = () => {
     const formData = new FormData(feedbackFormRef.current!);
+    const feedbackComment = formData.get('feedback-comment')?.toString().trim();
+
+    // Validate that feedback comment is not empty
+    if (!feedbackComment) {
+      setError('Feedback comment cannot be empty.');
+      return;
+    }
+
     setIsSubmitting(true);
+    setError(''); // Clear any previous error
     try {
       const title = encodeURIComponent('Feedback on Documentation');
-      const body = encodeURIComponent(`${formData.get('feedback-comment')}`);
+      const body = encodeURIComponent(feedbackComment);
       const url = `https://github.com/json-schema-org/website/issues/new?title=${title}&body=${body}`;
       window.open(url, '_blank');
       submitFeedbackHandler('github_issue');
@@ -236,8 +254,8 @@ export function DocsHelp({
                           <span className='font-bold text-[14px] block'>
                             Let us know your Feedback
                           </span>
-                          <span className='float-right text-[#7d8590] text-[14px] block'>
-                            Optional
+                          <span className='float-right text-[#da3633] text-[14px] block'>
+                            Required
                           </span>
                         </label>
                       </p>

--- a/cypress/components/DocsHelp.cy.tsx
+++ b/cypress/components/DocsHelp.cy.tsx
@@ -101,6 +101,61 @@ describe('DocsHelp Component', () => {
       .and('contains', /Ask the community on Slack/i);
   });
 
+  // test that empty feedback submission is prevented
+  it('should show error when submitting empty feedback', () => {
+    // click on yes button to open the form
+    cy.get(FEEDBACK_FORM_YES_BUTTON).click();
+    cy.get(FEEDBACK_FORM).should('be.visible');
+
+    // try to submit without entering any comment
+    cy.get(FEEDBACK_FORM_SUBMIT_BUTTON).click();
+
+    // check if error message is displayed
+    cy.get(FEEDBACK_ERROR_MESSAGE)
+      .should('have.prop', 'tagName', 'P')
+      .and('contain.text', 'Feedback comment cannot be empty.');
+
+    // form should still be visible (not submitted)
+    cy.get(FEEDBACK_FORM).should('be.visible');
+  });
+
+  // test that empty feedback submission is prevented for whitespace-only input
+  it('should show error when submitting whitespace-only feedback', () => {
+    // click on yes button to open the form
+    cy.get(FEEDBACK_FORM_YES_BUTTON).click();
+    cy.get(FEEDBACK_FORM).should('be.visible');
+
+    // type only whitespace
+    cy.get(FEEDBACK_FORM_INPUT).type('   ');
+    cy.get(FEEDBACK_FORM_SUBMIT_BUTTON).click();
+
+    // check if error message is displayed
+    cy.get(FEEDBACK_ERROR_MESSAGE)
+      .should('have.prop', 'tagName', 'P')
+      .and('contain.text', 'Feedback comment cannot be empty.');
+
+    // form should still be visible (not submitted)
+    cy.get(FEEDBACK_FORM).should('be.visible');
+  });
+
+  // test that empty feedback prevents creating GitHub issue
+  it('should show error when creating GitHub issue with empty feedback', () => {
+    // click on yes button to open the form
+    cy.get(FEEDBACK_FORM_YES_BUTTON).click();
+    cy.get(FEEDBACK_FORM).should('be.visible');
+
+    // try to create GitHub issue without entering any comment
+    cy.get(CREATE_GITHUB_ISSUE_BUTTON).click();
+
+    // check if error message is displayed
+    cy.get(FEEDBACK_ERROR_MESSAGE)
+      .should('have.prop', 'tagName', 'P')
+      .and('contain.text', 'Feedback comment cannot be empty.');
+
+    // form should still be visible (not submitted)
+    cy.get(FEEDBACK_FORM).should('be.visible');
+  });
+
   // test feedback form funtionality works correctly
   it('should handle successful feedback submission', () => {
     // mocking the feedback api call


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix - Prevents empty feedback form submissions by adding validation.

**Issue Number:**

- Closes #1415

**Screenshots/videos:**

N/A - This is a validation logic change. The form now shows an error message "Feedback comment cannot be empty." when users try to submit empty or whitespace-only feedback.

**If relevant, did you update the documentation?**

N/A - No documentation changes required.

**Summary**

This PR fixes the issue where users could submit empty feedback via the documentation help form. The changes include:
- Added validation in `createFeedbackHandler` to check for empty/whitespace feedback
- Added validation in `createGitHubIssueHandler` for consistency  
- Changed label from "Optional" to "Required" (red color)
- Shows error message "Feedback comment cannot be empty." when validation fails

**Test Coverage**

Added 3 new Cypress component tests:
- Empty feedback submission blocked
- Whitespace-only feedback blocked
- GitHub issue creation with empty feedback blocked

**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).