### PR TITLE
fix: persist blog pagination and filters in URL

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -104,10 +104,11 @@ export default function StaticMarkdownPage({
 }) {
   const router = useRouter();
   // Initialize the filter as an array. If "All" or not specified, we show all posts.
-  const initialFilters =
+  const initialFilters = (
     filterTag && filterTag !== 'All'
       ? filterTag.split(',').filter(isValidCategory)
-      : ['All'];
+      : ['All']
+  ) as blogCategories[];
 
   const [currentFilterTags, setCurrentFilterTags] =
     useState<blogCategories[]>(initialFilters);
@@ -138,10 +139,11 @@ export default function StaticMarkdownPage({
   }, [router.isReady, router.query.type, router.query.page]);
 
   useEffect(() => {
-    const tags =
+    const tags = (
       filterTag && filterTag !== 'All'
         ? filterTag.split(',').filter(isValidCategory)
-        : ['All'];
+        : ['All']
+    ) as blogCategories[];
     setCurrentFilterTags(tags);
   }, [filterTag]);
 
@@ -259,7 +261,7 @@ export default function StaticMarkdownPage({
 
   const handlePageChange = (newPage: number) => {
     const query = { ...router.query, page: newPage.toString() };
-    if (newPage === 1) delete query.page;
+    if (newPage === 1) delete (query as any).page;
 
     router.push(
       {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

- Closes #2245

**Screenshots/videos:**

<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/0827aa27-79da-4830-9591-44dfef6a695b" />

**If relevant, did you update the documentation?**

N/A (UI fix)

**Summary**

This PR fixes the issue where navigating through the blog pagination resets to page 1 upon reloading or using the browser's back/forward buttons.

**Key changes:**
- Synchronized the `currentPage` state and category filters with URL query parameters (`page` and `type`) using the Next.js router.
- Replaced raw `history.replaceState` with `router.push({ shallow: true })` for framework consistency and better navigation history.
- Added a `useEffect` hook to restore pagination and filter state from the URL on initial mount and route changes.
- Ensured that changing a category filter resets the page to 1 for the new set of results.

**Does this PR introduce a breaking change?**

No.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).