### PR TITLE
fix: prevent empty feedback form submission

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -86,8 +86,16 @@ export function DocsHelp({
   async function createFeedbackHandler(event: FormEvent) {
     event.preventDefault();
     const formData = new FormData(feedbackFormRef.current!);
+    const feedbackComment = formData.get('feedback-comment')?.toString().trim();
+
+    if (!feedbackComment) {
+      setError('Feedback comment cannot be empty.');
+      return;
+    }
+
     formData.append('feedback-page', router.asPath);
     setIsSubmitting(true);
+    setError('');
 
     try {
       const response = await fetch(
@@ -118,7 +126,15 @@ export function DocsHelp({
 
   const createGitHubIssueHandler = () => {
     const formData = new FormData(feedbackFormRef.current!);
+    const feedbackComment = formData.get('feedback-comment')?.toString().trim();
+
+    if (!feedbackComment) {
+      setError('Feedback comment cannot be empty.');
+      return;
+    }
+
     setIsSubmitting(true);
+    setError('');
     try {
       const title = encodeURIComponent('Feedback on Documentation');
       const body = encodeURIComponent(`${formData.get('feedback-comment')}`);

--- a/cypress/components/DocsHelp.cy.tsx
+++ b/cypress/components/DocsHelp.cy.tsx
@@ -188,6 +188,54 @@ describe('DocsHelp Component', () => {
       .and('contains', /An error occurred. Please try again later./i);
   });
 
+  // test feedback form shows error when submitting empty comment
+  it('should show error when submitting empty feedback comment', () => {
+    // click on yes button to open feedback form
+    cy.get(FEEDBACK_FORM_YES_BUTTON).click();
+    cy.get(FEEDBACK_FORM).should('be.visible');
+
+    // leave feedback input empty and click submit
+    cy.get(FEEDBACK_FORM_INPUT).should('be.visible').and('have.value', '');
+    cy.get(FEEDBACK_FORM_SUBMIT_BUTTON).click();
+
+    // check if error message is displayed
+    cy.get(FEEDBACK_ERROR_MESSAGE)
+      .should('have.prop', 'tagName', 'P')
+      .and('contain.text', 'Feedback comment cannot be empty.');
+  });
+
+  // test feedback form shows error when submitting whitespace-only comment
+  it('should show error when submitting whitespace-only feedback comment', () => {
+    // click on yes button to open feedback form
+    cy.get(FEEDBACK_FORM_YES_BUTTON).click();
+    cy.get(FEEDBACK_FORM).should('be.visible');
+
+    // type only whitespace and click submit
+    cy.get(FEEDBACK_FORM_INPUT).type('   ');
+    cy.get(FEEDBACK_FORM_SUBMIT_BUTTON).click();
+
+    // check if error message is displayed
+    cy.get(FEEDBACK_ERROR_MESSAGE)
+      .should('have.prop', 'tagName', 'P')
+      .and('contain.text', 'Feedback comment cannot be empty.');
+  });
+
+  // test create github issue shows error when comment is empty
+  it('should show error when creating github issue with empty comment', () => {
+    // click on yes button to open feedback form
+    cy.get(FEEDBACK_FORM_YES_BUTTON).click();
+    cy.get(FEEDBACK_FORM).should('be.visible');
+
+    // leave feedback input empty and click create issue
+    cy.get(FEEDBACK_FORM_INPUT).should('be.visible').and('have.value', '');
+    cy.get(CREATE_GITHUB_ISSUE_BUTTON).click();
+
+    // check if error message is displayed
+    cy.get(FEEDBACK_ERROR_MESSAGE)
+      .should('have.prop', 'tagName', 'P')
+      .and('contain.text', 'Feedback comment cannot be empty.');
+  });
+
   // test create github issue functionality when submitting feedback
   it('should open github issue page', () => {
     // mock window.open function


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**
- Closes #1415

**Screenshots/videos:**

**Before (Bug):**
The feedback form submits successfully even when the comment field is empty, allowing blank feedback entries.

![Before bug](https://github.com/user-attachments/assets/f8e2077e-65f3-4db3-8694-6c960270f3a2)

**After (Fix):**
The form now validates the input and displays an error message "Feedback comment cannot be empty." when attempting to submit empty or whitespace-only feedback.

![After fix](https://github.com/user-attachments/assets/34da2edd-a8fc-4b47-b994-8225c9a0a53d)

**Test Results:** All 12 component tests passing (including 3 new validation tests)

```bash
yarn cypress run --component --spec "cypress/components/DocsHelp.cy.tsx"
```

<img width="945" height="603" alt="test-results" src="https://github.com/user-attachments/assets/ac7411fc-1798-445c-9d17-cc3c0d74f068" />

**If relevant, did you update the documentation?**

Not applicable.

**Summary**

The feedback form previously allowed submission even when the comment field was empty, resulting in blank feedback entries being recorded.

This PR fixes the issue by:
- Adding validation in `createFeedbackHandler` to reject empty/whitespace-only comments
- Adding validation in `createGitHubIssueHandler` for consistency
- Displaying error message: "Feedback comment cannot be empty."
- Adding 3 new Cypress component tests covering empty validation scenarios
- All tests pass with 100% coverage on DocsHelp.tsx

**Does this PR introduce a breaking change?**

No

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).