### PR TITLE
fix: correct broken avatar image path for Greg Dennis in blog post

### DIFF
--- a/pages/blog/posts/ietf-cooperation.md
+++ b/pages/blog/posts/ietf-cooperation.md
@@ -8,7 +8,7 @@ type: Update
 cover: /img/posts/2026/ietf-cooperation/cover.webp
 authors:
   - name: Greg Dennis
-    photo: /img/avatars/gregsdennis.jpg
+    photo: /img/avatars/gregsdennis.webp
     byline: JSON Schema Specification Editor, JSON Tooling Implementer
 ---
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix.

**Issue Number:**

Fixes #2451

**Did you add tests for your changes?**

No — this is a one-line content/data fix (an image path in frontmatter), no logic changed.

**Summary**

`pages/blog/posts/ietf-cooperation.md` referenced `photo: /img/avatars/gregsdennis.jpg`, but only a `.webp` version of that file exists in `public/img/avatars/`. Since this is currently the most recent blog post, its author photo is rendered as the hero image on `/blog` (`pages/blog/index.page.tsx`, `recentBlog[0].frontmatter.authors[0].photo`), so the broken path causes a 404 and a blank avatar circle there — confirmed both locally and on production (`https://json-schema.org/img/avatars/gregsdennis.jpg` → 404).

Fix: point to the existing `gregsdennis.webp` file instead.

**Verification**

- Ran a clean local build (`yarn install`, `yarn lint`, `yarn typecheck`, `yarn build` — all pass, matching this repo's pre-commit hook).
- Confirmed via a local `next dev` run that the avatar now loads (200 OK) and renders correctly in the `/blog` hero card, with no more 404 in the console/network tab.

**Does this PR introduce a breaking change?**

No.