### PR TITLE
feat: Auto-collapse sidebar sub-navigation when opening a new section

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -355,17 +355,30 @@ export const DocsNav = ({
     }
   }, [resolvedTheme]);
 
+  /* Accordion helper: Auto-collapse other sections when opening a new one */
+  const handleAccordionChange = (key: keyof typeof active, isOpen: boolean) => {
+    if (isOpen) {
+      setActive({
+        getDocs: key === 'getDocs',
+        getStarted: key === 'getStarted',
+        getGuides: key === 'getGuides',
+        getReference: key === 'getReference',
+        getSpecification: key === 'getSpecification',
+      });
+    } else {
+      setActive((prev) => ({
+        ...prev,
+        [key]: false,
+      }));
+    }
+  };
+
   return (
     <div id='sidebar' className='lg:mt-8 w-4/5 mx-auto lg:ml-4'>
       {/* Introduction */}
       <Collapsible
         open={active.getDocs}
-        onOpenChange={(open) =>
-          setActive((prev) => ({
-            ...prev,
-            getDocs: open,
-          }))
-        }
+        onOpenChange={(open) => handleAccordionChange('getDocs', open)}
         className='my-2 bg-slate-200 dark:bg-slate-900 border-white border lg:border-hidden p-3 rounded transition-all duration-300 group'
       >
         <CollapsibleTrigger asChild>
@@ -467,12 +480,7 @@ export const DocsNav = ({
       {/* Get Started */}
       <Collapsible
         open={active.getStarted}
-        onOpenChange={(open) =>
-          setActive((prev) => ({
-            ...prev,
-            getStarted: open,
-          }))
-        }
+        onOpenChange={(open) => handleAccordionChange('getStarted', open)}
         className='mb-2 bg-slate-200 dark:bg-slate-900 p-3 rounded border border-white lg:border-hidden transition-all duration-300 group'
       >
         <CollapsibleTrigger asChild>
@@ -571,12 +579,7 @@ export const DocsNav = ({
       {/* Guides */}
       <Collapsible
         open={active.getGuides}
-        onOpenChange={(open) =>
-          setActive((prev) => ({
-            ...prev,
-            getGuides: open,
-          }))
-        }
+        onOpenChange={(open) => handleAccordionChange('getGuides', open)}
         className='mb-2 bg-slate-200 dark:bg-slate-900 p-3 rounded border border-white lg:border-hidden transition-all duration-300 group'
       >
         <CollapsibleTrigger asChild>
@@ -644,12 +647,7 @@ export const DocsNav = ({
       {/* Reference */}
       <Collapsible
         open={active.getReference}
-        onOpenChange={(open) =>
-          setActive((prev) => ({
-            ...prev,
-            getReference: open,
-          }))
-        }
+        onOpenChange={(open) => handleAccordionChange('getReference', open)}
         className='mb-2 bg-slate-200 dark:bg-slate-900 p-3 rounded border border-white lg:border-hidden transition-all duration-300 group'
       >
         <CollapsibleTrigger asChild>
@@ -827,12 +825,7 @@ export const DocsNav = ({
       {/* Specification */}
       <Collapsible
         open={active.getSpecification}
-        onOpenChange={(open) =>
-          setActive((prev) => ({
-            ...prev,
-            getSpecification: open,
-          }))
-        }
+        onOpenChange={(open) => handleAccordionChange('getSpecification', open)}
         className='mb-2 bg-slate-200 dark:bg-slate-900 p-3 rounded border border-white lg:border-hidden transition-all duration-300 group'
       >
         <CollapsibleTrigger asChild>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- Bug fix (UI / UX behavior)

---

**Issue Number:**
- Closes #2197

---

**Screenshots/videos:**

https://github.com/user-attachments/assets/82f853cc-a614-4669-bbda-57b2bfaae0c2


Attached screen recording demonstrating the updated accordion behavior where opening a sidebar section automatically collapses the previously opened one.

---

**If relevant, did you update the documentation?**

Not required.  
This change only affects client-side navigation behavior and does not modify documentation content.

---

**Summary**

The documentation sidebar currently allows multiple sub-navigation sections to remain expanded simultaneously, which leads to visual clutter and makes navigation harder to scan.

This PR updates the sidebar interaction to behave as a mutually exclusive accordion:
- When a new sidebar section is expanded, any previously expanded section is automatically collapsed.
- Only one sub-navigation section can be open at a time.

The change improves usability and accessibility while preserving existing markup, animations, and data attributes. No data models, APIs, or content were modified.

---

**Does this PR introduce a breaking change?**

No.  
This is a non-breaking, client-side UI behavior change that does not affect existing routes, data, or public APIs.

---

**Checklist**

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
