### PR TITLE
fixes #2304 prevents tools from overlapping with botwie and the i icon

### DIFF
--- a/pages/tools/components/ToolingTable.tsx
+++ b/pages/tools/components/ToolingTable.tsx
@@ -373,7 +373,7 @@ const ToolingTable = ({
                               )}
                             </div>
                           )}
-                          <div className='flex justify-between items-center'>
+                          <div className='flex justify-between items-center pr-24'>
                             <div className='font-medium'>
                               {tool.name}
                               {tool.status === 'obsolete' && (


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
- Bugfix 
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2304 
-  Related to #2304 
-  Others? As per maintainer i removed all the botwie overlapping along with i overlapping in the small screen phones.


**Screenshots/videos:**
After the changes it is seen like this.
<img width="992" height="1058" alt="image" src="https://github.com/user-attachments/assets/467fe6cf-bc3d-494c-b85f-1414bba5343c" />
<img width="956" height="384" alt="image" src="https://github.com/user-attachments/assets/d7609d96-bc72-452c-a2ff-364ae597e501" />

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

N/A

**Summary**
- It removes the overlapping botwie along with the i icon that was happening in the smaller screens. Closes the Issue #2304.



**Does this PR introduce a breaking change?**
- No
# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [ x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).