### PR TITLE
feat: add LinkedIn link support for blog post authors

### DIFF
--- a/pages/blog/posts/[slug].page.tsx
+++ b/pages/blog/posts/[slug].page.tsx
@@ -96,15 +96,14 @@ export default function StaticMarkdownPage({
                             )}
                             {author.link && !author.twitter && (
                               <a
-                              className='block text-sm text-blue-500 font-medium pl-2'
-                              href={author.link}
-                              target='_blank'
-                              rel='noopener noreferrer'
+                                className='block text-sm text-blue-500 font-medium pl-2'
+                                href={author.link}
+                                target='_blank'
+                                rel='noopener noreferrer'
                               >
-                                 LinkedIn
+                                LinkedIn
                               </a>
                             )}
-                            
                           </div>
                         </div>
                       );

--- a/pages/blog/posts/[slug].page.tsx
+++ b/pages/blog/posts/[slug].page.tsx
@@ -94,6 +94,17 @@ export default function StaticMarkdownPage({
                                 @{author.twitter}
                               </a>
                             )}
+                            {author.link && !author.twitter && (
+                              <a
+                              className='block text-sm text-blue-500 font-medium pl-2'
+                              href={author.link}
+                              target='_blank'
+                              rel='noopener noreferrer'
+                              >
+                                 LinkedIn
+                              </a>
+                            )}
+                            
                           </div>
                         </div>
                       );


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
I added the link section in each blog post under the name of "Author". I saw that someone was trying and that PR failed  from more than 2 weeks so i made changes related to that. Added the linkedin links in the md successfully with just few changes in the [pages/blog/posts/[slug].page.tsx].

<!-- E.g. a bugfix, feature, refactoring, etc… -->
- It's a feature

**Issue Number:**
#1398

-  Closes #1398 

-  Related to #1398 

-  Others? <!-- Add any additional notes or references here -->


**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

- This change was necessary cause the previous one's used to have twitter link but new blogs got nothing down to the name of the author. So, why not make changes and help people navigate who they actually are and their experiences as most of the engineers in our organization have more than 15+ years of experience.

**Does this PR introduce a breaking change?**

No
# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x ] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).