### PR TITLE
remove Thydux Schema Bridge from tooling data

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3380,45 +3380,6 @@
   supportedDialects:
     draft: ['2019-09', '2020-12']
 
-- name: 'Thydux Schema Bridge'
-  description: 'Thydux Schema Bridge is a conversion and validation tool designed to streamline integration between blockchain data models and standard JSON Schema dialects. It supports schema-to-code, schema validation, and schema migration tailored for DeFi and investment platforms.'
-  toolingTypes:
-    [
-      'validator',
-      'schema-to-code',
-      'util-schema-to-schema',
-      'util-draft-migration',
-      'util-format-conversion',
-    ]
-  languages: ['JavaScript', 'TypeScript', 'Python']
-  environments: ['Node.js', 'Browser (WebAssembly build planned)', 'CLI']
-  creators:
-    - name: 'Investor ab'
-      username: 'THYDUX'
-      platform: 'github'
-    - name: 'Thydux Open Source Contributors'
-      platform: 'other'
-  maintainers:
-    - name: 'Thydux Developers Team'
-      platform: 'other'
-    - name: 'Investor ab'
-      username: 'THYDUX'
-      platform: 'github'
-  license: 'MIT'
-  source: 'https://github.com/THYDUX/schema-bridge'
-  homepage: 'https://thyduxweb.com/tools/schema-bridge'
-  supportedDialects:
-    draft: ['4', '6', '7', '2019-09', '2020-12']
-    additional:
-      - name: 'Custom DeFi Schema dialect'
-        source: 'https://thyduxweb.com/docs/defi-schema'
-  toolingListingNotes: 'Currently in beta. Actively seeking contributors and validator testing feedback from the DeFi developer community.'
-  dependsOnValidators:
-    [
-      'https://github.com/ajv-validator/ajv',
-      'https://github.com/python-jsonschema/jsonschema',
-    ]
-
 - name: 'ToDiagram'
   description: 'ToDiagram is capable of accurately transforming JSON, YAML, XML and CSV into interactive diagrams where you can edit the data backwards from the visualization. Additionally, you can enable the JSON Schema validation which highlights the invalid fields in real-time, displaying the errors at the nodes.'
   toolingTypes:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Documentation fix (removing a broken tooling entry)

**Issue Number:**

- Closes #1891

**Screenshots/videos:**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

The Thydux Schema Bridge project no longer exists. Both the source repo (github.com/THYDUX/schema-bridge) and homepage (thyduxweb.com/tools/schema-bridge) return 404. This PR removes the entry from `data/tooling-data.yaml` as suggested by @Relequestual in #1891.

**Does this PR introduce a breaking change?**

No

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).