### PR TITLE
fix(pages): broken coc panel link

### DIFF
--- a/pages/overview/code-of-conduct/_index.md
+++ b/pages/overview/code-of-conduct/_index.md
@@ -165,14 +165,14 @@ In addition to any Code of Conduct review team, GitHub organizational owners wil
 
 The OpenJS Foundation provides an [escalation path](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CODE_OF_CONDUCT.md#escalate-an-issue) should you feel your report has not been handled appropriately. Recipients of reports commit to participate in the defined path of escalation when required, as required by the OpenJS Foundation Code of Conduct.
 
-> The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to coc-escalation@lists.openjsf.org.
+> The OpenJS Foundation maintains a [Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/15910968014412c9107155d64ee3255acfe21c3e/conduct/COC_POLICY.md). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to coc-escalation@lists.openjsf.org.
 
-## Enforcement responsabilities
+## Enforcement responsibilities
 
-If a Code of Conduct report involves a community leader, that member will not participate in the investigation or any decisions related to that report. If the report involves multiple community leaders, mediation will defer to the [OpenJS Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md#code-of-conduct-panel).
+If a Code of Conduct report involves a community leader, that member will not participate in the investigation or any decisions related to that report. If the report involves multiple community leaders, mediation will defer to the [OpenJS Code of Conduct Panel (CoCP)](https://github.com/openjs-foundation/cross-project-council/blob/15910968014412c9107155d64ee3255acfe21c3e/conduct/COC_POLICY.md).
 
 For more information, refer to the full
-[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/tree/HEAD/proposals/approved/CODE_OF_CONDUCT).
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/15910968014412c9107155d64ee3255acfe21c3e/governance/GOVERNANCE.md).
 
 # Attribution
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix (added the valid urls for conduct and governance)

**Issue Number:**

Closes #2345 

**Screenshots/videos:**

<img width="1804" height="965" alt="image" src="https://github.com/user-attachments/assets/abdc088b-a37c-4db0-a3fc-f3140f2e0481" />
<img width="1823" height="960" alt="image" src="https://github.com/user-attachments/assets/c015682e-c049-4214-89ec-54a113ea198a" />


**If relevant, did you update the documentation?**

No

**Summary**

The link to the OpenJS Code of Conduct Panel (CoCP) in the Code of Conduct page was pointing to conduct/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md in the openjs-foundation/cross-project-council repository, which no longer exists and returns a 404 error. Updated the link to point to the correct existing file conduct/COC_POLICY.md which contains the relevant CoC Panel information.

Note: This fix was accidentally committed on top of a different issue's branch (fix/add-missing-coc-_index-markdown) instead of a fresh branch from main. A cherry-pick to isolate it caused a conflict since _index.md doesn't exist on main yet. The fix is included in that branch's PR and documented here separately for transparency.

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).