### PR TITLE
feat: add google/jsonschema-go as Go validator

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1643,6 +1643,14 @@
   supportedDialects:
     draft: ['2020-12']
 
+- name: jsonschema-go
+  description: 'A Go implementation of JSON Schema by Google.'
+  toolingTypes: ['validator']
+  languages: ['Go']
+  license: 'MIT'
+  source: 'https://github.com/google/jsonschema-go'
+  lastUpdated: '2025-12-19'
+
 - name: protoc-gen-jsonschema
   description: 'Generates JSON schemas from protobuf proto v2 and v3 files.'
   toolingTypes: ['schema-to-code']


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature (adds a new tooling entry to the ecosystem listing)

**Issue Number:**

- Closes #2224

**Screenshots/videos:**

N/A (data update only)

**If relevant, did you update the documentation?**

No documentation changes required.

**Summary**

This PR adds `google/jsonschema-go` to the JSON Schema Ecosystem as a Go-based validator.

The entry includes:
- `toolingTypes: ['validator']`
- `languages: ['Go']`
- `license: MIT`
- `source: https://github.com/google/jsonschema-go`
- `lastUpdated: 2025-12-19` (based on latest release v0.4.2)

`supportedDialects` is intentionally omitted since the repository does not explicitly document supported draft versions.

The entry follows the existing formatting and conventions in `data/tooling-data.yaml`.

**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the contributing guidelines.