### PR TITLE
fix(pages): prevent writeOnly keyword links from sticking to bottom of viewport

### DIFF
--- a/pages/understanding-json-schema/keywords/index.page.tsx
+++ b/pages/understanding-json-schema/keywords/index.page.tsx
@@ -54,7 +54,7 @@ export default function StaticMarkdownPage({ datas }: { datas: DataObject[] }) {
         Below is a list of JSON Schema keywords with links to their respective
         documentation.
       </p>
-      <div className='mt-4'>
+      <div className='mt-4 mb-4'>
         {datas
           .sort((a: DataObject, b: DataObject) => a.name.localeCompare(b.name))
           .map(


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix (fix `writeOnly` keyword to not to stick at the bottom of the page and flow naturally within the page content)

**Issue Number:**
Closes #2361


**Screenshots/videos:**

<img width="1807" height="917" alt="image" src="https://github.com/user-attachments/assets/4a2ab9f6-b750-4b4a-be0a-f72c7f5be533" />

**Summary**

The links under the `writeOnly` keyword section on the JSON Schema. Keywords reference page were visually pinned/fixed to the bottom of the viewport, overlapping the "GO BACK" / "UP NEXT" navigation buttons.

Fixed by adding `mb-4` (margin-bottom) to the keyword section wrapper div in [index.page.tsx], ensuring consistent spacing for all keyword sections, including the last one in the list.

The `writeOnly` section is the **last item** in the list. Without `mb-4`, there was no bottom margin, causing the links to appear squished right up against the GO BACK/UP NEXT buttons — making it look like they were "pinned" to the bottom.

Adding `mb-4` gave it proper spacing below, so it now looks consistent with other sections.

The links now flow naturally within the page content, consistent with other keyword sections like `unevaluatedItems` and `uniqueItems`.

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).