### PR TITLE
fix: clear error message when feedback form is closed

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -63,9 +63,11 @@ export function DocsHelp({
     if (selectedVote == value) {
       setIsFormOpen(false);
       setSelectedVote(null);
+      setError('');
     } else {
       setIsFormOpen(true);
       setSelectedVote(value);
+      setError('');
     }
   };
   // Generate GitHub redirect URL
@@ -275,6 +277,7 @@ export function DocsHelp({
                         name='feedback-comment'
                         id='feedback-comment'
                         data-test='feedback-form-input'
+                        onChange={() => setError('')}
                       />
                     </div>
 


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2342 

**Video:**

<!--Add screenshots or videos wherever possible.-->
https://github.com/user-attachments/assets/72c3445c-915a-4493-a879-83ed44270db7

**If relevant, did you update the documentation?**

<!--Add link to it-->
Not applicable. 

**Summary**

In the `DocsHelp` component, submitting the feedback form with an empty textarea shows a validation error. However, if the user closes the form by toggling the same Yes/No button, the form disappears but the error message remains floating on the page. This happens because the `handleVoteClick` toggle handler never resets the error state. This PR clears the error state when the form is closed and also when the user begins typing, ensuring a clean UI at all times.

**Does this PR introduce a breaking change?**

No. The fix is minimal and only affects error state cleanup — existing validation behavior (error on empty/whitespace submission) is fully preserved.
