### PR TITLE
Fix/missing noopener noreferrer

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Thanks to these wonderful people who contributed to this website:
 ## Connect with the JSON Schema Community
 
 <p align="left">
-  <a href="https://json-schema.org/slack" target="_blank" style="margin-right: 5px;"><img align="center" src="https://img.icons8.com/color/48/null/slack-new.png" alt="JSON Schema Slack" height="30" width="auto" /></a>
-  <a href="https://twitter.com/jsonschema" target="_blank" style="margin-right: 5px;"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="JSON Schema Twitter" height="30" width="auto" /></a>
-  <a href="https://www.linkedin.com/company/jsonschema" target="_blank" style="margin-right: 5px;"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="JSON Schema LinkedIn" height="30" width="auto" /></a>
-  <a href="https://www.youtube.com/@JSONSchemaOrgOfficial" target="_blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/youtube.svg" alt="JSON Schema YouTube" height="30" width="auto" /></a>
+  <a href="https://json-schema.org/slack" target="_blank" rel="noopener noreferrer" style="margin-right: 5px;"><img align="center" src="https://img.icons8.com/color/48/null/slack-new.png" alt="JSON Schema Slack" height="30" width="auto" /></a>
+  <a href="https://twitter.com/jsonschema" target="_blank" rel="noopener noreferrer" style="margin-right: 5px;"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/twitter.svg" alt="JSON Schema Twitter" height="30" width="auto" /></a>
+  <a href="https://www.linkedin.com/company/jsonschema" target="_blank" rel="noopener noreferrer" style="margin-right: 5px;"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="JSON Schema LinkedIn" height="30" width="auto" /></a>
+  <a href="https://www.youtube.com/@JSONSchemaOrgOfficial" target="_blank" rel="noopener noreferrer"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/youtube.svg" alt="JSON Schema YouTube" height="30" width="auto" /></a>
 </p>
 
 ## Inspired by

--- a/pages/blog/posts/applicability-json-schema-fundamentals-part-1.md
+++ b/pages/blog/posts/applicability-json-schema-fundamentals-part-1.md
@@ -136,7 +136,7 @@ Luckily, picking this up with our Schema is simple. The `additionalProperties` k
 The value of `additionalProperties` is not just a Boolean, but a Schema. This subschema value is applied to all values of the instance object that are not defined in the `properties` object in our example. You could use `additionalProperties` to allow additional properties, but constrain their values to be a String.
 
 <specialBox>
-  <p>There is a little simplification here to help us understand the concept we're looking to learn. If you want to dig a little deeper, check out our <a href="https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties" target="_blank">learning resources on `additionalProperties`</a>.</p>
+  <p>There is a little simplification here to help us understand the concept we're looking to learn. If you want to dig a little deeper, check out our <a href="https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties" target="_blank" rel="noopener noreferrer">learning resources on `additionalProperties`</a>.</p>
 </specialBox>
 
 Finally, what if we expect an Object, but are given an Array or another non-object type?
@@ -180,7 +180,7 @@ Note, `type` takes an Array of types. It may be that your instance is allowed to
 ## Validating Arrays
 
 <specialBox>
-  <p>In this introduction, we're only going to be covering how things work for JSON Schema 2020-12. If you're using a previous version, including "draft-7" or prior, you will likely benefit from digging a little deeper into the <a href="https://json-schema.org/understanding-json-schema/reference/array.html" target="_blank">learning resources for Array validation.</a></p>
+  <p>In this introduction, we're only going to be covering how things work for JSON Schema 2020-12. If you're using a previous version, including "draft-7" or prior, you will likely benefit from digging a little deeper into the <a href="https://json-schema.org/understanding-json-schema/reference/array.html" target="_blank" rel="noopener noreferrer">learning resources for Array validation.</a></p>
 </specialBox>
 
 Let's step back to our previous example data, where we were provided with an Array as opposed to an Object. Let's say our data is now only allowed to be an Array.
@@ -311,7 +311,7 @@ It looks MOSTLY correct, but notice, if all the assertions are `true`, the resul
 <div className="flex flex-wrap justify-center gap-4">
   <figure>
     <img className="max-w-xs" src="/img/posts/2022/fundamentals-part-1/tt/oneOf.webp" />
-    <figcaption className="text-center text-xs text-gray-500 mt-2">Truth Table for "oneOf" - <a href="https://www.wolframalpha.com/input?i=%28a+xor+b+xor+c%29+%26+%21+%28a+%26%26+b+%26%26+c%29" target="_blank">(a xor b xor c) & ! (a && b && c)</a></figcaption>
+    <figcaption className="text-center text-xs text-gray-500 mt-2">Truth Table for "oneOf" - <a href="https://www.wolframalpha.com/input?i=%28a+xor+b+xor+c%29+%26+%21+%28a+%26%26+b+%26%26+c%29" target="_blank" rel="noopener noreferrer">(a xor b xor c) & ! (a && b && c)</a></figcaption>
   </figure>
 </div>
 
@@ -395,9 +395,9 @@ When you apply the second subschema in `oneOf` to the instance, there are no con
 
 # Now you try
 
-We can use the same approach as before to make sure our subschemas have sufficient constraints. <a href="https://jsonschema.dev/s/Cbcss" target="_blank">Give it a try</a>, and see if you can manage to make the validation work as expected.
+We can use the same approach as before to make sure our subschemas have sufficient constraints. <a href="https://jsonschema.dev/s/Cbcss" target="_blank" rel="noopener noreferrer">Give it a try</a>, and see if you can manage to make the validation work as expected.
 
-The link is pre-loaded with your starting Schema and instance. Let me know if you get stuck via <a href="/slack" target="_blank">Slack</a> or <a href="https://www.x.com/relequestual" target="_blank">X</a>.
+The link is pre-loaded with your starting Schema and instance. Let me know if you get stuck via <a href="/slack" target="_blank" rel="noopener noreferrer">Slack</a> or <a href="https://www.x.com/relequestual" target="_blank" rel="noopener noreferrer">X</a>.
 
 # In summary
 
@@ -413,9 +413,9 @@ Applicator keywords can not only relay the assertion results from subschemas but
 
 I've really enjoyed being able to share the first of our fundamentals series with you, and I hope you find it valuable enough to come back for the next article in the series.
 
-You can find all of the example instances and schemas in the <a href="https://github.com/Relequestual/json-schema-fundamentals" target="_blank">JSON Schema Fundamentals repo</a>.
+You can find all of the example instances and schemas in the <a href="https://github.com/Relequestual/json-schema-fundamentals" target="_blank" rel="noopener noreferrer">JSON Schema Fundamentals repo</a>.
 
-All feedback is welcome. If you have questions or comments, you can find me on the <a href="/slack" target="_blank">JSON Schema Slack</a> or reach out to me on X<a href="https://www.x.com/relequestual" target="_blank">@relequestual</a>.
+All feedback is welcome. If you have questions or comments, you can find me on the <a href="/slack" target="_blank" rel="noopener noreferrer">JSON Schema Slack</a> or reach out to me on X<a href="https://www.x.com/relequestual" target="_blank" rel="noopener noreferrer">@relequestual</a>.
 
 # Useful links and further reading
 

--- a/pages/understanding-json-schema/keywords/index.page.tsx
+++ b/pages/understanding-json-schema/keywords/index.page.tsx
@@ -63,7 +63,11 @@ export default function StaticMarkdownPage({ datas }: { datas: DataObject[] }) {
                 <div key={index} className='mt-4'>
                   <div className='flex flex-row items-center gap-2'>
                     <Headline4>{data.name}</Headline4>
-                    <Link href={data.learnjsonschemalink} target='_blank'>
+                    <Link
+                      href={data.learnjsonschemalink}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
                       <Image
                         src={'/icons/external-link.svg'}
                         height={20}

--- a/pages/understanding-json-schema/reference/type.md
+++ b/pages/understanding-json-schema/reference/type.md
@@ -183,6 +183,14 @@ JSON Schema offers a variety of keywords to validate data against specific types
 
 Understanding these basic data types gives you a strong foundation for building more complex JSON Schemas.
 
+<!--Remove the text below from this document and add it to the overview of the reference docs-->
+Dive deeper into our reference and explore JSON Schema's flexibility for creating complex data structures:
+
+- [Value restrictions](/understanding-json-schema/reference/generic). Define precise limitations for data, ensuring accuracy and consistency. 
+- [Conditional schema validation](/understanding-json-schema/reference/conditionals). Validate schemas dynamically based on specific conditions.
+- [Schema composition](/understanding-json-schema/reference/generic). Build modular and reusable schemas, making your validation process more efficient and maintainable.
+
+By utilizing these advanced features, you can create robust and flexible JSON Schemas that meet your exact needs.
 
 ## Format[#format]
 

--- a/pages/understanding-json-schema/reference/type.md
+++ b/pages/understanding-json-schema/reference/type.md
@@ -183,14 +183,6 @@ JSON Schema offers a variety of keywords to validate data against specific types
 
 Understanding these basic data types gives you a strong foundation for building more complex JSON Schemas.
 
-<!--Remove the text below from this document and add it to the overview of the reference docs-->
-Dive deeper into our reference and explore JSON Schema's flexibility for creating complex data structures:
-
-- [Value restrictions](/understanding-json-schema/reference/generic). Define precise limitations for data, ensuring accuracy and consistency. 
-- [Conditional schema validation](/understanding-json-schema/reference/conditionals). Validate schemas dynamically based on specific conditions.
-- [Schema composition](/understanding-json-schema/reference/generic). Build modular and reusable schemas, making your validation process more efficient and maintainable.
-
-By utilizing these advanced features, you can create robust and flexible JSON Schemas that meet your exact needs.
 
 ## Format[#format]
 


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bugfix (Code Quality / Defense-in-depth)

**Issue Number:**

- Closes #2465


**Screenshots/videos:**

N/A (No visual UI changes, structural HTML fix only)

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR adds the missing `rel="noopener noreferrer"` attribute to 14 `target="_blank"` external links across the repository.

While modern browsers automatically apply `noopener` protections by default, explicitly including these attributes remains an industry standard defense-in-depth practice. Relying entirely on browser defaults leaves users on legacy browsers vulnerable to reverse tabnabbing, and failing to explicitly set `noreferrer` means we still leak referrer data to external sites. Adding these ensures our automated code quality and security scans remain completely clean.

These 14 instances slipped through the tooling for two specific reasons:
1. In `pages/understanding-json-schema/keywords/index.page.tsx`, a Next.js `<Link>` component was missing it. The ESLint config (`plugin:react/recommended`) only checks standard HTML `<a>` tags by default, so it silently bypassed this custom component.
2. In the `applicability-json-schema-fundamentals-part-1.md` blog post and the `README.md`, raw HTML `<a>` tags were used instead of standard markdown syntax. This bypassed the repository's `StyledMarkdownBlock` component (which normally injects the `rel` attributes automatically for markdown links). 

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).