### PR TITLE
  Fix sponsor tier anchor navigation to correctly link Gold, Silver, and Bronze sections

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -622,7 +622,10 @@ const Home = (props: any) => {
             </p>
           </div>
           <div className=' text-center mb-12 '>
-            <h3 className='p-4 text-h4mobile md:text-h4 font-semibold my-4 dark:text-slate-200'   id="gold-sponsors" >
+            <h3
+              className='p-4 text-h4mobile md:text-h4 font-semibold my-4 dark:text-slate-200'
+              id='gold-sponsors'
+            >
               Gold Sponsors
             </h3>
             <Link
@@ -647,7 +650,10 @@ const Home = (props: any) => {
               </svg>
               <p className='block'>Your logo here</p>
             </Link>
-            <h3 className='p-4 text-h4mobile md:text-h4 font-semibold my-4 dark:text-slate-200'     id="silver-sponsors">
+            <h3
+              className='p-4 text-h4mobile md:text-h4 font-semibold my-4 dark:text-slate-200'
+              id='silver-sponsors'
+            >
               Silver Sponsors
             </h3>
             <Link
@@ -672,8 +678,10 @@ const Home = (props: any) => {
               </svg>
               <p>Your logo here</p>
             </Link>
-            <h3 className='p-4 text-h4mobile md:text-h4 font-semibold my-4 dark:text-slate-200'    id="bronze-sponsors"
->
+            <h3
+              className='p-4 text-h4mobile md:text-h4 font-semibold my-4 dark:text-slate-200'
+              id='bronze-sponsors'
+            >
               Bronze Sponsors
             </h3>
             <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-12 items-center mx-auto  md:mx-0 px-4 '>

--- a/pages/overview/sponsors/index.page.tsx
+++ b/pages/overview/sponsors/index.page.tsx
@@ -10,7 +10,10 @@ import { DocsHelp } from '~/components/DocsHelp';
 import NextPrevButton from '~/components/NavigationButtons';
 
 export async function getStaticProps() {
-  const block1 = fs.readFileSync('_includes/community/programs/sponsors/sponsors.md', 'utf-8');
+  const block1 = fs.readFileSync(
+    '_includes/community/programs/sponsors/sponsors.md',
+    'utf-8',
+  );
   const { content: block1Content } = matter(block1);
   return {
     props: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

Closes #2277

**Screenshots/videos:**

https://github.com/user-attachments/assets/ee09bc06-4e84-49cf-99ae-fa40df961215

**Summary**

This PR fixes the sponsor section anchor links so they correctly navigate to the respective sponsor tiers on the homepage.

Previously, the sponsor anchor links did not consistently navigate to the correct tier sections. This update ensures that the links correctly reference the anchors for all sponsor tiers:

* `#gold-sponsors`
* `#silver-sponsors`
* `#bronze-sponsors`

With this change, users can now navigate directly from the sponsor benefits section to the corresponding sponsor tier section on the homepage.

**Does this PR introduce a breaking change?**
No
