### PR TITLE
fix: blog pagination reset - implement URL parameter persistence

### DIFF
--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -35,7 +35,7 @@ const getCategories = (frontmatter: any): blogCategories[] => {
   return Array.isArray(cat) ? cat : [cat];
 };
 
-export async function getStaticProps({ query }: { query: any }) {
+export async function getStaticProps() {
   const files = fs.readdirSync(PATH);
   const blogPosts = files
     .filter((file) => file.substr(-3) === '.md')
@@ -55,12 +55,9 @@ export async function getStaticProps({ query }: { query: any }) {
 
   await generateRssFeed(blogPosts);
 
-  const filterTag: string = query?.type || 'All';
-
   return {
     props: {
       blogPosts,
-      filterTag,
     },
   };
 }
@@ -79,20 +76,32 @@ function isValidCategory(category: any): category is blogCategories {
 
 export default function StaticMarkdownPage({
   blogPosts,
-  filterTag,
 }: {
   blogPosts: any[];
-  filterTag: any;
 }) {
   const router = useRouter();
+
   // Initialize the filter as an array. If "All" or not specified, we show all posts.
   const initialFilters =
-    filterTag && filterTag !== 'All'
-      ? filterTag.split(',').filter(isValidCategory)
+    router.query.type && router.query.type !== 'All'
+      ? (typeof router.query.type === 'string' ? router.query.type : '')
+          .split(',')
+          .filter(isValidCategory)
       : ['All'];
 
-  const [currentFilterTags, setCurrentFilterTags] =
-    useState<blogCategories[]>(initialFilters);
+  const [currentFilterTags, setCurrentFilterTags] = useState<blogCategories[]>(
+    initialFilters as blogCategories[],
+  );
+
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Set client-side flag and initialize from URL
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const pageParam = urlParams.get('page');
+    const initialPage = pageParam ? Math.max(1, parseInt(pageParam, 10)) : 1;
+    setCurrentPage(initialPage);
+  }, []);
 
   // When the router query changes, update the filters.
   useEffect(() => {
@@ -101,18 +110,28 @@ export default function StaticMarkdownPage({
       const tags = (typeof query.type === 'string' ? query.type : '')
         .split(',')
         .filter(isValidCategory);
-      setCurrentFilterTags(tags.length ? tags : ['All']);
+      setCurrentFilterTags(tags.length ? (tags as blogCategories[]) : ['All']);
       setCurrentPage(1);
+    }
+    // Update page from URL query parameter
+    if (query.page) {
+      const page = Math.max(
+        1,
+        parseInt(Array.isArray(query.page) ? query.page[0] : query.page, 10),
+      );
+      setCurrentPage(page);
     }
   }, [router.query]);
 
   useEffect(() => {
     const tags =
-      filterTag && filterTag !== 'All'
-        ? filterTag.split(',').filter(isValidCategory)
+      router.query.type && router.query.type !== 'All'
+        ? (typeof router.query.type === 'string' ? router.query.type : '')
+            .split(',')
+            .filter(isValidCategory)
         : ['All'];
-    setCurrentFilterTags(tags);
-  }, [filterTag]);
+    setCurrentFilterTags(tags as blogCategories[]);
+  }, [router.query.type]);
 
   const toggleCategory = (tag: blogCategories) => {
     let newTags: blogCategories[] = [];
@@ -132,7 +151,8 @@ export default function StaticMarkdownPage({
         newTags = ['All'];
       }
     }
-    setCurrentFilterTags(newTags);
+    setCurrentFilterTags(newTags as blogCategories[]);
+    setCurrentPage(1); // Reset to page 1 when filter changes
     if (newTags.includes('All')) {
       history.replaceState(null, '', '/blog');
     } else {
@@ -193,7 +213,6 @@ export default function StaticMarkdownPage({
 
   // pagination implement
   const POSTS_PER_PAGE = 10;
-  const [currentPage, setCurrentPage] = useState(1);
 
   const totalPages = Math.ceil(sortedFilteredPosts.length / POSTS_PER_PAGE);
 
@@ -210,6 +229,29 @@ export default function StaticMarkdownPage({
       blogPostsContainerRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [currentPage]);
+
+  // Function to update URL with current page and filters
+  const updateUrl = (page: number, tags: blogCategories[]) => {
+    const params = new URLSearchParams();
+    if (page > 1) params.set('page', page.toString());
+    if (tags.length > 0 && !tags.includes('All')) {
+      params.set('type', tags.join(','));
+    }
+    const queryString = params.toString();
+    const newUrl = queryString ? `/blog?${queryString}` : '/blog';
+    history.replaceState(null, '', newUrl);
+  };
+
+  // Update URL when page or filters change
+  useEffect(() => {
+    updateUrl(currentPage, currentFilterTags);
+  }, [currentPage, currentFilterTags]);
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 1 && newPage <= totalPages) {
+      setCurrentPage(newPage);
+    }
+  };
 
   const currentPagePosts = sortedFilteredPosts.slice(
     (currentPage - 1) * POSTS_PER_PAGE,
@@ -465,7 +507,7 @@ export default function StaticMarkdownPage({
                 : 'bg-blue-600 text-white hover:bg-blue-700'
             }`}
             disabled={currentPage === 1}
-            onClick={() => setCurrentPage((p) => p - 1)}
+            onClick={() => handlePageChange(currentPage - 1)}
           >
             Previous
           </button>
@@ -479,7 +521,7 @@ export default function StaticMarkdownPage({
                 : 'bg-blue-600 text-white hover:bg-blue-700'
             }`}
             disabled={currentPage === totalPages}
-            onClick={() => setCurrentPage((p) => p + 1)}
+            onClick={() => handlePageChange(currentPage + 1)}
           >
             Next
           </button>

--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -84,9 +84,7 @@ export default function StaticMarkdownPage({
   // Initialize the filter as an array. If "All" or not specified, we show all posts.
   const initialFilters =
     router.query.type && router.query.type !== 'All'
-      ? (typeof router.query.type === 'string' ? router.query.type : '')
-        .split(',')
-        .filter(isValidCategory)
+      ? (router.query.type as string).split(',').filter(isValidCategory)
       : ['All'];
 
   const [currentFilterTags, setCurrentFilterTags] = useState<blogCategories[]>(
@@ -126,9 +124,7 @@ export default function StaticMarkdownPage({
   useEffect(() => {
     const tags =
       router.query.type && router.query.type !== 'All'
-        ? (typeof router.query.type === 'string' ? router.query.type : '')
-          .split(',')
-          .filter(isValidCategory)
+        ? (router.query.type as string).split(',').filter(isValidCategory)
         : ['All'];
     setCurrentFilterTags(tags as blogCategories[]);
   }, [router.query.type]);

--- a/pages/blog/index.page.tsx
+++ b/pages/blog/index.page.tsx
@@ -85,8 +85,8 @@ export default function StaticMarkdownPage({
   const initialFilters =
     router.query.type && router.query.type !== 'All'
       ? (typeof router.query.type === 'string' ? router.query.type : '')
-          .split(',')
-          .filter(isValidCategory)
+        .split(',')
+        .filter(isValidCategory)
       : ['All'];
 
   const [currentFilterTags, setCurrentFilterTags] = useState<blogCategories[]>(
@@ -127,8 +127,8 @@ export default function StaticMarkdownPage({
     const tags =
       router.query.type && router.query.type !== 'All'
         ? (typeof router.query.type === 'string' ? router.query.type : '')
-            .split(',')
-            .filter(isValidCategory)
+          .split(',')
+          .filter(isValidCategory)
         : ['All'];
     setCurrentFilterTags(tags as blogCategories[]);
   }, [router.query.type]);


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix (pagination state persistence) with minor refactoring.

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2213

**Screenshots/videos:**

Before:
- Navigating to page N (e.g., page 3) and refreshing caused the blog to reset to page 1.
- Pagination state was not reflected in the URL.
- Hydration mismatch warnings appeared in the console.

After:
- Pagination state persists via `?page=N`.
- Category filter persists via `?type=Category`.
- No hydration errors.
- TypeScript compilation passes successfully.

[Screencast from 2026-02-25 16-50-33.webm](https://github.com/user-attachments/assets/e22500bb-e5dd-46f7-bb42-d0176993275e)


**If relevant, did you update the documentation?**

Not required. This change affects internal state handling and does not modify public documentation or APIs.

**Summary**

This PR fixes the bug where the blog pagination resets to page 1 after a browser reload.

Previously, pagination state was stored only in component state and was not synchronized with the URL. As a result, refreshing the browser caused the blog to reload on page 1, losing the current pagination context.

Changes made:
- Initialized `currentPage` from URL query parameters in `pages/blog/index.page.tsx`.
- Added an `updateUrl` helper function to synchronize pagination and filter state with the browser URL.
- Updated `toggleCategory` to reset pagination to page 1 when filters change.
- Removed server-side URL parameter access to prevent hydration mismatches.
- Resolved TypeScript errors.
- Applied Prettier formatting.

This ensures pagination and filter state persist across reloads and eliminates hydration warnings.

**Does this PR introduce a breaking change?**

No. This change is backward compatible and does not affect any public APIs or external behavior.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).