### PR TITLE
fix(a11y): update alt text for validation icons in GettingStarted

### DIFF
--- a/components/GettingStarted.tsx
+++ b/components/GettingStarted.tsx
@@ -272,7 +272,7 @@ const GettingStarted = () => {
             {details[1] ? (
               <Image
                 src='/icons/green-tick.svg'
-                alt='green tick'
+                alt='Validation passed'
                 width={24}
                 height={24}
                 className='dark:brightness-100 brightness-90'
@@ -280,7 +280,7 @@ const GettingStarted = () => {
             ) : (
               <Image
                 src='/icons/red-cross.svg'
-                alt='red cross'
+                alt='Validation failed'
                 width={24}
                 height={24}
                 className='dark:brightness-100 brightness-90'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Accessibility improvement (a11y)

**Issue Number:**
- Others? This addresses a general accessibility best-practice issue identified in the codebase without a prior tracked issue.

**Screenshots/videos:**

No visual changes. This is an accessibility (a11y) fix for screen readers.

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR resolves an accessibility issue inside [components/GettingStarted.tsx](cci:7://file:///c:/Users/Rithi/OneDrive/Desktop/json%20schema/website/components/GettingStarted.tsx:0:0-0:0) where the validation success/error state icons were using non-descriptive alt text (`"green tick"`, `"red cross"`). 

These have been replaced with context-aware screen reader descriptions (`"Validation passed"`, `"Validation failed"`) to improve the experience for visually impaired users.

**Does this PR introduce a breaking change?**

No.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes locally.
