### PR TITLE
feat: display community event times in user local timezone (#2283)

### DIFF
--- a/components/LocalizedTime.tsx
+++ b/components/LocalizedTime.tsx
@@ -10,23 +10,28 @@ const LocalizedTime: React.FC<LocalizedTimeProps> = ({ utcTime, utcDate }) => {
 
   useEffect(() => {
     try {
-      // Convert "YYYY-MM-DD HH:mm:ss" to ISO "YYYY-MM-DDTHH:mm:ssZ"
       const dateStr = utcDate.replace(' ', 'T') + 'Z';
       const date = new Date(dateStr);
-
       if (isNaN(date.getTime())) return;
 
       const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-      // Don't show if user is already in UTC to avoid redundancy
       if (userTimeZone === 'UTC' || userTimeZone === 'Etc/UTC') return;
 
-      const formatted = new Intl.DateTimeFormat(undefined, {
+      const options: Intl.DateTimeFormatOptions = {
         hour: '2-digit',
         minute: '2-digit',
         timeZoneName: 'short',
-      }).format(date);
+      };
 
+      // Check if the date changed locally (e.g., event is 11 PM UTC, but 4 AM next day local)
+      if (new Date(dateStr).getUTCDate() !== date.getDate()) {
+        options.month = 'short';
+        options.day = 'numeric';
+      }
+
+      const formatted = new Intl.DateTimeFormat(undefined, options).format(
+        date,
+      );
       setLocalized(formatted);
     } catch (err) {
       console.error('Error localizing time:', err);
@@ -36,7 +41,11 @@ const LocalizedTime: React.FC<LocalizedTimeProps> = ({ utcTime, utcDate }) => {
   return (
     <>
       {utcTime} UTC
-      {localized && <span> ({localized})</span>}
+      {localized && (
+        <span className='text-blue-600 dark:text-blue-400 font-semibold ml-1'>
+          ({localized})
+        </span>
+      )}
     </>
   );
 };

--- a/components/LocalizedTime.tsx
+++ b/components/LocalizedTime.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+
+interface LocalizedTimeProps {
+  utcTime: string;
+  utcDate: string;
+}
+
+const LocalizedTime: React.FC<LocalizedTimeProps> = ({ utcTime, utcDate }) => {
+  const [localized, setLocalized] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      // Convert "YYYY-MM-DD HH:mm:ss" to ISO "YYYY-MM-DDTHH:mm:ssZ"
+      const dateStr = utcDate.replace(' ', 'T') + 'Z';
+      const date = new Date(dateStr);
+
+      if (isNaN(date.getTime())) return;
+
+      const userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+      // Don't show if user is already in UTC to avoid redundancy
+      if (userTimeZone === 'UTC' || userTimeZone === 'Etc/UTC') return;
+
+      const formatted = new Intl.DateTimeFormat(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZoneName: 'short',
+      }).format(date);
+
+      setLocalized(formatted);
+    } catch (err) {
+      console.error('Error localizing time:', err);
+    }
+  }, [utcDate]);
+
+  return (
+    <>
+      {utcTime} UTC
+      {localized && <span> ({localized})</span>}
+    </>
+  );
+};
+
+export default LocalizedTime;

--- a/lib/calendarUtils.ts
+++ b/lib/calendarUtils.ts
@@ -17,7 +17,7 @@ export function printEventsForNextWeeks(icalData: { [x: string]: any }) {
   const arrayDates = [];
   if (!icalData) {
     console.error('iCal data is empty or invalid.');
-    return;
+    return [];
   }
 
   // Calculate the range of dates for the next 12 weeks from today

--- a/pages/community/index.page.tsx
+++ b/pages/community/index.page.tsx
@@ -15,6 +15,7 @@ import {
   fetchRemoteICalFile,
   printEventsForNextWeeks,
 } from '../../lib/calendarUtils';
+import LocalizedTime from '~/components/LocalizedTime';
 
 export const getStaticProps: GetStaticProps = async () => {
   const PATH = 'pages/blog/posts';
@@ -286,7 +287,10 @@ export default function CommunityPages(props: any) {
                         <b className='text-blue-700'>{event.title}</b>
                         <br />
                         <span>
-                          {event.time}({event.timezone})
+                          <LocalizedTime
+                            utcTime={event.time}
+                            utcDate={event.parsedStartDate}
+                          />
                         </span>
                       </p>
                     </div>

--- a/pages/community/index.page.tsx
+++ b/pages/community/index.page.tsx
@@ -47,7 +47,7 @@ export const getStaticProps: GetStaticProps = async () => {
   return {
     props: {
       blogPosts,
-      datesInfo,
+      datesInfo: datesInfo ?? [],
       fallback: false,
     },
   };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature: Display Community Event Times in User's Local Timezone.

**Issue Number:**
- Closes #2283

**Screenshots/videos:**
### Before
![before](https://github.com/user-attachments/assets/3232e480-51ba-423b-800d-57bad5c2d8b1)

### After
![After](https://github.com/user-attachments/assets/b21e36a8-03c2-42af-be18-5bc364a7652b)

**If relevant, did you update the documentation?**
N/A

### Summary
The "Upcoming events" section on the community page previously displayed times only in UTC. This PR introduces a new [LocalizedTime](cci:1://file:///d:/GSoC%202026/website/components/LocalizedTime.tsx:7:0-41:2) component that detects the user's browser timezone and displays the local time alongside the UTC time. This reduces friction for community members in different regions (APAC, EMEA, Americas, etc.) by eliminating the need for manual timezone conversion.

The implementation uses the native `Intl.DateTimeFormat` API for a lightweight footprint and handles hydration correctly by waiting for the client-side mount before displaying the localized time.

**Changes made:**

**New Component:** Created `components/LocalizedTime.tsx` which utilizes the native Intl.DateTimeFormat API for lightweight time conversion.

**Hydration Fix:** Implemented a `useEffect` hook to ensure time conversion only occurs after the client-side mount, preventing Next.js hydration mismatches between the server (UTC) and the user's browser.

**UI Update:** Modified `pages/community/index.page.tsx` to replace static UTC displays with the dynamic LocalizedTime component.

**Does this PR introduce a breaking change?**
No.

# Checklist
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
