### PR TITLE
Solved #2305 External X (Twitter) Profile Link Opens in Same Tab Instead of New Tab 

### DIFF
--- a/pages/blog/posts/[slug].page.tsx
+++ b/pages/blog/posts/[slug].page.tsx
@@ -89,6 +89,8 @@ export default function StaticMarkdownPage({
                             {author.twitter && (
                               <a
                                 className='block text-sm text-blue-500 font-medium'
+                                target='_blank'
+                                rel='noopener noreferrer'
                                 href={`https://x.com/${author.twitter}`}
                               >
                                 @{author.twitter}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

Closes #2305

**Screenshots/videos:**

https://github.com/user-attachments/assets/ad0db041-2808-4f94-86b9-a50754765306

**Summary**

This PR fixes an issue where clicking on a sponsor's X (Twitter) handle opened the external link in the same browser tab.

The fix adds `target="_blank"` and `rel="noopener noreferrer"` to ensure external links open in a new tab while following security best practices.

This improves user experience by allowing users to remain on the JSON Schema website while viewing external profiles.

**Does this PR introduce a breaking change?**

No