### PR TITLE
fix(homepage): prevent "Open Community Working Meetings" button text overflow on mobile/ipad

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -530,7 +530,7 @@ const Home = (props: any) => {
                     href='https://github.com/orgs/json-schema-org/discussions/35'
                     target='_blank'
                     rel='noopener noreferrer'
-                    className='max-w-[300px] w-full text-center rounded border-2 bg-primary hover:bg-blue-700 transition-all duration-300 ease-in-out text-white h-[40px] mb-4 flex items-center justify-center mx-auto dark:border-none'
+                    className='w-fit max-w-full text-center rounded border-2 bg-primary hover:bg-blue-700 transition-all duration-300 ease-in-out text-white min-h-[40px] px-4 py-2 mb-4 flex items-center justify-center mx-auto dark:border-none'
                   >
                     Open Community Working Meetings
                   </a>

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -168,7 +168,7 @@ const Home = (props: any) => {
               Build more. Break less. Empower others.
             </h1>
 
-            <h2 className='lg:leading-6 text-center text-h5mobile md:text-h5  text-white mt-4 dark:text-slate-300'>
+            <h2 className='lg:leading-6 text-center text-h5mobile md:text-h5  text-white mt-4 px-4 md:px-0 dark:text-slate-300'>
               JSON Schema enables the confident and reliable use of the JSON
               data format.
             </h2>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix (CSS-only, one line)

**Issue Number:**

- Closes #2436

**Screenshots/videos:**
Before:
<img width="651" height="945" alt="Screenshot 2026-07-12 at 12 14 47 PM" src="https://github.com/user-attachments/assets/004d4559-86f0-4c83-84b7-dde4be8d4b43" />

After:
<img width="651" height="958" alt="Screenshot 2026-07-12 at 12 13 50 PM" src="https://github.com/user-attachments/assets/ce1d014c-a12a-483c-9186-0f810f8219dc" />

Before:
<img width="771" height="831" alt="Screenshot 2026-07-12 at 12 15 54 PM" src="https://github.com/user-attachments/assets/cca5d3ce-4fc0-4925-ae93-d3844cf667df" />

After:
<img width="786" height="843" alt="Screenshot 2026-07-12 at 12 16 22 PM" src="https://github.com/user-attachments/assets/45eec0b4-5608-4b15-ac3d-fabcc76dda64" />


**If relevant, did you update the documentation?**

Not applicable — no documentation changes needed.

**Summary**

On mobile viewports, the "Open Community Working Meetings" button on the
homepage broke: its label wrapped to two lines, overflowing the fixed
`h-[40px]` height, and with no horizontal padding the text touched the
button borders.


This PR sizes the button by its content instead of hardcoding dimensions:

- `h-[40px]` → `min-h-[40px]` — desktop still renders at exactly 40px,
  but the button can grow when the label wraps
- added `px-4 py-2` — the text keeps breathing room at every width
- `max-w-[300px] w-full` → `w-fit max-w-full` — the button shrink-wraps
  to its label plus padding (the same sizing model already used by the
  equivalent button on the Community page, which does not have this bug)

The sibling "Office Hours" button is unaffected (its short label never
wraps), so it was intentionally left untouched to keep the diff minimal.

All Cypress specs pass (`yarn cypress:run:all`, 294/294).

**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
