### PR TITLE
fix: resolve broken relative links on draft and spec pages (#2358)

### DIFF
--- a/pages/draft/2020-12/index.md
+++ b/pages/draft/2020-12/index.md
@@ -15,8 +15,7 @@ next:
 
 ### Introduction
 
-The JSON Schema Draft 2020-12 is a comprehensive update to the previous [draft 2019-09](draft/2019-09), addressing feedback and implementation experiences. This draft introduces features to simplify creating and validating JSON schemas.
-
+The JSON Schema Draft 2020-12 is a comprehensive update to the previous [draft 2019-09](/draft/2019-09), addressing feedback and implementation experiences. This draft introduces features to simplify creating and validating JSON schemas.
 Here's an overview of updates to Draft 2020-12;
 
 - **Redesigned Array and Tuple Keywords**: The `items` and `additionalItems` keywords have been replaced by `prefixItems` and `items`.
@@ -61,4 +60,4 @@ _These were updated without changing functionality or meta-schemas due to a few 
 
 ### Release Notes
 
-- [Draft 2020-12 Release Notes](../draft/2020-12/release-notes)
+- [Draft 2020-12 Release Notes](/draft/2020-12/release-notes)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**
- Closes #2358


**Screenshots/videos:**

<img width="1366" height="684" alt="Screenshot (933)" src="https://github.com/user-attachments/assets/66d480e1-91a4-4fcf-8bdb-b9d65098ee82" />

<img width="1366" height="681" alt="Screenshot (934)" src="https://github.com/user-attachments/assets/e8b93ee8-d01b-4eed-8e14-e93b4afd85a2" />


**If relevant, did you update the documentation?**

N/A

**Summary**

This PR fixes a broken link on the Draft 2020-12 page that was leading to a 404 error when navigating to draft 2019-09 (`/draft/draft/2019-09`).

Changed the relative link path to a root-relative path (`/draft/2019-09`) so that the link resolves correctly.


**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).