### PR TITLE
Added SJF4J to JSON Schema Ecosystem (#2158)

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3523,5 +3523,5 @@
   source: 'https://github.com/sjf4j-projects/sjf4j'
   homepage: 'https://sjf4j.org'
   supportedDialects:
-    draft: ['1', '2', '3', '4', '6', '7', '2019-09', '2020-12']
+    draft: ['2020-12']
   toolingListingNotes: 'SJF4J has passed Bowtie evaluation and provides full Draft 2020-12 support. Validates native Java objects directly without JSON serialization.'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Feature addition — adds the SJF4J tool to the JSON Schema Ecosystem tooling list.

**Issue Number:**

- Closes #2158

**Screenshots/videos:**

<img width="1920" height="933" alt="Screenshot from 2026-02-25 13-56-48" src="https://github.com/user-attachments/assets/b5a9188b-5938-438a-ab24-67ff69a41e10" />


**If relevant, did you update the documentation?**

No separate documentation was updated. The tooling entry has been added to the ecosystem data file with all relevant metadata, including repository and homepage links.

**Summary**

This PR adds **SJF4J (Simple JSON Facade for Java)** to the JSON Schema Ecosystem.

SJF4J is a Java library that provides full support for JSON Schema Draft 2020-12 and allows validation of native Java object models such as POJOs, Maps, and Lists without requiring serialization to JSON.

The tool has passed Bowtie compliance evaluation and supports multiple JSON Schema drafts. This change updates the `tooling-data.yaml` file to include SJF4J with its metadata such as tooling type (validator), supported dialects, license (MIT), and source repository.

This resolves issue #2158.

**Does this PR introduce a breaking change?**

No. This PR only adds a new tooling entry and does not modify existing functionality.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).