### PR TITLE
docs(understanding-json-schema): remove leftover text and broken link…

### DIFF
--- a/pages/understanding-json-schema/reference/type.md
+++ b/pages/understanding-json-schema/reference/type.md
@@ -183,14 +183,6 @@ JSON Schema offers a variety of keywords to validate data against specific types
 
 Understanding these basic data types gives you a strong foundation for building more complex JSON Schemas.
 
-<!--Remove the text below from this document and add it to the overview of the reference docs-->
-Dive deeper into our reference and explore JSON Schema's flexibility for creating complex data structures:
-
-- [Value restrictions](/understanding-json-schema/reference/generic). Define precise limitations for data, ensuring accuracy and consistency. 
-- [Conditional schema validation](/understanding-json-schema/reference/conditionals). Validate schemas dynamically based on specific conditions.
-- [Schema composition](/understanding-json-schema/reference/generic). Build modular and reusable schemas, making your validation process more efficient and maintainable.
-
-By utilizing these advanced features, you can create robust and flexible JSON Schemas that meet your exact needs.
 
 ## Format[#format]
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix / Documentation update

**Issue Number:**

- Closes #2462

**Screenshots/videos:**

<img width="1470" height="813" alt="image" src="https://github.com/user-attachments/assets/76e98a2d-09c2-49ad-97da-17208490136e" />

**If relevant, did you update the documentation?**

This PR itself is a documentation cleanup.

**Summary**

This PR removes an orphaned block of text and a leftover HTML TODO comment in `pages/understanding-json-schema/reference/type.md`. As shown in the screenshot above (highlighted by the red border), this cleanup targets a leftover section near the bottom of the page.

The HTML comment (`<!--Remove the text below from this document and add it to the overview of the reference docs-->`) instructed contributors to move the text to the reference index page. That migration was actually completed a while ago (the content now lives in the `<Card>` components on `index.page.tsx`), but the original text was never deleted from `type.md` as instructed. 

Additionally, removing this leftover text resolves a broken link, as the "Schema composition" link within this orphaned block was incorrectly pointing to `/understanding-json-schema/reference/generic` instead of `composition`.

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).