### PR TITLE
fix(pages): add missing code-of-conduct markdown file

### DIFF
--- a/pages/overview/code-of-conduct/_index.md
+++ b/pages/overview/code-of-conduct/_index.md
@@ -1,1 +1,194 @@
-../../../_includes/dot-github/CODE_OF_CONDUCT.md
+# JSON Schema Organizational Code of Conduct
+
+Our (The JSON Schema Organization) Code of Conduct is a combination of:
+- [The IETF BCP 54 "IETF Guidelines for Conduct" (RFC7154)](#ietf-guidelines-for-conduct)
+- [The "Contributor Covenant Code of Conduct" 2.1](#contributor-covenant-code-of-conduct)
+- [The OpenJS Foundation Code of Conduct](#the-openjs-foundation-code-of-conduct)
+
+## Applicable sections
+
+We take the whole of the Contributor Covenant Code of Conduct 2.1 as is.
+
+We reference the IETF BCP 54 "IETF Guidelines for Conduct" (RFC7154) as a guideline. We do not subscribe to its defined Reporting Transgressions of the Guidelines (Appendix A), as JSON Schema is not part of any IETF working group.
+
+We subscribe to [the OpenJS Foundation Code of Conduct](https://github.com/openjs-foundation/cross-project-council/blob/main/CODE_OF_CONDUCT.md) in full. The OpenJS Foundation Code of Conduct consists of the Contributor Covenant Code of Conduct, commitments relating to reports, and an escalation process.
+
+# IETF Guidelines for Conduct
+
+While the JSON Schema project is not formally part of the IETF, historically the project was initially published and updated as "personal drafts" through the IETF process. The project members have found the approach and assumptions defined as Guidelines for Conduct to be well informed and a good foundation of behaviour and expectations.
+
+The IETF defined BCP 54 (Best Current Practice), also assinged RFC 7154.
+Some extracts are provided which are found to be key principles.
+Please see [BCP 54/RFC 7154 document](https://www.rfc-editor.org/rfc/rfc7154.html) for full details.
+
+BCP 54 provides a set of guidelines for personal interaction in the Internet Engineering Task Force.  The guidelines recognize the diversity of IETF participants, emphasize the value of mutual respect, and stress the broad applicability of our work.
+
+The work of the IETF relies on cooperation among a diverse range of people with different ideas and communication styles.  The IETF strives, through these guidelines for conduct, to create and maintain an environment in which every person is treated with dignity, decency, and respect.
+
+We dispute ideas by using reasoned argument rather than through intimidation or personal attack.
+
+The IETF puts its emphasis on technical competence, rough consensus, and individual participation, and it needs to be open to competent input from any source.
+
+IETF participants use their best engineering judgment to find the best solution for the whole Internet, not just the best solution for any particular network, technology, vendor, or user.
+
+Some thoughts on "consensus": https://datatracker.ietf.org/doc/html/rfc7282
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[coc@json-schema.org](mailto:coc@json-schema.org).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Conflicts of Interest
+In the event of any conflict of interest, a community leader must immediately notify the other leaders, and recuse themselves if necessary.
+
+# The OpenJS Foundation Code of Conduct
+
+The OpenJS Foundation Code of Conduct is mostly formed from the Contributor Covenant Code of Conduct.
+Significantly, we copy here the defined issue escalation process.
+
+## Privacy Expectations
+
+As per Code of Conduct requirements set out by the OpenJS Foundation, recipients of reports will maintain the confidentiality with regard to the reporter of an incident.
+For the purposes of tracking between Code of Conduct review members, incidents may be tracked in a private organizational GitHub Repository.
+In addition to any Code of Conduct review team, GitHub organizational owners will have access to view details of reports by way of having full GitHub organizational admin access.
+
+## Escalation
+
+The OpenJS Foundation provides an [escalation path](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CODE_OF_CONDUCT.md#escalate-an-issue) should you feel your report has not been handled appropriately. Recipients of reports commit to participate in the defined path of escalation when required, as required by the OpenJS Foundation Code of Conduct.
+
+> The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to coc-escalation@lists.openjsf.org.
+
+## Enforcement responsabilities
+
+If a Code of Conduct report involves a community leader, that member will not participate in the investigation or any decisions related to that report. If the report involves multiple community leaders, mediation will defer to the [OpenJS Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel).
+
+For more information, refer to the full
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/tree/HEAD/proposals/approved/CODE_OF_CONDUCT).
+
+# Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix (added _index.md file to render coc correctly)

**Issue Number:**

Closes #2369 

**Screenshots/videos:**

<img width="1814" height="936" alt="image" src="https://github.com/user-attachments/assets/a3ad3052-2850-4b43-ba60-f954c47718cc" />

**If relevant, did you update the documentation?**

No

**Summary**

This PR fixes the Code of Conduct page that was failing to load due to a missing markdown file. The getStaticProps() function in `index.page.tsx` was trying to read `_index.md` which didn't exist. This PR adds the missing file with the official Code of Conduct content from the JSON Schema GitHub repository.

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).