### PR TITLE
Change "Optional" to "required" in the feedback comment field

### DIFF
--- a/components/DocsHelp.tsx
+++ b/components/DocsHelp.tsx
@@ -266,7 +266,7 @@ export function DocsHelp({
                             Let us know your Feedback
                           </span>
                           <span className='float-right text-[#7d8590] text-[14px] block'>
-                            Optional
+                            required
                           </span>
                         </label>
                       </p>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix / UI text correction.

**Issue Number:**

- Closes #2467 

**Screenshot:**
<img width="270" height="400" alt="Screenshot 2026-08-29 144108" src="https://github.com/user-attachments/assets/42ca5517-bb58-4bc8-afb3-4e138b53027c" />



**Before:**
The feedback comment field was labeled `Optional`, even though
submitting an empty comment results in a validation error.


**After:**
The label is changed to `required`.

**If relevant, did you update the documentation?**

Not applicable.


**Summary**

The "Need Help?" feedback widget displayed the comment field as
`Optional`, while the form requires a comment and shows
"Feedback comment cannot be empty" when submitted without one.

This PR changes the label from `Optional` to `required` so that
the UI is consistent with the existing validation behavior.


**Does this PR introduce a breaking change?**

No.

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).