### PR TITLE
feat: implemented "Jump to Section" menu for Tooling page

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -37,8 +37,8 @@ const buttonVariants = cva(
   },
 );
 
-type ButtonProps = React.ComponentProps<'button'> &
-  React.ComponentProps<'select'> &
+type ButtonProps = Omit<React.ComponentProps<'button'>, 'size'> &
+  Omit<React.ComponentProps<'select'>, 'size'> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
     selectButton?: boolean;

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -37,16 +37,46 @@ const buttonVariants = cva(
   },
 );
 
+type ButtonProps = React.ComponentProps<'button'> &
+  React.ComponentProps<'select'> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+    selectButton?: boolean;
+  };
+
 function Button({
   className,
   variant,
   size,
   asChild = false,
+  selectButton = false,
+  children,
   ...props
-}: React.ComponentProps<'button'> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+}: ButtonProps) {
+  if (selectButton) {
+    return (
+      <div className='relative inline-flex'>
+        <select
+          data-slot='select-button'
+          className={cn(
+            buttonVariants({ variant, size }),
+            'appearance-none cursor-pointer pr-8',
+            className,
+          )}
+          {...(props as React.ComponentProps<'select'>)}
+        >
+          {children}
+        </select>
+
+        <div className='pointer-events-none absolute inset-y-0 right-2 flex items-center'>
+          <svg className='h-4 w-4 fill-current opacity-70' viewBox='0 0 20 20'>
+            <path d='M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z' />
+          </svg>
+        </div>
+      </div>
+    );
+  }
+
   const Comp = asChild ? Slot : 'button';
 
   return (
@@ -54,7 +84,9 @@ function Button({
       data-slot='button'
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
-    />
+    >
+      {children}
+    </Comp>
   );
 }
 

--- a/pages/tools/components/GroupByMenu.tsx
+++ b/pages/tools/components/GroupByMenu.tsx
@@ -50,7 +50,7 @@ const GroupByMenu = ({
   };
 
   return (
-    <div className='ml-2 my-8 flex flex-col gap-y-4 w-full'>
+    <div className='ml-2 my-8 flex flex-col lg:flex-row items-start lg:items-center gap-4 w-full'>
       <div className='flex items-center space-x-2 max-w-screen overflow-x-auto'>
         <span className='text-slate-600 dark:text-slate-300'>GROUP BY:</span>
         {groupBy.map((group) => {
@@ -68,7 +68,7 @@ const GroupByMenu = ({
         })}
       </div>
       {activeSections.length > 0 && groupedBy !== 'none' && (
-        <div className='relative inline-block w-48'>
+        <div className='relative inline-block w-48 lg:ml-2'>
           <select
             onChange={(e) => scrollToSection(e.target.value)}
             defaultValue=''
@@ -83,8 +83,10 @@ const GroupByMenu = ({
               </option>
             ))}
           </select>
-          <div className='pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-slate-500'>
-            ▼
+          <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-slate-500'>
+            <svg className='h-4 w-4 fill-current' viewBox='0 0 20 20'>
+              <path d='M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z' />
+            </svg>
           </div>
         </div>
       )}

--- a/pages/tools/components/GroupByMenu.tsx
+++ b/pages/tools/components/GroupByMenu.tsx
@@ -5,10 +5,24 @@ import { Transform } from '../hooks/useToolsTransform';
 interface GroupByMenuProps {
   transform: Transform;
   setTransform: Dispatch<SetStateAction<Transform>>;
+  activeSections?: string[];
 }
 
-const GroupByMenu = ({ transform, setTransform }: GroupByMenuProps) => {
+const GroupByMenu = ({
+  transform,
+  setTransform,
+  activeSections = [],
+}: GroupByMenuProps) => {
   const groupedBy = transform.groupBy;
+
+  const scrollToSection = (section: string) => {
+    const id = `group-${section}`;
+    const element = document.getElementById(id);
+    if (element) {
+      const y = element.getBoundingClientRect().top + window.scrollY - 100;
+      window.scrollTo({ top: y, behavior: 'smooth' });
+    }
+  };
 
   const groupBy = [
     {
@@ -36,21 +50,44 @@ const GroupByMenu = ({ transform, setTransform }: GroupByMenuProps) => {
   };
 
   return (
-    <div className='ml-2 my-8 flex items-center space-x-2 max-w-screen overflow-x-auto'>
-      <span className='text-slate-600 dark:text-slate-300'>GROUP BY:</span>
-      {groupBy.map((group) => {
-        return (
-          <Button
-            key={group.accessorKey}
-            value={group.accessorKey}
-            onClick={setGroupBy}
-            variant={groupedBy === group.accessorKey ? 'default' : 'outline'}
-            className={`${groupedBy === group.accessorKey ? 'text-white dark:text-slate-900 dark:bg-[#bfdbfe]' : 'dark:bg-[#0f172a] text-black dark:text-slate-300 dark:border-transparent'}`}
+    <div className='ml-2 my-8 flex flex-col gap-y-4 w-full'>
+      <div className='flex items-center space-x-2 max-w-screen overflow-x-auto'>
+        <span className='text-slate-600 dark:text-slate-300'>GROUP BY:</span>
+        {groupBy.map((group) => {
+          return (
+            <Button
+              key={group.accessorKey}
+              value={group.accessorKey}
+              onClick={setGroupBy}
+              variant={groupedBy === group.accessorKey ? 'default' : 'outline'}
+              className={`${groupedBy === group.accessorKey ? 'text-white dark:text-slate-900 dark:bg-[#bfdbfe]' : 'dark:bg-[#0f172a] text-black dark:text-slate-300 dark:border-transparent'}`}
+            >
+              {group.label}
+            </Button>
+          );
+        })}
+      </div>
+      {activeSections.length > 0 && groupedBy !== 'none' && (
+        <div className='relative inline-block w-48'>
+          <select
+            onChange={(e) => scrollToSection(e.target.value)}
+            defaultValue=''
+            className='w-full h-9 pl-3 pr-8 appearance-none rounded-md text-sm font-medium border bg-white dark:bg-[#0f172a] text-black dark:text-slate-300 dark:border-transparent cursor-pointer outline-none shadow-sm transition-all'
           >
-            {group.label}
-          </Button>
-        );
-      })}
+            <option value='' disabled>
+              Jump to Section
+            </option>
+            {activeSections.map((section) => (
+              <option key={section} value={section}>
+                {section}
+              </option>
+            ))}
+          </select>
+          <div className='pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs text-slate-500'>
+            ▼
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/pages/tools/components/GroupByMenu.tsx
+++ b/pages/tools/components/GroupByMenu.tsx
@@ -50,7 +50,7 @@ const GroupByMenu = ({
   };
 
   return (
-    <div className='ml-2 my-8 flex flex-col lg:flex-row items-start lg:items-center gap-4 w-full'>
+    <div className='ml-2 my-8 flex flex-col md:flex-row items-start md:items-center gap-4 w-full'>
       <div className='flex items-center space-x-2 max-w-screen overflow-x-auto'>
         <span className='text-slate-600 dark:text-slate-300'>GROUP BY:</span>
         {groupBy.map((group) => {
@@ -68,7 +68,7 @@ const GroupByMenu = ({
         })}
       </div>
       {activeSections.length > 0 && groupedBy !== 'none' && (
-        <div className='relative inline-block w-48 lg:ml-2'>
+        <div className='relative inline-block w-48'>
           <select
             onChange={(e) => scrollToSection(e.target.value)}
             defaultValue=''

--- a/pages/tools/components/GroupByMenu.tsx
+++ b/pages/tools/components/GroupByMenu.tsx
@@ -68,27 +68,24 @@ const GroupByMenu = ({
         })}
       </div>
       {activeSections.length > 0 && groupedBy !== 'none' && (
-        <div className='relative inline-block w-48'>
-          <select
-            onChange={(e) => scrollToSection(e.target.value)}
-            defaultValue=''
-            className='w-full h-9 pl-3 pr-8 appearance-none rounded-md text-sm font-medium border bg-white dark:bg-[#0f172a] text-black dark:text-slate-300 dark:border-transparent cursor-pointer outline-none shadow-sm transition-all'
-          >
-            <option value='' disabled>
-              Jump to Section
+        <Button
+          selectButton
+          variant='outline'
+          defaultValue=''
+          onChange={(e) =>
+            scrollToSection((e.target as HTMLSelectElement).value)
+          }
+          className='dark:bg-[#0f172a] text-black dark:text-slate-300 dark:border-transparent'
+        >
+          <option value='' disabled>
+            Jump to
+          </option>
+          {activeSections.map((section) => (
+            <option key={section} value={section}>
+              {section}
             </option>
-            {activeSections.map((section) => (
-              <option key={section} value={section}>
-                {section}
-              </option>
-            ))}
-          </select>
-          <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-slate-500'>
-            <svg className='h-4 w-4 fill-current' viewBox='0 0 20 20'>
-              <path d='M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z' />
-            </svg>
-          </div>
-        </div>
+          ))}
+        </Button>
       )}
     </div>
   );

--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -217,7 +217,13 @@ export default function ToolingPage({
 
           <div className='flex flex-wrap items-center justify-between gap-4 mb-6'>
             <div className='flex items-center gap-4'>
-              <GroupByMenu transform={transform} setTransform={setTransform} />
+              <GroupByMenu
+                transform={transform}
+                setTransform={setTransform}
+                activeSections={Object.keys(toolsByGroup).filter(
+                  (g) => g !== 'none' && toolsByGroup[g].length > 0,
+                )}
+              />
             </div>
             <div className='flex items-center gap-4'>
               <div className='text-sm text-gray-500 hidden sm:block'>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature (UX Improvement)

**Issue Number:**
- Closes #2104

**Screenshots/videos:**
<img width="358" height="772" alt="image" src="https://github.com/user-attachments/assets/37e30192-8614-4d94-8826-2e209af3f6d1" />
<img width="1512" height="911" alt="image" src="https://github.com/user-attachments/assets/06b726f1-a69e-418c-a7a0-bd118b4ca571" />

**If relevant, did you update the documentation?**

N/A (UI enhancement)

### Technical Changes

* **Implemented Native Jump Menu**: Added a native HTML `<select>` element in `GroupByMenu.tsx`.
* **Added `scrollToSection` Logic**:
    * Implemented smooth-scrolling with a `-100px` offset to prevent headers from being covered by the sticky navbar.
* **Responsive Layout Refactor**: 
    * Updated `GroupByMenu.tsx` to use `flex-col` and `gap-y-4` so the buttons and dropdown stack correctly on mobile.
* **Updated `index.page.tsx`**: Passed a filtered `activeSections` prop to ensure the jump menu only lists categories that currently contain tools.

**Summary**

This PR adds a **"Jump to Section"** navigation menu to the Tooling page to improve usability when the "Group By" feature is enabled. 

**Does this PR introduce a breaking change?**

No

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
- [x] Verified that the implementation works correctly on both desktop and mobile views.
- [x] Confirmed that the "Jump to Section" IDs match the section headers in the Tooling Table.