### PR TITLE
Add schema-parity to tooling data (#2464)

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3531,3 +3531,17 @@
   homepage: 'https://github.com/clairey-zx81/json-model'
   supportedDialects:
     draft: ['2020-12']
+
+- name: 'schema-parity'
+  description: 'Checks whether a JSON Schema accepts exactly the same set of values as the runtime validator it was generated from (Zod, ArkType, Valibot, TypeBox, or any other schema-to-JSON-Schema generator), and reports every value where the two disagree. Not a linter against the JSON Schema spec — a differential check between a schema and the tool that produced it.'
+  toolingTypes: ['validator', 'util-testing']
+  languages: ['JavaScript', 'TypeScript']
+  maintainers:
+    - username: 'tamerkalla'
+      platform: 'github'
+  license: 'MIT'
+  source: 'https://github.com/tamerkalla/schema-parity'
+  homepage: 'https://www.npmjs.com/package/schema-parity'
+  supportedDialects:
+    draft: ['2020-12']
+  toolingListingNotes: 'Library, not a CLI: install it and point it at your own schema/validator pairs. Published with npm provenance attestation.'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Addition of a new tool to the JSON Schema Ecosystem registry.

**Issue Number:**

- Closes #2464

**Screenshots/videos:**

N/A (Data/registry update only)

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR adds the `schema-parity` library to `data/tooling-data.yaml`. 

`schema-parity` is a differential testing harness that checks whether a generated JSON Schema accepts exactly the same set of values as the runtime validator it was generated from (e.g. Zod, ArkType, Valibot, TypeBox, etc.) and identifies any value ranges/cases where they disagree.

**Does this PR introduce a breaking change?**

No

# Checklist

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).