### PR TITLE
fix: remove anchor hash

### DIFF
--- a/pages/specification.md
+++ b/pages/specification.md
@@ -75,7 +75,7 @@ The release notes discuss the changes impacting users and implementers:
     - [Draft-04 to Draft-06](../../draft-06/json-schema-release-notes)
 - JSON Hyper-Schema
     - There was no JSON Hyper-Schema draft for 2020-12 releases.
-    - [Draft-07 to 2019-09](../../draft/2019-09/release-notes#hyper-schema-vocabulary)
+    - [Draft-07 to 2019-09](../../draft/2019-09/release-notes)
     - [Draft-04 to Draft-07](../../draft-07/json-hyper-schema-release-notes)
     - [Draft-04 to Draft-06](../../draft-06/json-hyper-schema-release-notes)
 

--- a/pages/specification/json-hyper-schema/_index.md
+++ b/pages/specification/json-hyper-schema/_index.md
@@ -33,6 +33,6 @@ In essence:
 
 ### Release Notes
 
-- [Draft-07 to 2019-09](../draft/2019-09/release-notes#hyper-schema-vocabulary)
+- [Draft-07 to 2019-09](../draft/2019-09/release-notes)
 - [Draft-04 to Draft-07](../draft-07/json-hyper-schema-release-notes)
 - [Draft-04 to Draft-06](../draft-06/json-hyper-schema-release-notes)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix.

**Issue Number:**

- Closes #2333

**Screenshots/videos:**
After(navigates directly to the top of the page)
<img width="1448" height="672" alt="image" src="https://github.com/user-attachments/assets/f5f50483-aeb8-4211-90f8-51413375c3fb" />

**Summary**

The markdown links contained an anchor (`#hyper-schema-vocabulary`) that disrupted the standard scroll behavior. I removed this anchor from the affected links in both `pages/specification/json-hyper-schema/_index.md` and `pages/specification.md` so the router now correctly loads the target page at the top header.

**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the contributing guidelines.

***