### PR TITLE
Fix: prevent matchMedia listener accumulation in FaviconHead (#2263)

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -503,9 +503,16 @@ const FaviconHead = () => {
     const matcher: MediaQueryList = window.matchMedia(
       '(prefers-color-scheme: dark)',
     );
-    matcher.addEventListener('change', () => onUpdate(matcher));
+
+    const handleChange = () => onUpdate(matcher);
+
+    matcher.addEventListener('change', handleChange);
     onUpdate(matcher);
-  }, []);
+
+    return () => {
+      matcher.removeEventListener('change', handleChange);
+    };
+  }, [onUpdate]);
 
   if (isDarkMode) {
     return (


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix


**Issue Number:**

- Closes #2263


**Screenshots/videos:**

N/A – internal lifecycle fix, no visible UI changes.


**If relevant, did you update the documentation?**

No documentation changes required.


**Summary**

This PR fixes a matchMedia `'change'` event listener cleanup issue in
`components/Layout.tsx` inside the `FaviconHead` component.

Previously, the `useEffect` hook registered a `matchMedia('(prefers-color-scheme: dark)')`
listener using an anonymous handler and did not remove it on unmount.
In scenarios where the component could remount, this could lead to
listener accumulation and redundant executions.

The fix:

- Introduces a named `handleChange` function
- Properly removes the listener in the `useEffect` cleanup function
- Preserves existing behavior and SSR safety
- Ensures the listener is registered only once

No other logic or UI behavior was changed.


**Does this PR introduce a breaking change?**

No.


# Checklist

- [x] Read, understood, and followed the contributing guidelines