### PR TITLE
Modify toolingTypes to add annotation support for LateApexEarlySpeed.…

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -45,7 +45,7 @@
 
 - name: LateApexEarlySpeed.Json.Schema
   description: 'Simple and high performance json schema implementation for .Net and related json validation in .Net'
-  toolingTypes: ['validator', 'code-to-schema']
+  toolingTypes: ['validator', 'code-to-schema', 'annotations']
   languages: ['.NET']
   maintainers:
     - name: 'LateApexEarlySpeed'
@@ -56,7 +56,7 @@
   homepage: 'https://www.nuget.org/packages/Lateapexearlyspeed.Json.Schema'
   supportedDialects:
     draft: ['7', '2019-09', '2020-12']
-  lastUpdated: '2026-02-10'
+  lastUpdated: '2026-09-02'
 
 - name: f5-json-schema
   description: 'JSON schema validation'


### PR DESCRIPTION
…Json.Schema

Updated toolingTypes to include 'annotations' for LateApexEarlySpeed.Json.Schema.

**What kind of change does this PR introduce?**

lateapexearlyspeed .net [implementation ](https://github.com/lateapexearlyspeed/Lateapexearlyspeed.JsonSchema)has added annotation collection support recently and passed official annotation test suite, so I would update tooling type here about also including annotation support, thanks !

**Issue Number:**

_(No issue, just for skipping check)_ - Closes https://github.com/json-schema-org/website/issues/0