### PR TITLE
 Fix: Inconsistent Sidebar Active State

### DIFF
--- a/components/TableOfContentMarkdown.tsx
+++ b/components/TableOfContentMarkdown.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import slugifyMarkdownHeadline from '~/lib/slugifyMarkdownHeadline';
 import { hiddenElements } from '~/lib/markdownUtils';
 import { FullMarkdownContext } from '~/context';
+import { useRouter } from 'next/router';
 
 interface TableOfContentMarkdownProps {
   markdown: string;
@@ -17,6 +18,29 @@ export function TableOfContentMarkdown({
   markdown,
   depth = 2,
 }: TableOfContentMarkdownProps) {
+  const router = useRouter();
+  const [activeSlug, setActiveSlug] = useState('');
+
+  useEffect(() => {
+    const hashIndex = router.asPath.indexOf('#');
+    const slugFromPath =
+      hashIndex !== -1 ? router.asPath.slice(hashIndex + 1) : '';
+    setActiveSlug(slugFromPath);
+  }, [router.asPath]);
+
+  const handleLinkClick = (e: React.MouseEvent, slug: string) => {
+    e.preventDefault();
+    router.push({ hash: slug }, undefined, { shallow: true });
+  };
+
+  const getLinkClassName = (
+    baseClass: string,
+    activeClass: string,
+    slug: string,
+  ) => {
+    return `${baseClass} ${activeSlug === slug ? activeClass : ''}`;
+  };
+
   return (
     <Markdown
       options={{
@@ -27,7 +51,12 @@ export function TableOfContentMarkdown({
               return (
                 <a
                   href={`#${slug}`}
-                  className='flex cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-6  font-medium'
+                  onClick={(e) => handleLinkClick(e, slug)}
+                  className={getLinkClassName(
+                    'flex cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-6 font-medium',
+                    'text-blue-600 dark:text-blue-400',
+                    slug,
+                  )}
                 >
                   {children}
                 </a>
@@ -39,91 +68,112 @@ export function TableOfContentMarkdown({
           h2:
             depth === 0
               ? {
+                component: ({ children }) => {
+                  const slug = slugifyMarkdownHeadline(children);
+                  return (
+                    <a
+                      href={`#${slug}`}
+                      onClick={(e) => handleLinkClick(e, slug)}
+                      className={getLinkClassName(
+                        'block cursor-pointer mb-3 text-slate-600 dark:text-slate-300 leading-5 font-medium ml-4',
+                        'text-blue-600 dark:text-blue-400',
+                        slug,
+                      )}
+                    >
+                      {children}
+                    </a>
+                  );
+                },
+              }
+              : depth >= 2
+                ? {
                   component: ({ children }) => {
                     const slug = slugifyMarkdownHeadline(children);
+                    const [isChrome, setIsChrome] = useState(false);
+
+                    useEffect(() => {
+                      const chromeCheck =
+                        /Chrome/.test(navigator.userAgent) &&
+                        /Google Inc/.test(navigator.vendor);
+                      setIsChrome(chromeCheck);
+                    }, []);
+
                     return (
+                      // chromeClass
                       <a
                         href={`#${slug}`}
-                        className='block cursor-pointer mb-3 text-slate-600  dark:text-slate-300 leading-5 font-medium ml-4'
+                        onClick={(e) => handleLinkClick(e, slug)}
+                        className={getLinkClassName(
+                          `block cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-4 max-sm:-ml-[6px] font-medium ${isChrome ? '-ml-[4.8px]' : '-ml-[6.5px]'
+                          }`,
+                          'text-blue-600 dark:text-blue-400',
+                          slug,
+                        )}
                       >
+                        <span className='mr-1 text-blue-400 text-[0.7em]'>
+                          &#9679;
+                        </span>
                         {children}
                       </a>
                     );
                   },
                 }
-              : depth >= 2
-                ? {
-                    component: ({ children }) => {
-                      const slug = slugifyMarkdownHeadline(children);
-                      const [isChrome, setIsChrome] = useState(false);
-
-                      useEffect(() => {
-                        const chromeCheck =
-                          /Chrome/.test(navigator.userAgent) &&
-                          /Google Inc/.test(navigator.vendor);
-                        setIsChrome(chromeCheck);
-                      }, []);
-
-                      return (
-                        // chromeClass
-                        <a
-                          href={`#${slug}`}
-                          className={`block cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-4 ] max-sm:-ml-[6px] font-medium ${isChrome ? '-ml-[4.8px]' : '-ml-[6.5px]'}`}
-                        >
-                          <span className='mr-1 text-blue-400 text-[0.7em]'>
-                            &#9679;
-                          </span>
-                          {children}
-                        </a>
-                      );
-                    },
-                  }
                 : { component: () => null },
           h3:
             depth >= 3
               ? {
-                  component: ({ children }) => {
-                    const slug = slugifyMarkdownHeadline(children);
-                    return (
-                      <a
-                        href={`#${slug}`}
-                        className='flex flex-row items-center cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-4 ml-[-0.25rem]'
-                      >
-                        <span className='text-blue-400/40 font-extrabold text-[0.8em] max-sm:text-[1.2em] ml-1'>
-                          &mdash;&mdash;
-                        </span>
-                        <span className='mr-1 text-blue-400/90 text-[0.7em] flex justify-center items-center'>
-                          &#9679;
-                        </span>
+                component: ({ children }) => {
+                  const slug = slugifyMarkdownHeadline(children);
+                  return (
+                    <a
+                      href={`#${slug}`}
+                      onClick={(e) => handleLinkClick(e, slug)}
+                      className={getLinkClassName(
+                        'flex flex-row items-center cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-4 ml-[-0.25rem]',
+                        'text-blue-600 dark:text-blue-400',
+                        slug,
+                      )}
+                    >
+                      <span className='text-blue-400/40 font-extrabold text-[0.8em] max-sm:text-[1.2em] ml-1'>
+                        &mdash;&mdash;
+                      </span>
+                      <span className='mr-1 text-blue-400/90 text-[0.7em] flex justify-center items-center'>
+                        &#9679;
+                      </span>
 
-                        {children}
-                      </a>
-                    );
-                  },
-                }
+                      {children}
+                    </a>
+                  );
+                },
+              }
               : { component: () => null },
           h4:
             depth >= 4
               ? {
-                  component: ({ children }) => {
-                    const slug = slugifyMarkdownHeadline(children);
-                    return (
-                      <a
-                        href={`#${slug}`}
-                        className='flex flex-row items-center cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-4 ml-[-0.25rem] '
-                      >
-                        <span className='text-blue-400/40 font-extrabold text-[0.8em] ml-1 max-sm:text-[1.2em]'>
-                          &mdash;&mdash;&mdash;&mdash;
-                        </span>
-                        <span className='mr-1 text-blue-400/90 text-[0.7em] flex justify-center items-center'>
-                          &#9679;
-                        </span>
+                component: ({ children }) => {
+                  const slug = slugifyMarkdownHeadline(children);
+                  return (
+                    <a
+                      href={`#${slug}`}
+                      onClick={(e) => handleLinkClick(e, slug)}
+                      className={getLinkClassName(
+                        'flex flex-row items-center cursor-pointer mb-3 max-sm:text-sm text-slate-600 dark:text-slate-300 leading-4 ml-[-0.25rem]',
+                        'text-blue-600 dark:text-blue-400',
+                        slug,
+                      )}
+                    >
+                      <span className='text-blue-400/40 font-extrabold text-[0.8em] ml-1 max-sm:text-[1.2em]'>
+                        &mdash;&mdash;&mdash;&mdash;
+                      </span>
+                      <span className='mr-1 text-blue-400/90 text-[0.7em] flex justify-center items-center'>
+                        &#9679;
+                      </span>
 
-                        {children}
-                      </a>
-                    );
-                  },
-                }
+                      {children}
+                    </a>
+                  );
+                },
+              }
               : { component: () => null },
           ...hiddenElements(
             'strong',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix – fixes an inconsistency in the sidebar (Table of Contents) active state on blog pages.

**Issue Number**

Closes #2172

**Summary**

Previously, clicking a Table of Contents (TOC) item scrolled to the correct section but did not update the URL hash in a way that the Headlines component could detect. This caused the active state (highlighted section) to remain on the previously active heading, so the sidebar TOC and the visible content heading were out of sync.

This PR updates the navigation behavior so that the URL hash is updated consistently and the active state stays synchronized between the sidebar TOC and the corresponding content headings.

**Changes**

- Updated `components/TableOfContentMarkdown.tsx` to use `next/router`.
- Implemented `router.push(..., { shallow: true })` on TOC item clicks to correctly update the URL hash without a full page reload.
- Ensured that the active TOC item is visually highlighted (blue text) when its section is active, keeping the sidebar and content view aligned.

**Screenshots / Videos**

Please verify manually by:

- Clicking different TOC items on a blog page.
- Confirming that the URL hash updates to the correct section ID.
- Checking that the active state moves correctly between sections in both the sidebar TOC and the headings.

**Does this PR introduce a breaking change?**

No.

**Documentation Updates**

N/A.

**Checklist**

Please ensure the following tasks are completed before submitting this pull request.
