### PR TITLE
Add schema-mock-gen to tooling list (offline JSON Schema to mock data generator)

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3531,3 +3531,17 @@
   homepage: 'https://github.com/clairey-zx81/json-model'
   supportedDialects:
     draft: ['2020-12']
+
+- name: 'schema-mock-gen'
+  description: 'Local offline JSON Schema to mock data generator. Single-file HTML, zero dependency, data stays on your machine, Chinese-friendly, outputs JSON/CSV/SQL.'
+  toolingTypes: ['schema-to-data']
+  languages: ['JavaScript']
+  maintainers:
+    - name: 'aks-666888'
+      username: 'aks-666888'
+      platform: 'github'
+  license: 'MIT'
+  source: 'https://github.com/aks-666888/schema-mock-gen'
+  homepage: 'https://github.com/aks-666888/schema-mock-gen'
+  supportedDialects:
+    draft: ['2020-12']


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Content / tooling addition

**Issue Number:**

- Closes #2454

**Screenshots/videos:**

![schema-mock-gen preview](https://raw.githubusercontent.com/aks-666888/schema-mock-gen/main/preview.png)

**If relevant, did you update the documentation?**

N/A — this only updates the tooling data file (no docs affected).

**Summary**

Add **schema-mock-gen** to the tooling list (`data/tooling-data.yaml`).

A local, offline JSON Schema to mock data generator — single-file HTML, zero dependency, data never leaves your machine. Chinese-friendly UI. Outputs JSON / CSV / SQL.

- Tooling type: `schema-to-data`
- License: MIT
- Language: JavaScript (no build, open in browser)
- GitHub: https://github.com/aks-666888/schema-mock-gen
- Dialect: Draft 2020-12

Entry was validated locally against `data/tooling-data.schema.json` (the `validate-tooling-data` check passes).

**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).