### PR TITLE
fix: extract text from React elements in slugifyMarkdownHeadline to fix code-wrapped heading anchors

### DIFF
--- a/lib/slugifyMarkdownHeadline.ts
+++ b/lib/slugifyMarkdownHeadline.ts
@@ -1,5 +1,14 @@
 import slugify from 'slugify';
 
+function extractTextFromNode(node: any): string {
+  if (typeof node === 'string') return node;
+  if (Array.isArray(node)) return node.map(extractTextFromNode).join('');
+  if (node && typeof node === 'object' && node.props) {
+    return extractTextFromNode(node.props.children);
+  }
+  return '';
+}
+
 export default function slugifyMarkdownHeadline(
   markdownChildren: string | any[],
 ): string {
@@ -16,11 +25,12 @@ export default function slugifyMarkdownHeadline(
     return slug || null;
   }, null);
   if (metaSlug) return metaSlug;
-
   const joinedChildren = markdownChildren
-    .filter((child) => typeof child === 'string')
-    .map((string) => string.replace(FRAGMENT_REGEX, ''))
-    .join(' ');
+    .map(extractTextFromNode)
+    .map((s) => s.replace(FRAGMENT_REGEX, ''))
+    .join(' ')
+    .trim();
+
   const slug = slugify(joinedChildren, { lower: true, trim: true });
   return slug;
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**
- Closes #2341

**Screenshots/videos:**
*(see issue #2341 for reproduction video)*

After
<img width="1716" height="730" alt="image" src="https://github.com/user-attachments/assets/870aac02-528f-420a-a18b-6f6b00bcdca5" />
<img width="1358" height="687" alt="image" src="https://github.com/user-attachments/assets/8e30c6fa-6e98-44d2-910d-12f9d9faae6b" />


**Summary**
Section headers wrapped in backticks (e.g. `` #### `Schema` ``) were rendered by `markdown-to-jsx` as React `<code>` elements, not plain strings. `slugifyMarkdownHeadline` only handled string children, so it returned `""` for these headings — causing `href="#"` in the ToC (scroll to top) and `"" === ""` matching all headings at once (all highlighted).

Added `extractTextFromNode` to recursively extract text from React elements, so `` `Schema` `` now correctly produces the slug `schema`.

**Does this PR introduce a breaking change?**
No.

# Checklist
- [ ] Read, understood, and followed the [[contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md)](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).