### PR TITLE
Bugfix and refactoring of the JSON Schema scope detection logic in th…

### DIFF
--- a/lib/getScopesOfParsedJsonSchema.ts
+++ b/lib/getScopesOfParsedJsonSchema.ts
@@ -13,47 +13,95 @@ export default function getScopesOfParsedJsonSchema(
 ): JsonSchemaPathWithScope[] {
   if (typeof parsedJsonSchema !== 'object' || parsedJsonSchema === null)
     return [];
-  const typeDefinitionScope = {
-    jsonPath,
-    scope: JsonSchemaScope.TypeDefinition,
-  };
-  if (parsedJsonSchema.type === 'object') {
-    const scopesOfProperties = Object.keys(
-      parsedJsonSchema?.properties || {},
-    ).reduce<JsonSchemaPathWithScope[]>((acc, property) => {
-      return [
-        ...acc,
+
+  let scopes: JsonSchemaPathWithScope[] = [
+    {
+      jsonPath,
+      scope: JsonSchemaScope.TypeDefinition,
+    },
+  ];
+
+  // 1. Objects where each value is a subschema
+  const mapKeywords = [
+    'properties',
+    'patternProperties',
+    'definitions',
+    '$defs',
+    'dependentSchemas',
+  ];
+  mapKeywords.forEach((keyword) => {
+    const map = parsedJsonSchema[keyword];
+    if (map && typeof map === 'object' && !Array.isArray(map)) {
+      Object.keys(map).forEach((key) => {
+        scopes = [
+          ...scopes,
+          ...getScopesOfParsedJsonSchema(
+            map[key],
+            `${jsonPath}['${keyword}']['${key}']`,
+          ),
+        ];
+      });
+    }
+  });
+
+  // 2. Arrays where each item is a subschema
+  const arrayKeywords = ['allOf', 'anyOf', 'oneOf', 'prefixItems'];
+  arrayKeywords.forEach((keyword) => {
+    const list = parsedJsonSchema[keyword];
+    if (Array.isArray(list)) {
+      list.forEach((subschema: any, index: number) => {
+        scopes = [
+          ...scopes,
+          ...getScopesOfParsedJsonSchema(
+            subschema,
+            `${jsonPath}['${keyword}'][${index}]`,
+          ),
+        ];
+      });
+    }
+  });
+
+  // 3. Single subschemas
+  const singleKeywords = [
+    'items',
+    'not',
+    'if',
+    'then',
+    'else',
+    'additionalProperties',
+    'propertyNames',
+    'unevaluatedProperties',
+    'additionalItems',
+    'unevaluatedItems',
+  ];
+  singleKeywords.forEach((keyword) => {
+    const subschema = parsedJsonSchema[keyword];
+    // In JSON Schema, a subschema can be an object or a boolean (true/false)
+    if (typeof subschema === 'object' && subschema !== null) {
+      scopes = [
+        ...scopes,
+        ...getScopesOfParsedJsonSchema(subschema, `${jsonPath}['${keyword}']`),
+      ];
+    } else if (typeof subschema === 'boolean') {
+      scopes.push({
+        jsonPath: `${jsonPath}['${keyword}']`,
+        scope: JsonSchemaScope.TypeDefinition,
+      });
+    }
+  });
+
+  // Special case: "items" as an array (pre-Draft 2020-12 style)
+  if (Array.isArray(parsedJsonSchema.items)) {
+    parsedJsonSchema.items.forEach((subschema: any, index: number) => {
+      scopes = [
+        ...scopes,
         ...getScopesOfParsedJsonSchema(
-          parsedJsonSchema.properties?.[property],
-          `${jsonPath}['properties']['${property}']`,
+          subschema,
+          `${jsonPath}['items'][${index}]`,
         ),
       ];
-    }, []);
-    const scopesOfPatternProperties = Object.keys(
-      parsedJsonSchema?.patternProperties || {},
-    ).reduce<JsonSchemaPathWithScope[]>((acc, property) => {
-      return [
-        ...acc,
-        ...getScopesOfParsedJsonSchema(
-          parsedJsonSchema.patternProperties?.[property],
-          `${jsonPath}['patternProperties']['${property}']`,
-        ),
-      ];
-    }, []);
-    return [
-      typeDefinitionScope,
-      ...scopesOfProperties,
-      ...scopesOfPatternProperties,
-    ];
+    });
   }
-  if (parsedJsonSchema.type === 'array') {
-    return [
-      typeDefinitionScope,
-      ...getScopesOfParsedJsonSchema(
-        parsedJsonSchema.items,
-        `${jsonPath}['items']`,
-      ),
-    ];
-  }
-  return [typeDefinitionScope];
+
+  return scopes;
 }


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix and refactoring of the schema scope detection logic in the [JsonEditor](cci:1://file:///d:/websitejson/components/JsonEditor.tsx:288:0-788:1) component.

**Issue Number:**
- Closes #2259

**Screenshots/videos:**

_Before:_ Keywords like `type`, `items` inside `$defs` blocks render in cyan (plain data) and are not clickable.

_After:_ The same keywords render in interactive blue and link to reference docs, matching the behaviour inside `properties` blocks.

**If relevant, did you update the documentation?**

N/A — this change improves the interactive behaviour of the documentation's built-in JSON editor. No content docs needed updating.

**Summary**

[getScopesOfParsedJsonSchema.ts](cci:7://file:///d:/websitejson/lib/getScopesOfParsedJsonSchema.ts:0:0-0:0) previously gated subschema recursion on `parsedJsonSchema.type === 'object'` or `=== 'array'`, only traversing `properties`, `patternProperties`, and single-form `items`. JSON Schema doesn't require a `type` field, so any schema without it (e.g. `{ "$defs": { ... } }`) caused the function to return early — leaving all nested keywords non-interactive.

This PR replaces the type-gated logic with a keyword-driven traversal across all three subschema-bearing keyword categories from the spec:

1. **Map keywords** (`$defs`, `definitions`, `properties`, `patternProperties`, `dependentSchemas`)
2. **Array keywords** (`allOf`, `anyOf`, `oneOf`, `prefixItems`)
3. **Single-subschema keywords** (`not`, `if`, `then`, `else`, `additionalProperties`, `propertyNames`, `unevaluatedProperties`, `additionalItems`, `unevaluatedItems`, `items`)

Boolean subschemas (e.g. `additionalProperties: false`) are also now handled correctly.

Closes #2259

**Does this PR introduce a breaking change?**

No. This is purely additive — all previously recognised scope paths continue to be emitted as before. The fix only adds scope paths for keywords that were previously missed.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
