### PR TITLE
fix: correct JSON string boundary detection for escaped backslashes

### DIFF
--- a/lib/getPartsOfJson.ts
+++ b/lib/getPartsOfJson.ts
@@ -9,7 +9,7 @@ const regexNumber = /^\s*(?<number>-?\d+(\.\d+)?([Ee][+-]?\d+)?)\s*$/g;
 const regexString = /^\s*(?<string>"(\\"|[^"])*")\s*$/g;
 const regexBoolean = /^\s*(?<boolean>true|false)\s*$/g;
 const regexNull = /^\s*(?<null>null)\s*$/g;
-const regexDoubleQuote = /(?<!\\)"/g;
+const regexDoubleQuote = /(?<!(?<!\\)(\\\\)*\\)"/g;
 const regexCommaOrEndOfLine = /,/g;
 
 export type SyntaxPart = {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**
Fixes #2237

**Screenshots/videos:**
Before the fix:
<img width="1024" height="236" alt="image" src="https://github.com/user-attachments/assets/ff46e9fc-684a-4723-b307-1adc6f0aed7a" />
After the fix:
<img width="1047" height="199" alt="image" src="https://github.com/user-attachments/assets/a9a22ab6-6d82-44c4-baa7-fa6dc39f2b94" />

**How should this be tested?**
Open any markdown file in the project (eg: pages/understanding-json-schema/basics.md).
Try adding even number of trailing backslashes in any json code block.

**Does this PR introduce a breaking change?**
No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).