### PR TITLE
Add yj-schema-validator and spring-boot-config-json-schema to tooling

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -455,6 +455,37 @@
   toolingListingNotes: 'Allows auto-generation of API client libraries (SDK generation) given an OpenAPI document. JSON schema validation run when validating schemas.'
   lastUpdated: '2024-05-20'
 
+- name: spring-boot-config-json-schema
+  description: 'Spring Boot starter that generates JSON Schema from @ConfigurationProperties classes for IDE autocomplete and CI validation of application.yml and .properties files.'
+  toolingTypes: ['code-to-schema']
+  languages: ['Java']
+  maintainers:
+    - name: 'Alexander Mondshain'
+      username: 'alexmond'
+      platform: 'github'
+  license: 'Apache-2.0'
+  source: 'https://github.com/alexmond/spring-boot-config-json-schema'
+  homepage: 'https://www.alexmond.org/spring-boot-config-json-schema-starter/current/'
+  supportedDialects:
+    draft: ['2020-12']
+  lastUpdated: '2026-07-06'
+
+- name: yj-schema-validator
+  description: 'CLI to validate YAML and JSON files against a JSON Schema, with colored, JSON, and JUnit report output. Built on the networknt json-schema-validator.'
+  toolingTypes: ['validator']
+  languages: ['Java']
+  environments: ['Command Line']
+  maintainers:
+    - name: 'Alexander Mondshain'
+      username: 'alexmond'
+      platform: 'github'
+  license: 'Apache-2.0'
+  source: 'https://github.com/alexmond/yj-schema-validator'
+  homepage: 'https://www.alexmond.org/yj-schema-validator/current/'
+  supportedDialects:
+    draft: ['4', '6', '7', '2019-09', '2020-12']
+  lastUpdated: '2026-07-06'
+
 - name: '@hyperjump/json-schema'
   description: 'JSON Schema Validation, Annotation, and Bundling. Supports Draft 04, 06, 07, 2019-09, 2020-12, OpenAPI 3.0, and OpenAPI 3.1'
   toolingTypes:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A new tooling listing — adds two Java tools (a JSON Schema validator and a schema generator) to `data/tooling-data.yaml`.

**Issue Number:**

Closes #2434

**Details**

- **yj-schema-validator** — a CLI to validate YAML/JSON files against a JSON Schema, with colored, JSON, and JUnit report output. Built on the networknt json-schema-validator, so it supports drafts 4, 6, 7, 2019-09, and 2020-12.
- **spring-boot-config-json-schema** — a Spring Boot starter that generates JSON Schema (2020-12) from `@ConfigurationProperties` classes, for IDE autocomplete and CI validation of `application.yml` / `.properties`.

Both are Apache-2.0. Entries were validated locally against `data/tooling-data.schema.json` (the `validate-tooling-data` check passes).

**If relevant, did you update the documentation?**

N/A — data-only addition to the tooling listing.
