### PR TITLE
fix: resolve hydration mismatch in img alt attribute (#2340)

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -877,150 +877,206 @@ const Home = (props: any) => {
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.octue}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.octue}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='octue'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://www.apideck.com/'
                 target='_blank'
                 rel='noreferrer'
               >
-                <img
-                  src={logos.apideck}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='The Realtime Unified API
-for Accounting integrations'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.apideck}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='The Realtime Unified API for Accounting integrations'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://rxdb.info/?utm_source=sponsor&utm_medium=json-schema&utm_campaign=json-schema'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.rxdb}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='The local Database for JavaScript Applications'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.rxdb}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='The local Database for JavaScript Applications'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://topagency.webflow.io'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.wda}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='best website design agencies'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.wda}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='best website design agencies'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://anonstories.com'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.anon}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='Instagram Story Viewer'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.anon}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='Instagram Story Viewer'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://supadata.ai/'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.supadata}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='supadata logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.supadata}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='supadata logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://dottxt.ai/'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.dottxt}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='dottxt logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.dottxt}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='dottxt logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://www.sourcemeta.com/'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.sourcemeta}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='dottxt logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.sourcemeta}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='sourcemeta logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://www.n-ix.com/'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.nix}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='n-iX logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.nix}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='n-iX logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://www.oracle.com/'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.oracle}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='Oracle logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.oracle}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='Oracle logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://spinthewheel.io/'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.spinthewheel}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='Spin the wheel logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.spinthewheel}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='Spin the wheel logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://litslink.com/'
                 target='_blank'
                 rel='noopener noreferrer'
               >
-                <img
-                  src={logos.litslink}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='Litslink logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.litslink}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='Litslink logo'
+                    />
+                  </>
+                )}
               </a>
               <a href='https://time.now/' target='_blank' rel='noreferrer'>
-                <img
-                  src={logos.timenow}
-                  className='w-24 transition-transform duration-300 hover:scale-105'
-                  alt='Time Now logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.timenow}
+                      className='w-24 transition-transform duration-300 hover:scale-105'
+                      alt='Time Now logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://www.legasset.com/'
                 target='_blank'
                 rel='noreferrer'
               >
-                <img
-                  src={logos.legasset}
-                  className='w-44 transition-transform duration-300 hover:scale-105'
-                  alt='legasset logo'
-                />
+                {isClient && (
+                  <>
+                    <img
+                      src={logos.legasset}
+                      className='w-44 transition-transform duration-300 hover:scale-105'
+                      alt='legasset logo'
+                    />
+                  </>
+                )}
               </a>
               <a
                 href='https://opencollective.com/json-schema/contribute/sponsor-10816/checkout?interval=month&amount=100&name=&legalName=&email='


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix - Resolves hydration mismatch warnings in React/Next.js

**Issue Number:**

Closes #2340

**Summary**

This PR fixes hydration mismatch warnings that occur when server-rendered and client-rendered content differs. The changes include:

- Added missing alt='octue' attribute to the octue sponsor image
- Fixed multi-line alt text on the apideck image (collapsed to single line)
- Fixed incorrect alt on sourcemeta image (was 'dottxt logo', now 'sourcemeta logo')
- Wrapped all 14 raw <img> tags in {isClient && (<>...</>)} guards to prevent server/client theme mismatch, consistent with the existing pattern used by all other <Image> components on the page

**Does this PR introduce a breaking change?**

No, this is a non-breaking bug fix that only improves hydration compatibility.

## Checklist

- [x] My changes follow the project's code style
- [x] I have updated relevant documentation
- [x] All tests pass
- [x] This PR is ready for review


<img width="1915" height="1007" alt="image" src="https://github.com/user-attachments/assets/81e0647a-6818-4ff4-bca0-3e61710fafa6" />
