### PR TITLE
Added Jedison to tooling data

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1974,6 +1974,21 @@
   homepage: 'https://react-jsonschema-form-material-ui.github56.now.sh/'
   lastUpdated: '2023-08-17'
 
+- name: Jedison
+  description: 'A JavaScript library that generates forms from JSON Schemas for editing and validating JSON.'
+  toolingTypes: ['validator', 'schema-to-web-UI']
+  languages: ['JavaScript']
+  maintainers:
+    - name: 'German Bisurgi'
+      username: 'germanbisurgi'
+      platform: 'github'
+  license: 'MIT'
+  source: 'https://github.com/germanbisurgi/jedison'
+  homepage: 'https://germanbisurgi.github.io/jedison-docs/'
+  supportedDialects:
+    draft: ['2020-12']
+  lastUpdated: '2026-03-02'
+
 - name: React Schema Form (networknt)
   description: 'React form based on json schema for form generation and validation'
   toolingTypes: ['schema-to-web-UI']


### PR DESCRIPTION
**What kind of change does this PR introduce?**

 Feature — adds a new JavaScript library (Jedison) to the tooling directory.

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2306

**Screenshots/videos:**

https://github.com/user-attachments/assets/fe72b7de-a394-4c87-903d-9952ff6321b6

**If relevant, did you update the documentation?**

 Not applicable.

**Summary**

Adds https://github.com/germanbisurgi/jedison to the tooling directory. Jedison is a JavaScript library that generates forms from JSON Schemas for editing and validating JSON data. It supports JSON
Schema draft 2020-12, is MIT-licensed, and is maintained by German Bisurgi (https://github.com/germanbisurgi on GitHub).


**Does this PR introduce a breaking change?**

 No.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).