### PR TITLE
Fix #2215: open external Slack and Common Room links in new tab

### DIFF
--- a/components/StyledMarkdownBlock.tsx
+++ b/components/StyledMarkdownBlock.tsx
@@ -86,7 +86,8 @@ export const StyledMarkdownBlock = ({ markdown }: StyledMarkdownBlockProps) => {
                       as={href}
                       href='/'
                       title={title}
-                      target='_blank' rel='noopener noreferrer'
+                      target='_blank'
+                      rel='noopener noreferrer'
                       className={combinedClassName} // Use the combined className
                     >
                       {children}
@@ -94,7 +95,8 @@ export const StyledMarkdownBlock = ({ markdown }: StyledMarkdownBlockProps) => {
                   ) : (
                     <a
                       href={href}
-                       target='_blank' rel='noopener noreferrer'
+                      target='_blank'
+                      rel='noopener noreferrer'
                       title={title}
                       className={combinedClassName} // Use the combined className
                     >

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -182,7 +182,8 @@ const Home = (props: any) => {
               </Link>
               <Link
                 href='/slack'
-                target='_blank' rel='noopener noreferrer'
+                target='_blank'
+                rel='noopener noreferrer'
                 className='flex items-center justify-center rounded border-2 border-white dark:border-none hover:bg-blue-700 transition-all duration-300 ease-in-out text-white  w-[194px] h-[40px] font-semibold bg-primary dark:shadow-2xl'
               >
                 Join Slack
@@ -967,7 +968,11 @@ for Accounting integrations'
             </p>
           </div>
           <div className='flex flex-col items-center md:flex-row justify-center text-center gap-x-14 gap-y-4 mb-12'>
-            <a href='https://dev.events/'    target='_blank' rel='noopener noreferrer'  >
+            <a
+              href='https://dev.events/'
+              target='_blank'
+              rel='noopener noreferrer'
+            >
               {isClient && (
                 <>
                   <Image


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR introduces a bug fix (UX improvement).  
External links in the “Supported by” section were opening in the same tab.  
They now open in a new tab 

---

**Issue Number:**

- Closes #2215




**Screenshots/videos:**


https://github.com/user-attachments/assets/e902c3d5-9813-4e82-b32f-5b0158c9f92f

Before:
External links replaced the current page.

After:
External links open in a new tab, preserving the user’s session on the website.

---

**If relevant, did you update the documentation?**

No documentation update was required since this change only affects link behavior.

---

**Summary**

This PR fixes a user experience issue where external links (Slack & Common Room)
opened in the same browser tab. This interrupted the user flow by navigating
away from the site.

The fix ensures external links:
- Open in a new tab
- Follow security best practices using `rel="noopener noreferrer"`

This improves usability and aligns with standard web UX conventions.

---

**Does this PR introduce a breaking change?**

No. This change is fully backward-compatible and does not affect existing functionality.

---

# Checklist

- [x] Read, understood, and followed the contributing guidelines
