### PR TITLE
Fix: remove resize listener on unmount in Sidebar (#2241)

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -205,14 +205,20 @@ export const SidebarLayout = ({ children }: { children: React.ReactNode }) => {
   const shouldHideSidebar = pathWtihoutFragment === '/md-style-guide';
 
   useEffect(() => {
-    if (window) {
-      window.addEventListener('resize', () => {
-        if (window.innerWidth > 1024) {
-          setOpen(false);
-        }
-      });
-    }
-  }, [typeof window !== 'undefined']);
+    if (typeof window === 'undefined') return;
+
+    const handleResize = () => {
+      if (window.innerWidth > 1024) {
+        setOpen(false);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
   return (
     <div className='max-w-[1400px] mx-auto flex flex-col items-center'>
       <section>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix

---

**Issue Number:**

- Closes #2241

---

**Screenshots/videos:**

N/A – internal lifecycle fix, no visible UI changes.

---

**If relevant, did you update the documentation?**

No documentation changes required.

---

**Summary**

This PR fixes a resize event listener accumulation issue in `components/Sidebar.tsx`.

Previously, the `useEffect` hook added a `window.resize` listener using an anonymous function and did not remove it on unmount. When navigating between pages that mount/unmount the Sidebar, multiple resize listeners accumulated over time. This caused redundant executions on resize and a small memory leak.

The fix:

- Introduces a named `handleResize` function
- Adds proper cleanup using `window.removeEventListener`
- Keeps the implementation SSR-safe
- Uses an empty dependency array to ensure the listener is registered only once

No other logic or behavior was changed.

---

**Notes**

- Verified locally that only a single `resize` listener remains attached after repeated navigation.
- All existing tests pass.
- Lint and type checks pass locally.
- No UI behavior changes were introduced.

---

**Does this PR introduce a breaking change?**

No.

---

# Checklist

- [x] Read, understood, and followed the contributing guidelines.