### PR TITLE
Add Okyline to similar technologies

### DIFF
--- a/pages/overview/similar-technologies.md
+++ b/pages/overview/similar-technologies.md
@@ -19,6 +19,8 @@ While we think that JSON Schema has a unique value proposition, we'd like to pro
 
 * **CBOR Data Definition Language (Cddl):** While not strictly focused on constraints, Cddl allows defining the structure of CBOR data. Check out the Cddl IETF draft: [https://tools.ietf.org/html/draft-greevenbosch-appsawg-cbor-cddl-08](https://tools.ietf.org/html/draft-greevenbosch-appsawg-cbor-cddl-08) for more information.
 
+* * **Okyline:** a declarative, example-driven language that expresses both the structure and the cross-field business invariants of JSON data in a single contract, with built-in versioning and cross-schema composition. Open specification, CC BY-SA 4.0: [https://github.com/Okyline/okyline-spec](https://github.com/Okyline/okyline-spec).
+
 ## Contributing to the Community
 
 Do you know of any other relevant technologies that we should add to this list? Please submit a pull request. We encourage contributions! 


### PR DESCRIPTION
I'm the author and maintainer of Okyline, an open specification. This page invites suggestions of other technologies with similar goals, so I'm proposing to add it.

**What kind of change does this PR introduce?**
It proposed to add one entry (Okyline) to the Similar Technologies list.

**Issue Number:**
None. There's no related issue; this follows the page's invitation to submit relevant technologies via a pull request.

**Summary**
Adds Okyline to the Similar Technologies list. Okyline is an open, example-driven language for describing and validating JSON data. It expresses both the structure and the cross-field business invariants of the data in a single contract, with built-in versioning and cross-schema composition. Specification (CC BY-SA 4.0): https://github.com/Okyline/okyline-spec

Does this PR introduce a breaking change?
No.

Checklist
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).