### PR TITLE
Remove JSON Toolkit from the tools

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1529,21 +1529,6 @@
     draft: ['6']
   lastUpdated: '2024-05-31'
 
-- name: JSON Toolkit
-  description: 'JSON Toolkit is a swiss-army knife library for expressive JSON programming in modern C++, and it comes with various JSON Schema foundational utilities, like bundling, analyzing references, and more'
-  toolingTypes: ['util-general-processing']
-  languages: ['C++']
-  maintainers:
-    - name: 'Juan Cruz Viotti'
-      username: 'jviotti'
-      platform: 'github'
-  license: 'AGPL-3.0 and Commercial'
-  source: 'https://github.com/sourcemeta/jsontoolkit'
-  supportedDialects:
-    draft: ['0', '1', '2', '3', '4', '6', '7', '2019-09', '2020-12']
-  toolingListingNotes: 'Comes with its own JSON parser'
-  lastUpdated: '2024-10-15'
-
 - name: Blaze
   description: 'Blaze is an ultra high-performance JSON Schema validator built on the JSON Toolkit library'
   toolingTypes: ['validator']


### PR DESCRIPTION
This library is what eventually became Blaze. It doesn't exist standalone anymore.