### PR TITLE
fix: sync community meeting schedule with homepage (#2381)

### DIFF
--- a/pages/community/index.page.tsx
+++ b/pages/community/index.page.tsx
@@ -241,7 +241,7 @@ export default function CommunityPages(props: any) {
                     We hold monthly Office Hours and weekly Open Community
                     Working Meetings. Office Hours are every first Tuesday of
                     the month at 15:00 BST, and by appointment. Open Community
-                    Working Meetings are every Monday at 14:00 PT.
+                    Working Meetings are every Monday at 12:00 PT.
                   </h2>
                   <div className='mt-10 flex justify-center'>
                     <a


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix — corrected the Open Community Working Meetings schedule text on the community page to match the homepage and official Google Calendar.

**Issue Number:**
- Closes #2381


**Summary**
The community page (`/community`) displayed an incorrect Open Community Working Meetings schedule that conflicted with the homepage. Updated the text in `pages/community/index.page.tsx` to match the homepage and the official Google Calendar: "every third Monday of the month at 12:00 PT".

**Does this PR introduce a breaking change?**
No breaking changes. This is a text-only update.

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).