### PR TITLE
fix: sync-contributors file path mismatch

### DIFF
--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -43,14 +43,14 @@ jobs:
                 ({ login, id, avatar_url, html_url }));
               
               // Store the data in a file
-              fs.writeFileSync('data/roadmap.json', JSON.stringify(data, null, 2));
+              fs.writeFileSync('data/community-users.json', JSON.stringify(data, null, 2));
             
         - name: Commit changes
           run: |
             git config user.name "the-json-schema-bot[bot]"
             git config user.email "the-json-schema-bot[bot]@users.noreply.github.com"
             git add data/community-users.json
-            git diff --quiet && git diff --staged --quiet || (git commit -m "chore(community-users): update communit-users.json")
+            git diff --quiet && git diff --staged --quiet || (git commit -m "chore(community-users): update community-users.json")
         
         - name: Create Pull Request
           id: cpr


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #2376 


**Screenshots/videos:**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR fixes a critical bug in the sync-contributors.yml GitHub Actions workflow that has been silently failing for 14+ months. The workflow was fetching contributor data correctly but writing it to `data/roadmap.json` instead of `data/community-users.json`, then attempting to commit the unchanged `community-users.json` file. This mismatch resulted in no actual updates being made to the contributor list.

The fix involves:
1. Updating line 46 to write to the correct file path (`data/community-users.json`)
2. Fixing a typo in the commit message

This restores the weekly contributor sync functionality that should have been running since October 2024.

<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [X] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
