### PR TITLE
Fixes:#2170 Community links should be open in new tab

### DIFF
--- a/pages/community/index.page.tsx
+++ b/pages/community/index.page.tsx
@@ -100,17 +100,14 @@ export default function CommunityPages(props: any) {
                 </h2>
               </div>
               <div className='mt-8'>
-                <button
+                <a
+                  href='https://github.com/orgs/json-schema-org/discussions'
+                  target='_blank'
+                  rel='noopener noreferrer'
                   className='bg-blue-700 hover:bg-blue-800 text-white font-bold py-2 px-4 rounded block md:inline-block focus:outline-none'
-                  onClick={() =>
-                    window.open(
-                      'https://github.com/orgs/json-schema-org/discussions',
-                      '_self',
-                    )
-                  }
                 >
                   Join Discussions
-                </button>
+                </a>
               </div>
             </div>
           </div>
@@ -188,6 +185,7 @@ export default function CommunityPages(props: any) {
                 >
                   <Link
                     href='/ambassadors'
+                    target='_blank'
                     rel='noopener noreferrer'
                     className='bg-blue-700 hover:bg-blue-800 text-white font-bold py-2 px-4 rounded block md:inline-block focus:outline-none'
                   >
@@ -215,6 +213,7 @@ export default function CommunityPages(props: any) {
                 <div className='mt-10'>
                   <Link
                     href='/slack'
+                    target='_blank'
                     rel='noopener noreferrer'
                     className='bg-blue-700 hover:bg-blue-800 text-white font-bold py-2 px-4 rounded block md:inline-block focus:outline-none'
                   >
@@ -247,6 +246,7 @@ export default function CommunityPages(props: any) {
                   <div className='mt-10 flex justify-center'>
                     <a
                       href='https://github.com/orgs/json-schema-org/discussions/35'
+                      target='_blank'
                       rel='noopener noreferrer'
                       className='bg-blue-700 hover:bg-blue-800 text-white font-bold py-2 px-4 rounded block md:inline-block focus:outline-none'
                     >
@@ -256,6 +256,7 @@ export default function CommunityPages(props: any) {
                   <div className='mt-4 flex justify-center'>
                     <a
                       href='https://github.com/orgs/json-schema-org/discussions/34/'
+                      target='_blank'
                       rel='noopener noreferrer'
                       className='bg-blue-700 hover:bg-blue-800 text-white font-bold py-2 px-4 rounded block md:inline-block focus:outline-none'
                     >
@@ -321,6 +322,7 @@ export default function CommunityPages(props: any) {
                   </h2>
                   <div className='mt-10'>
                     <Link
+                      target='_blank'
                       href='/blog'
                       rel='noopener noreferrer'
                       className='bg-blue-700 hover:bg-blue-800 text-white font-bold py-2 px-4 rounded block md:inline-block focus:outline-none'
@@ -400,6 +402,7 @@ export default function CommunityPages(props: any) {
                 <div className='mx-auto '>
                   <Link
                     href='/blog'
+                    target='_blank'
                     rel='noopener noreferrer'
                     className='bg-blue-700 hover:bg-blue-800 text-white font-bold py-2 px-4 rounded block md:inline-block focus:outline-none mt-4'
                   >


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Enhancement / Bugfix (UX)
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2170 


**Screenshots/videos:**
N/A (Links now open in new tab)
<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
N/A

<!--Add link to it-->

**Summary**
Replaced <button> with <a> - The "Join Discussions" button was previously a semantic <button> using onClick and window.open as told by the maintainer. Then did 4-5 changes in the link and redirected it to new page when clicking i.e added target="_blank" and rel="noopener noreferrer" to external links links slack, become and ambassador etc.


<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [ x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).