### PR TITLE
Add Schemagic in JSON Schema Ecosystem (#2461)

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -3531,3 +3531,26 @@
   homepage: 'https://github.com/clairey-zx81/json-model'
   supportedDialects:
     draft: ['2020-12']
+
+- name: 'Schemagic'
+  description: 'Schemagic is a visual JSON Schema editor with built-in payload validation and easy schema sharing.'
+  toolingTypes:
+    [
+      'editor',
+      'validator',
+      'schema-to-web-UI',
+      'documentation',
+    ]
+  languages: ['JSON', 'YAML', 'CSV']
+  creators:
+    - name: 'Vladimir Ivakin'
+      username: 'Minhir'
+      platform: 'github'
+    - name: 'Ekaterina Mozheiko'
+      username: 'EkaterinaMozheiko'
+      platform: 'github'
+  license: 'Proprietary'
+  homepage: 'https://schemagic.app/'
+  supportedDialects:
+    draft: ['2020-12']
+  toolingListingNotes: 'Editor, Validator, Schema To Web UI, Documentation'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature / Tooling data update

**Issue Number:**
- Closes #2461

**Screenshots/videos:**

N/A (data update in `data/tooling-data.yaml`)

**If relevant, did you update the documentation?**

N/A

**Summary**

Adds **Schemagic** to the JSON Schema ecosystem tooling list in `data/tooling-data.yaml` as requested in #2461.

- **Name**: Schemagic
- **Description**: Schemagic is a visual JSON Schema editor with built-in payload validation and easy schema sharing.
- **Tooling Types**: `editor`, `validator`, `schema-to-web-UI`, `documentation`
- **Languages**: JSON, YAML, CSV
- **Creators**: Vladimir Ivakin (@Minhir), Ekaterina Mozheiko (@EkaterinaMozheiko)
- **License**: Proprietary
- **Homepage**: https://schemagic.app/
- **Supported Dialects**: Draft 2020-12
- **Tooling Listing Notes**: Editor, Validator, Schema To Web UI, Documentation

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).