### PR TITLE
Add json-schema-generator to tooling list

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3531,3 +3531,17 @@
   homepage: 'https://github.com/clairey-zx81/json-model'
   supportedDialects:
     draft: ['2020-12']
+- name: json-schema-generator
+  description: 'Natural language to JSON Schema 2020-12 generator. Zero-dependency, runs offline, ships with example data and validation notes.'
+  toolingTypes: ['model-to-schema']
+  languages: ['Python']
+  maintainers:
+    - name: 'XiaoqiangDev'
+      username: 'aks-666888'
+      platform: 'github'
+  license: 'MIT'
+  source: 'https://github.com/aks-666888/json-schema-generator'
+  supportedDialects:
+    draft: ['2020-12']
+  lastUpdated: '2026-08-10'
+  status: 'active'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Content / tooling addition

**Issue Number:**

- Closes #2446

**Summary**

Add json-schema-generator to the official tooling directory. It is a natural-language-to-JSON-Schema 2020-12 generator written in Python, runs offline with zero dependencies, and ships with example data and validation notes.

**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).