### PR TITLE
Update Slack invite link and add redirect page

### DIFF
--- a/data/ambassadors.json
+++ b/data/ambassadors.json
@@ -1,1 +1,392 @@
-../_includes/community/programs/ambassadors/ambassadors.json
+[
+  {
+    "name": "Andreas Eberhart",
+    "img": "https://media.licdn.com/dms/image/v2/C5603AQFwzjco4Zp2iw/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1522155839579?e=1739404800&v=beta&t=A3Ki-Ct3mzO_0fTe6w_zWNj5z_1CCX0wpxxuDpCMxXA",
+    "bio": "With 25 years of professional experience, Andreas is very proficient in the areas of enterprise cloud, linked & big data, as well as systems architecture and development. He co-founded two startups and drove their growth resulting in two acquisitions by silicon valley giants HP and Veritas. Combined with his extensive background in cutting edge research, he has the unique ability to address projects from technical, time to market, and ROI angles. He holds a PhD in Computer Science from the University of Saarbrücken and a Master in Computer Science from Portland State University.",
+    "title": "CEO at Dashjoin",
+    "github": "aeberhart",
+    "twitter": "dashjoin",
+    "linkedin": "andreas-eberhart-94264a44",
+    "company": "Dashjoin",
+    "country": "🇩🇪",
+    "contributions": [
+      {
+        "type": "article",
+        "title": "JSON Schema, Schema.org, JSON-LD: What’s the Difference?",
+        "date": {
+          "year": 2020,
+          "month": "August"
+        },
+        "link": "https://medium.com/@dashjoin/json-schema-schema-org-json-ld-whats-the-difference-e30d7315686a"
+      },
+      {
+        "type": "video",
+        "title": "Supercharge your Angular Project with JSON Schema Forms",
+        "date": {
+          "year": 2020,
+          "month": "August"
+        },
+        "link": "https://www.youtube.com/watch?v=Xk9dxbbBFjo"
+      },
+      {
+        "type": "adopter",
+        "title": "Add Dashjoin to the JSON Schema Adopters list.",
+        "date": {
+          "year": 2024,
+          "month": "April"
+        },
+        "link": "https://landscape.json-schema.org/"
+      },
+      {
+        "type": "article",
+        "title": "JSON Schema, OpenAPI & Low Code: A Match Made in Heaven",
+        "date": {
+          "year": 2024,
+          "month": "October"
+        },
+        "link": "https://dashjoin.medium.com/json-schema-openapi-low-code-a-match-made-in-heaven-d29723e543ac"
+      }
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "July"
+    }
+  },      
+  {
+    "name": "David Biesack",
+    "img": "https://avatars.githubusercontent.com/u/545944?s=400&u=26818946106e2d8ae8c0cb5e0b72d6c7f612d268&v=4",
+    "bio": "Chief API Officer at APiture (I design banking APIs with OpenAPI 3.1, JSON Schema 2020/12) and author of the API Design Matters blog, https://apidesignmatters.substack.com/ ",
+    "title": "Chief API Officer",
+    "github": "DavidBiesack",
+    "mastodon": "@DavidBiesack@fosstodon.org",
+    "linkedin": "davidbiesack",
+    "company": "Apiture",
+    "country": "🇺🇸",
+    "contributions": [
+      {
+        "type": "article",
+        "title": "Composing API Models with JSON Schema",
+        "date": {
+          "year": 2023,
+          "month": "June"
+        },
+        "link": "https://apidesignmatters.substack.com/p/composing-api-models-with-json-schema"
+      },
+      {
+        "type": "article",
+        "title": "Master JSON Schema's Subtleties",
+        "date": {
+          "year": 2023,
+          "month": "July"
+        },
+        "link": "https://apidesignmatters.substack.com/p/master-json-schemas-subtleties"
+      },
+      {
+        "type": "article",
+        "title": "Master More JSON Schema's Subtleties",
+        "date": {
+          "year": 2023,
+          "month": "July"
+        },
+        "link": "https://apidesignmatters.substack.com/p/master-more-json-schemas-subtleties"
+      },
+      {
+        "type": "article",
+        "title": "Learning the Language of API Data",
+        "date": {
+          "year": 2023,
+          "month": "May"
+        },
+        "link": "https://apidesignmatters.substack.com/p/learning-the-language-of-api-data"
+      },
+      {
+        "type": "other",
+        "title": "What is JSON Schema?",
+        "date": {
+          "year": 2024,
+          "month": "June"
+        },
+        "link": "https://github.com/json-schema-org/website/pull/679"
+      },
+      {
+        "type": "talk",
+        "title": "Wielding the Double-Edged Sword of JSON Schema",
+        "date": {
+          "year": 2022,
+          "month": "September"
+        },
+        "link": "https://www.youtube.com/watch?v=6ukZEUBRpqo"
+      }
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "July"
+    }
+  },
+  {
+    "name": "Juan Cruz Viotti",
+    "img": "https://avatars.githubusercontent.com/u/2192773?v=4",
+    "bio": "Founder at Sourcemeta, consultant, and author",
+    "title": "Founder",
+    "github": "jviotti",
+    "linkedin": "jviotti",
+    "company": "Sourcemeta",
+    "country": "🇧🇴",
+    "contributions": [
+      {
+        "type": "project",
+        "title": "Alterschema",
+        "date": {
+          "year": 2022,
+          "month": "May"
+        },
+        "link": "https://alterschema.sourcemeta.com"
+      },
+      {
+        "type": "article",
+        "title": "How the W3C Web of Things brings JSON Schema to the Internet of Things",
+        "date": {
+          "year": 2022,
+          "month": "October"
+        },
+        "link": "https://json-schema.org/blog/posts/w3c-wot-case-study"
+      },
+      {
+        "type": "project",
+        "title": "Learn JSON Schema",
+        "date": {
+          "year": 2023,
+          "month": "March"
+        },
+        "link": "https://www.learnjsonschema.com"
+      },
+      {
+        "type": "article",
+        "title": "Understanding JSON Schema Lexical and Dynamic Scopes",
+        "date": {
+          "year": 2024,
+          "month": "February"
+        },
+        "link": "https://json-schema.org/blog/posts/understanding-lexical-dynamic-scopes"
+      },
+      {
+        "type": "book",
+        "title": "Unifying Business, Data, and Code: Designing Data Products with JSON Schema",
+        "date": {
+          "year": 2024,
+          "month": "January"
+        },
+        "link": "https://www.oreilly.com/library/view/unifying-business-data/9781098144999/"
+      },
+      {
+        "type": "initiative",
+        "title": "GSoC 2024: Upgrade/Downgrade Rules",
+        "date": {
+          "year": 2024,
+          "month": "March"
+        },
+        "link": "https://github.com/json-schema-org/community/issues/599"
+      },
+      {
+        "type": "talk",
+        "title": "Applying Software Engineering Practices to Schemas",
+        "date": {
+          "year": 2024,
+          "month": "December"
+        },
+        "link": "http://conference.json-schema.org"
+      }
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "August"
+    }
+  },
+  {
+    "name": "Esther Okafor",
+    "img": "https://media.licdn.com/dms/image/v2/D4D03AQGO8M-VFQJvAQ/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1719478757384?e=1739404800&v=beta&t=N6GOewG0on7VdbwaEWMjPkXxY9o0haL5ek5rX9rEHcc",
+    "bio": "I am a QA engineer currently working with Storyblok. I am passionate about quality and making sure software design systems are developed with the highest standards",
+    "title": "Test engineer at Storyblok",
+    "github": "Estherokafor05/My-portfolio",
+    "twitter": "Estherokafor_",
+    "linkedin": "okaforesther/",
+    "company": "Storyblok",
+    "country": "Nigeria",
+    "contributions": [
+      {
+        "type": "article",
+        "title": "Postman Series - writing assertions and validating responses",
+         "date": {
+          "year": 2024,
+          "month": "May"
+        },
+        "link": "https://estherokafor.com/postman-series-writing-assertions-and-validating-responses"
+      },
+      {
+        "type": "article",
+        "title": "Beyond Assertions: Data Validation using Cypress with JSON Schema in End-to-End Testing",
+        "date": {
+          "year": 2024,
+          "month": "May"
+        },
+        "link": "https://estherokafor.com/beyond-assertions-data-validation-using-cypress-with-json-schema-in-end-to-end-testing"
+      },
+      {
+        "type": "article",
+        "title": "Beyond Basics: Leveraging JSON Schema for API Security Testing",
+        "date": {
+          "year": 2024,
+          "month": "June"
+        },
+        "link": "https://estherokafor.com/beyond-basics-leveraging-json-schema-for-api-security-testing"
+      },
+      {
+        "type": "talk",
+        "title": "Beyond Code: A qa's perspective to API design",
+        "date": {
+          "year": 2024,
+          "month": "July"
+        },
+        "link": "https://www.canva.com/design/DAGJgnhNUYA/GLVTP-Yx7wcBVFjOhsN2uQ/edit?utm_content=DAGJgnhNUYA&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton"
+      }
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "August"
+    }
+  },
+  {
+    "name": "Ege Korkan",
+    "img": "https://media.licdn.com/dms/image/v2/D4D03AQG03-U--zDJpw/profile-displayphoto-shrink_400_400/profile-displayphoto-shrink_400_400/0/1707341764311?e=1739404800&v=beta&t=jO5SgCnwdAKU1sRapA7-DzVq-p4tzu5GvNV_aJnci-k",
+    "bio": "Research and standardization focused engineer at Siemens with a passion to drive interoperability across all levels.",
+    "title": "Web of Things Expert at Siemens",
+    "github": "egekorkan",
+    "twitter": "egekorkan",
+    "linkedin": "ege-korkan",
+    "mastodon":"@egekorkan@mastodon.social",
+    "company": "Siemens AG",
+    "country": "Germany",
+    "contributions": [
+      {
+        "type": "talk",
+        "title": "One Year Update: Using LinkML in Web of Things Specifications",
+        "date": {
+          "year": 2024,
+          "month": "September"
+        },
+        "link": "https://www.w3.org/events/meetings/e5cb0ff4-1696-4367-b9fe-9e74c5034dd3/"
+      },
+      {
+        "type": "article",
+        "title": "How the W3C Web of Things brings JSON Schema to the Internet of Things",
+        "date": {
+          "year": 2022,
+          "month": "October"
+        },
+        "link": "https://json-schema.org/blog/posts/w3c-wot-case-study"
+      },
+      {
+        "type": "project",
+        "title": "Web of Things Tutorial which contains a part on JSON Schema",
+        "date": {
+          "year": 2024,
+          "month": "January"
+        },
+        "link": "https://w3c.github.io/wot-cg/tutorials/whatiswot/docs/preliminary/json-schema/intro"
+      },
+      {
+        "type": "adopter",
+        "title": "Add Standards Category to the JSON Schema Adopters list.",
+        "date": {
+          "year": 2024,
+          "month": "May"
+        },
+        "link": "https://landscape.json-schema.org/"
+      },
+      {
+        "type": "working group",
+        "title": "Web of Things Working Group participation at the W3C, which is using JSON Schema",
+        "date": {
+          "year": 2018,
+          "month": "September"
+        },
+        "link": "https://www.w3.org/WoT/"
+      },
+      {
+        "type": "project",
+        "title": "JSON Spell-checker based on JSON Schema",
+        "date": {
+          "year": 2023,
+          "month": "January"
+        },
+        "link": "https://github.com/eclipse-thingweb/playground/tree/master/packages/json-spell-checker"
+      }
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "August"
+    }
+  },
+  {
+    "name": "Jeremy Fiel",
+    "img": "https://avatars.githubusercontent.com/u/32110157?v=4",
+    "bio": "Originally, an international logistics expert with more than 15 years of professional experience, Jeremy transitioned to software, specifically APIs, about 8 years ago. His passion for learning and contributing back to the community is where he found a love for open source projects. He is now a consistent contributor to projects such as [Redocly](https://github.com/redocly) and the [OpenAPI Initiative](https://github.com/OAI) projects, and a very active community member of JSON Schema.",
+    "title": "Principal Software Engineer | OpenAPI | JSON Schema | Arazzo | APIs",
+    "github": "jeremyfiel",
+    "twitter": "jeremyfiel",
+    "linkedin": "https://www.linkedin.com/in/jeremyfiel",
+    "company": "ADP, Inc.",
+    "country": "US",
+    "contributions": [
+      {
+        "type": "project",
+        "title": "Schema author of OpenAPI Initiative's Arazzo Specification v1.0 JSON Schema",
+        "date": {
+          "year": 2024,
+          "month": "August"
+        },
+        "link": "https://github.com/oai/arazzo-specification/schemas/v1.0/schema.yaml"
+      },
+      {
+        "type": "project",
+        "title": "OSS contributor for Redocly CLI",
+        "date": {
+          "year": 2023,
+          "month": "April"
+        },
+        "link": "https://github.com/redocly/redocly-cli"
+      },
+      {
+        "type": "other",
+        "title": "JSON Schema Slack Community Member",
+        "date": {
+          "year": 2021,
+          "month": "November"
+        },
+        "link": "https://json-schema.slack.com"
+      },
+      {
+        "type": "other",
+        "title": "JSON Schema Stack Overflow Community Member",
+        "date": {
+          "year": 2021,
+          "month": "November"
+        },
+        "link": "https://stackoverflow.com/questions/tagged/json-schema"
+      },
+      {
+        "type": "adopter",
+        "title": "Add ADP, Inc. to the JSON Schema Adopters list.",
+        "date": {
+          "year": 2023,
+          "month": "October"
+        },
+        "link": "https://landscape.json-schema.org/"
+      }
+    ],
+    "startedOn": {
+        "year": 2024,
+        "month": "September"
+    }
+  }  
+]

--- a/pages/slack.page.tsx
+++ b/pages/slack.page.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+
+export default function SlackRedirect() {
+  useEffect(() => {
+    window.location.href = 'https://json-schema.org/slack';
+  }, []);
+
+  return (
+    <div className='flex flex-col items-center justify-center min-h-screen gap-5'>
+      <p className='text-lg'>Redirecting to JSON Schema Slack workspace...</p>
+      <p className='text-lg'>
+        If you are not redirected automatically,{' '}
+        <a
+          href='https://json-schema.org/slack'
+          className='text-blue-600 underline hover:text-blue-800'
+        >
+          click here
+        </a>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
The previous Slack invite link was outdated. Updated to the latest invite link and created a dedicated redirect page at `/slack` with better UX - shows a loading message and fallback link in case JavaScript is disabled or redirect fails.

**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**
- Closes #2253

**Screenshots/videos:**

<!-- Add screenshots here -->
<img width="1623" height="957" alt="image" src="https://github.com/user-attachments/assets/155b2bd4-8773-4d55-a642-aa1bc1a647dc" />

<img width="1919" height="1137" alt="image" src="https://github.com/user-attachments/assets/7747d8b4-0ce4-418e-a568-7dd64ffcb407" />


**If relevant, did you update the documentation?**
No documentation update was required for this change.

**Summary**

The Slack invite link on the JSON Schema website had expired. When users clicked the "Join our Slack community" link, they were redirected to a Slack error page displaying "This link is no longer active. To join this workspace, you'll need to ask the person who originally invited you for a new link." This was a frustrating experience for new contributors and community members trying to join the JSON Schema Slack workspace.

This PR fixes the issue by:
- Updating the expired Slack invite URL to the latest working invite link
- Creating a dedicated `/slack` redirect page that automatically redirects users to the Slack workspace
- Adding a loading message so users know the redirect is in progress
- Adding a fallback link for users who have JavaScript disabled or in case the automatic redirect fails for any reason

This approach is better than just replacing the URL because now all Slack links on the website can point to `/slack`, making future link updates much easier — maintainers will only need to update a single file if the invite link expires again.

**Does this PR introduce a breaking change?**
No, this is a straightforward non-breaking bugfix. No existing functionality is affected.

**Checklist:**
- [x] Read, understood, and followed the contributing guidelines.