### PR TITLE
fix(tools): increase z-index of filters drawer and detail modal to z-…

### DIFF
--- a/pages/tools/components/SearchBar.tsx
+++ b/pages/tools/components/SearchBar.tsx
@@ -24,7 +24,7 @@ const SearchBar = ({ transform, onQueryChange }: SearchBarProps) => {
     <div className='w-full max-w-md mx-auto my-6 lg:my-auto'>
       <Input
         type='text'
-        className='dark:border-slate-900 focus:border-blue-300 dark:bg-slate-900'
+        className='dark:border-slate-700 focus:border-blue-300 dark:bg-slate-900'
         placeholder='Search'
         name='query'
         value={query}

--- a/pages/tools/components/ToolingDetailModal.tsx
+++ b/pages/tools/components/ToolingDetailModal.tsx
@@ -38,7 +38,7 @@ export default function ToolingDetailModal({
   }, [onClose]);
 
   return (
-    <div className='fixed inset-0 flex items-center justify-center z-50 overflow-x-hidden'>
+    <div className='fixed inset-0 flex items-center justify-center z-[200] overflow-x-hidden'>
       <div
         className='fixed inset-0 bg-black opacity-50'
         onClick={onClose}

--- a/pages/tools/index.page.tsx
+++ b/pages/tools/index.page.tsx
@@ -123,7 +123,7 @@ export default function ToolingPage({
       <div className='mx-auto w-full max-w-[1400px] min-h-screen flex flex-col items-center px-4 md:px-12'>
         {/* Filter Drawer */}
         <div
-          className={`fixed inset-0 z-50 flex transform transition-all duration-300 ${isSidebarOpen ? 'visible' : 'invisible pointer-events-none'}`}
+          className={`fixed inset-0 z-[200] flex transform transition-all duration-300 ${isSidebarOpen ? 'visible' : 'invisible pointer-events-none'}`}
         >
           {/* Backdrop */}
           <div


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix (UI Layout Improvement)

**Issue Number:**
- Closes #2448

**Screenshots/videos:**

<!-- Drag and drop your screenshots/videos here if you have any -->

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR resolves an issue where the Tools page's Filter Drawer and Tooling Detail Modal did not overlay other page components properly because of their low z-index (`z-50`). 

To fix this:
* Increased the container z-index class from `z-50` to `z-[200]` in both `ToolingDetailModal.tsx` and `index.page.tsx`.

These changes ensure both overlays display on top of all other elements correctly.

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).
