### PR TITLE
fix(tools): eliminate groupBy flicker on page reload

### DIFF
--- a/pages/tools/hooks/useToolsTransform.tsx
+++ b/pages/tools/hooks/useToolsTransform.tsx
@@ -46,24 +46,9 @@ const buildQueryString = (transform: Transform) => {
 export default function useToolsTransform(tools: JSONSchemaTool[]) {
   const router = useRouter();
   const { query } = router;
+  const [isReady, setIsReady] = useState(false);
 
-  const [transform, setTransform] = useState<Transform>({
-    query: '',
-    sortBy: 'name',
-    sortOrder: 'ascending',
-    groupBy: 'toolingTypes',
-    languages: [],
-    licenses: [],
-    drafts: [],
-    toolingTypes: [],
-    environments: [],
-    showObsolete: 'false',
-    supportsBowtie: 'false',
-  });
-
-  useEffect(() => {
-    if (!router.isReady) return;
-
+  const getInitialTransform = (): Transform => {
     const parseArrayParam = (
       param: string | string[] | undefined,
     ): string[] => {
@@ -76,7 +61,24 @@ export default function useToolsTransform(tools: JSONSchemaTool[]) {
       return [];
     };
 
-    const updatedTransform = {
+    // If router is not ready, return empty transform (will be updated)
+    if (!router.isReady) {
+      return {
+        query: '',
+        sortBy: 'name',
+        sortOrder: 'ascending',
+        groupBy: 'none',
+        languages: [],
+        licenses: [],
+        drafts: [],
+        toolingTypes: [],
+        environments: [],
+        showObsolete: 'false',
+        supportsBowtie: 'false',
+      };
+    }
+
+    return {
       query: (query.query as Transform['query']) || '',
       sortBy: (query.sortBy as Transform['sortBy']) || 'name',
       sortOrder: (query.sortOrder as Transform['sortOrder']) || 'ascending',
@@ -92,7 +94,15 @@ export default function useToolsTransform(tools: JSONSchemaTool[]) {
       ) as Transform['environments'],
       showObsolete: query.showObsolete === 'true' ? 'true' : 'false',
       supportsBowtie: query.supportsBowtie === 'true' ? 'true' : 'false',
-    } satisfies Transform;
+    };
+  };
+
+  const [transform, setTransform] = useState<Transform>(getInitialTransform);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    const updatedTransform = getInitialTransform();
 
     const queryString = buildQueryString(updatedTransform);
     const hash = window.location.hash;
@@ -102,7 +112,8 @@ export default function useToolsTransform(tools: JSONSchemaTool[]) {
     });
 
     setTransform(updatedTransform);
-  }, [router.isReady]);
+    setIsReady(true);
+  }, [router.isReady, query]);
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -187,6 +198,7 @@ export default function useToolsTransform(tools: JSONSchemaTool[]) {
     transform,
     setTransform: updateTransform,
     resetTransform,
+    isReady,
   };
 }
 

--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -112,7 +112,22 @@ export default function ToolingPage({
     transform,
     setTransform,
     resetTransform,
+    isReady,
   } = useToolsTransform(toolingData);
+
+  // Don't render until router is ready to prevent flicker
+  if (!isReady) {
+    return (
+      <SectionContext.Provider value={'tools'}>
+        <Head>
+          <title>JSON Schema - Tools</title>
+        </Head>
+        <div className='mx-auto w-full max-w-[1400px] min-h-screen flex items-center justify-center'>
+          <div className='text-slate-600 dark:text-slate-300'>Loading...</div>
+        </div>
+      </SectionContext.Provider>
+    );
+  }
 
   return (
     <SectionContext.Provider value={'tools'}>


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix (UI state initialization & flicker fix)

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2140



**Screenshots/videos:**


https://github.com/user-attachments/assets/7dc11df9-8158-4719-bc89-f065aaa24ff2


**If relevant, did you update the documentation?**

N/A

**Summary**

This PR fixes a UI flicker issue on the Tooling page where the default grouping (`toolingTypes`) briefly rendered before applying the selected value from URL query parameters.

### Root Cause
The `useToolsTransform` hook:
- Initialized state with hardcoded defaults
- Then updated state inside `useEffect` after parsing router query
- Since `router.isReady` is initially `false`, the default state rendered first, causing visible flicker

### Solution
- Introduced a `getInitialTransform()` helper to centralize query parsing logic
- Initialized state directly from URL parameters
- Added an `isReady` loading guard to prevent rendering until router is ready
- Removed duplicated parsing logic inside `useEffect`
- Updated dependency array to correctly respond to query changes

### Result
- Eliminates flicker completely
- Ensures consistent behavior on page refresh and direct URL access
- Improves code maintainability by removing duplicate logic
- Maintains full backward compatibility
**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).