### PR TITLE
Add rsonschema to JSON Schema ecosystem

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -886,6 +886,29 @@
     draft: ['4', '6', '7', '2019-09', '2020-12']
   lastUpdated: '2023-02-22'
 
+- name: rsonschema
+  description: 'A high-performance JSON Schema validator for Rust and Python, designed for low-overhead and memory-efficient validation.'
+  toolingTypes: ['validator']
+  languages: ['Rust', 'Python']
+  creators:
+    - name: 'Dario Curreri'
+      username: 'dariocurr'
+      platform: 'github'
+  maintainers:
+    - name: 'Dario Curreri'
+      username: 'dariocurr'
+      platform: 'github'
+  license: 'Apache-2.0'
+  source: 'https://github.com/hiop-oss/rsonschema'
+  homepage: 'https://docs.rs/rsonschema'
+  supportedDialects:
+    draft: ['2020-12']
+  compliance:
+    config:
+      docs: 'https://github.com/hiop-oss/rsonschema'
+      instructions: 'tested against the JSON-Schema-Test-Suite'
+  lastUpdated: '2026-04-17'
+
 - name: Reactive Core Circe JSON Validator
   description: 'This is a Scala implementation of a JSON Schema validator based upon the great io.circe Library.'
   toolingTypes: ['validator']


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature — adds a new tool to the JSON Schema ecosystem listing.

**Issue Number:**

- Closes #2383

**Screenshots/videos:**

N/A

**If relevant, did you update the documentation?**

N/A — this is a data-only change to `data/tooling-data.yaml`.

**Summary**

Adds [rsonschema](https://github.com/hiop-oss/rsonschema) to the JSON Schema tooling ecosystem as a validator for Rust and Python. It is a high-performance JSON Schema validator designed for low-overhead and memory-efficient validation, supporting draft 2020-12 and tested against the JSON-Schema-Test-Suite.

**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).