### PR TITLE
Fixed the 404 Page not found issue Fixes #2358

### DIFF
--- a/pages/draft/2020-12/index.md
+++ b/pages/draft/2020-12/index.md
@@ -13,9 +13,10 @@ next:
   url: /draft/2019-09
 ---
 
+
 ### Introduction
 
-The JSON Schema Draft 2020-12 is a comprehensive update to the previous [draft 2019-09](draft/2019-09), addressing feedback and implementation experiences. This draft introduces features to simplify creating and validating JSON schemas.
+The JSON Schema Draft 2020-12 is a comprehensive update to the previous [draft 2019-09](\2019-09), addressing feedback and implementation experiences. This draft introduces features to simplify creating and validating JSON schemas.
 
 Here's an overview of updates to Draft 2020-12;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix
**Issue Number:**
- Closes #2358
**Screenshots/videos:**
N/A - Links were resolving to incorrect URLs (`/draft/draft/2019-09/...` instead of `/draft/2019-09/...`)
**If relevant, did you update the documentation?**
N/A
**Summary**
Fixed broken navigation links in the draft pages that were causing 404 errors. The issue was caused by incorrect relative paths in markdown files.
**Does this PR introduce a breaking change?**
No