### PR TITLE
Add GitHub contributors API feature

### DIFF
--- a/pages/community/index.page.tsx
+++ b/pages/community/index.page.tsx
@@ -69,7 +69,6 @@ export const getStaticProps: GetStaticProps = async () => {
 };
 
 function CommunityPages({ blogPosts, datesInfo, imageData }: any) {
-
   const timeToRead = Math.ceil(readingTime(blogPosts[0].content).minutes);
 
   // Shuffle contributors on every render


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature enhancement

**Issue Number:**
   Fixes #2099


**Screenshots/videos:**

https://github.com/user-attachments/assets/34db2fc9-3e51-4777-bcab-9bf08d10f146



**Summary**
This PR updates the Community page to dynamically fetch contributors directly from the GitHub API instead of using static data.
It restores and improves the original functionality by:

- Fetching contributors dynamically from the GitHub API
- Displaying contributor avatars with shuffle behavior
- Preserving hover animation effects
- Adding clickable redirection to each contributor’s GitHub profile

**Does this PR introduce a breaking change?**
No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).