### PR TITLE
fix(ui): adjust faq accordion scroll target to prevent clipping

### DIFF
--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -127,9 +127,7 @@ const Accordion: React.FC<AccordionProps> = ({ items }) => {
               className='overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down'
               data-test={`accordion-answer-${item.id}`}
             >
-              <div
-                className='px-4 pb-4 text-muted-foreground leading-relaxed'
-              >
+              <div className='px-4 pb-4 text-muted-foreground leading-relaxed'>
                 {item.answer}
               </div>
             </CollapsibleContent>

--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -56,6 +56,7 @@ const Accordion: React.FC<AccordionProps> = ({ items }) => {
           data-test={`accordion-item-${item.id}`}
         >
           <div
+            id={`${item.id}`}
             className={cn(
               'border border-border dark:border-[#bfdbfe] rounded-lg transition-colors',
               openItems.has(item.id) &&
@@ -127,7 +128,6 @@ const Accordion: React.FC<AccordionProps> = ({ items }) => {
               data-test={`accordion-answer-${item.id}`}
             >
               <div
-                id={`${item.id}`}
                 className='px-4 pb-4 text-muted-foreground leading-relaxed'
               >
                 {item.answer}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

- Closes #2473 

**Screenshots/videos:**

Before changes : 
<img width="800" height="440" alt="ScreenRecording2026-08-29at3 34 20PM-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/4dd66641-ceb7-40ee-bdb5-e4ebfa210cdd" />

After changes : 
<img width="800" height="440" alt="ScreenRecording2026-08-29at4 26 45PM-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/0cde9654-10dd-4756-aec2-ddc20b259d25" />

After changes (phone view) : 
<img width="604" height="1334" alt="ScreenRecording2026-09-01at8 56 49PM-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/8df32e0b-37e1-4596-8ce5-4c34b7040b7f" />

**If relevant, did you update the documentation?**

Not applicable

**Summary**

When expanding an FAQ item, the automatic scroll behavior currently calculates its offset by targeting the inner answer block. This causes the scroll to overshoot and clip the top of the accordion card underneath the sticky navigation bar. 

To fix this without losing the helpful scrolling behavior, this PR simply moves the HTML `id` attribute from the inner answer block up to the outer wrapper of the accordion item. This ensures the scroll calculation perfectly aligns the top of the entire question card below the header. As an added bonus, it also fixes native URL deep-linking so direct links to FAQs jump to the top of the card instead of the answer text.

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).