### PR TITLE
fix: resolve internal markdown link routing (#2267)

### DIFF
--- a/components/StyledMarkdownBlock.tsx
+++ b/components/StyledMarkdownBlock.tsx
@@ -80,29 +80,26 @@ export const StyledMarkdownBlock = ({ markdown }: StyledMarkdownBlockProps) => {
                 const combinedClassName =
                   `${baseClassName} ${additionalClass}`.trim();
 
-                const link =
-                  href.charAt(0) === '/' ? (
-                    <Link
-                      as={href}
-                      href='/'
-                      title={title}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      className={combinedClassName} // Use the combined className
-                    >
-                      {children}
-                    </Link>
-                  ) : (
-                    <a
-                      href={href}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      title={title}
-                      className={combinedClassName} // Use the combined className
-                    >
-                      {children}
-                    </a>
-                  );
+                const isInternal = href.startsWith('/') || href.startsWith('#');
+                const link = isInternal ? (
+                  <Link
+                    href={href}
+                    title={title}
+                    className={combinedClassName} // Use the combined className
+                  >
+                    {children}
+                  </Link>
+                ) : (
+                  <a
+                    href={href}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    title={title}
+                    className={combinedClassName} // Use the combined className
+                  >
+                    {children}
+                  </a>
+                );
 
                 return <>{link}</>;
               },


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**
-  Closes #2267

**Screenshots/videos:**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
Internal Markdown links in `StyledMarkdownBlock` were incorrectly forced to open in new tabs (`target="_blank"`) and routed to the homepage (`/`), which broke SPA transitions and Next.js prefetching. 

This PR updates the routing logic to properly recognize internal paths (starting with `/` or `#`) and uses the Next.js `<Link>` component correctly without `target="_blank"`, restoring standard client-side navigation.

**Does this PR introduce a breaking change?**
No.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).