### PR TITLE
feat(tools): add jsonschema-go to the jsonschema ecosystem

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1285,7 +1285,7 @@
   description: 'A Go implementation for JSON Schema by Google.'
   toolingTypes: ['validator']
   languages: ['Go']
-  licence: 'MIT'
+  license: 'MIT'
   source: 'https://github.com/google/jsonschema-go'
   supportedDialects:
     draft: ['7', '2020-12']

--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1281,6 +1281,16 @@
     draft: ['2020-12']
   lastUpdated: '2024-02-19'
 
+- name: jsonschema-go
+  description: 'A Go implementation for JSON Schema by Google.'
+  toolingTypes: ['validator']
+  languages: ['Go']
+  licence: 'MIT'
+  source: 'https://github.com/google/jsonschema-go'
+  supportedDialects:
+    draft: ['7', '2020-12']
+  lastUpdated: '2025-12-20'
+
 - name: Liform
   description: 'Liform generates schemas from Symfony forms.'
   toolingTypes: ['code-to-schema']


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature (add google/jsonschema-go library)

**Issue Number:**
Closes #2224 


**Screenshots/videos:**
Only data added

**If relevant, did you update the documentation?**
N/A

**Summary**
This PR adds google/jsonschema-go to the jsonschema ecosystem. Supports Draft 07 and Draft 2020-12 with no external dependencies.

**Does this PR introduce a breaking change?**
No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).