### PR TITLE
fix: resolve 404 error on homepage URL routing

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -2376,7 +2376,7 @@
       platform: 'github'
   license: 'Apache-2.0'
   source: 'https://github.com/schemastore/schemastore/'
-  homepage: 'https://schemastore.org/json/'
+  homepage: 'https://schemastore.org'
 
 - name: json-schema-linter
   description: 'Lint/validate/parse json-schema itself, and find typos, missing properties, missing required keys, etc.'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix (SchemaStore homepage URL)

**Issue Number:**

Closes  #2303

**Screenshots/videos:**

<img width="980" height="784" alt="image" src="https://github.com/user-attachments/assets/dd96c696-f205-4ba7-8e00-4d3abe269dfc" />

<img width="1459" height="910" alt="image" src="https://github.com/user-attachments/assets/988e6f70-7425-450c-8f23-dfea7c6aa563" />

https://www.schemastore.org

**If relevant, did you update the documentation?**

N/A

**Summary**

Closes #2303 

This PR updates the homepage URL to the correct path so that it properly redirects users to the intended website which is https://www.schemastore.org.

Previously the homepage link for the tool was pointing to an incorrect URL that is https://schemastore.org/json/ this /json is reason of the issue, which caused users to encounter a 404 "Page Not Found" error when attempting to access the tool's official homepage.

After this change, the homepage link works correctly and no longer returns a 404 error. Users can now navigate to the homepage URL successfully.

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).