### PR TITLE
Split JSON schema examples

### DIFF
--- a/pages/learn/json-schema-examples.md
+++ b/pages/learn/json-schema-examples.md
@@ -226,7 +226,9 @@ This schema represents electronic devices with a `deviceType` property that dete
     }
   ]
 }
+```
 
+```json
 {
   "$id": "https://example.com/smartphone.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -244,7 +246,9 @@ This schema represents electronic devices with a `deviceType` property that dete
   },
   "required": ["brand", "model", "screenSize"]
 }
+```
 
+```json
 {
   "$id": "https://example.com/laptop.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",


### PR DESCRIPTION
the device JSON schema example merge 3 JSON into a single codeblock which break the syntax coloration and the example display


<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

editorial fix on the example page

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->

Closes #2346 



I just finished Reading the example on the website


**Screenshots of the syntax issue:**

<img width="1079" height="1648" alt="Screenshot_20260310-090202" src="https://github.com/user-attachments/assets/8d1786b9-e0cb-4e75-89ca-e02525305c33" />

<!--Add screenshots or videos wherever possible.-->

<!--Add link to it-->

**Summary**

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The example page provide a "single merged" code block of 3 JSON when demonstrating the usage of $ref. this merged example is not a valid json. (at least not with the website syntax hilighting lib. This PR split the 3 files into 3 codeblocks

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).