### PR TITLE
fix: resolve broken Figma link on GSOD 2024 blog post

### DIFF
--- a/pages/blog/posts/GSOD-docs-project-2024.md
+++ b/pages/blog/posts/GSOD-docs-project-2024.md
@@ -36,7 +36,7 @@ The main goal of JSON Schema's [documentation project](https://github.com/orgs/j
 Since May, the team ([Valeria Hernandez](https://www.linkedin.com/in/valeriahhdez/), [Blessing Ene Anyebe](https://www.linkedin.com/in/anyebe-blessing-ene-kwennb/), [Dhairya Amrish Majmudar](https://www.linkedin.com/in/dhairya-majmudar/), and [Benjamin Granados](https://www.linkedin.com/in/benjagranados/)) has been working hard to achieve these goals. On the part of documentation, we have completed the following: 
 
 - Conducted a thorough content audit
-- Mapped out the [developer experience journey](<(https://www.figma.com/board/TRjQUw33K93y8RlJMSRkJs/JSON-dev-journey?node-id=0-1&t=gYkdGtHk2sKrCQM0-0)>)
+- Mapped out the [developer experience journey](https://www.figma.com/board/TRjQUw33K93y8RlJMSRkJs/JSON-dev-journey?node-id=0-1&t=gYkdGtHk2sKrCQM0-0)
 - Implemented the [keywords page](https://json-schema.org/understanding-json-schema/keywords)
 - Restructured the [specification docs](https://github.com/json-schema-org/website/pull/823)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix


**Issue Number:**
- Closes #2458 


**Screenshots/videos:**
<img width="1354" height="684" alt="image" src="https://github.com/user-attachments/assets/9aed6ce3-4839-4f41-8f17-94ddf09bbda3" />
<img width="1366" height="687" alt="image" src="https://github.com/user-attachments/assets/4cccfc2f-33db-4feb-b151-122fcf202e9a" />


**If relevant, did you update the documentation?**
N/A


**Summary**
The "developer experience journey" Figma link on the GSOD 2024 blog post was wrapped in malformed markdown syntax `<(...)>`, causing it to resolve as a relative URL under `/blog/posts/` instead of opening the external Figma board. This resulted in a 404 error. Removed the extra wrapping so the link works correctly.


**Does this PR introduce a breaking change?**
No


# Checklist
Please ensure the following tasks are completed before submitting this pull request.
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).