### PR TITLE
fix: use canonical URL with trailing slash in Atom feed id

### DIFF
--- a/pages/blog/generateRssFeed.tsx
+++ b/pages/blog/generateRssFeed.tsx
@@ -8,7 +8,7 @@ export default async function generateRssFeed(blogPosts: any) {
   const feed = new Feed({
     title: 'JSON Schema Blog RSS Feed',
     description: 'JSON Schema Blog',
-    id: SITE_URL,
+    id: `${SITE_URL}/`,
     link: `${SITE_URL}/blog`,
     image: `${SITE_URL}/logo-blue.svg`,
     favicon: `${SITE_URL}/favicon.png`,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix – corrects the Atom feed ID to use the canonical URL with a trailing slash.

**Issue Number**

Closes #2226

**Summary**

The Atom feed at `https://json-schema.org/rss/atom.xml` was using a non-canonical URL for its `<id>` element (`https://json-schema.org`). Feed validators recommend using the canonical form with a trailing slash (`https://json-schema.org/`) to ensure better interoperability across feed readers and clients. This PR updates `pages/blog/generateRssFeed.tsx` so that the `id` field in the generated Atom feed includes the trailing slash.

**Screenshots / Videos**

N/A – code change only, verified via the generated feed output.

**If relevant, did you update the documentation?**

No documentation update required.

**Does this PR introduce a breaking change?**

No.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
