### PR TITLE
fix: resolve duplicate Example heading anchor

### DIFF
--- a/pages/understanding-json-schema/reference/non_json_data.md
+++ b/pages/understanding-json-schema/reference/non_json_data.md
@@ -21,7 +21,7 @@ JSON schema has a set of [keywords](../../learn/glossary#keyword) to describe an
 
 The `contentMediaType` keyword specifies the media type of the content of a string, as described in [RFC 2046](https://tools.ietf.org/html/rfc2046). The Internet Assigned Numbers Authority (IANA) has officially registered [a comprehensive list of media types](http://www.iana.org/assignments/media-types/media-types.xhtml), but the set of supported types depends on the application and operating system. Mozilla Developer Network maintains a [shorter list of media types that are important for the web](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types)
 
-### Example 
+### Example [#example-html] 
 
 The following schema specifies a string containing an HTML file using the document's default encoding.
 
@@ -56,7 +56,7 @@ There are two main scenarios:
 2. **Binary data**: Set `contentEncoding` to `base64` and encode the content using Base64. This is appropriate for binary content types such as images (`image/png`) or audio files (`audio/mpeg`).
 
 
-### Example
+### Example [#example-base64]
 
 The following schema indicates that a string contains a PNG file and is encoded using Base64:
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Issue Number:**
- Closes #2343

**Summary**
Both `### Example` headings in `non_json_data.md` slugified to the same `id="example"`, causing the TOC to always scroll to the first one and highlight both simultaneously.

Fixed by using the existing `[#fragment]` syntax to give each heading a unique ID (`#example-html` and `#example-base64`). No code changes required.

**Does this PR introduce a breaking change?**
No

# Checklist
- [x] Read, understood, and followed the [[contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md)](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).