### PR TITLE
 Fixes #2430 Add rock_solid to JSON Schema Ecosystem

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -214,6 +214,27 @@
     draft: ['4', '6', '7']
   lastUpdated: '2023-04-04'
 
+- name: rock_solid
+  description: 'Elixir library to generate test data from JSON schema'
+  toolingTypes: ['schema-to-data']
+  languages: ['Elixir', 'Erlang']
+  environments: ['Any platform that supports Elixir']
+  dependsOnValidators: ['https://github.com/lud/jsv']
+  maintainers:
+    - name: 'Ignacio Goldchluk'
+      username: 'IgnacioGoldchluk'
+      platform: 'github'
+  license: 'MIT'
+  source: 'https://github.com/IgnacioGoldchluk/rock_solid'
+  homepage: 'https://hex.pm/packages/rock_solid'
+  supportedDialects:
+    draft: ['4', '6', '7', '2019-09', '2020-12']
+  toolingListingNotes: 'Supports draft-04 to 2020-12 and can generate data for recursive schemas, schemas with dependentSchemas, if/then/else, references to remote schemas, etc.'
+  compliance:
+    config:
+      instructions: 'Some keywords are not supported due to their dynamic nature ($dynamicAnchor, unevaluatedProperties, etc.), and a long chain of if/then/else and/or dependentSchemas can cause a branch explosion and crash the library.'
+  lastUpdated: '2026-09-03'
+
 - name: JsonXema
   description: 'A JSON Schema validator.'
   toolingTypes: ['validator']


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->
**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, etc… -->
Data addition — adds a new tool entry to the JSON Schema Ecosystem tooling directory (`data/tooling-data.yaml`).

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
- Closes #2430

**Screenshots/videos:**
<!--Add screenshots or videos wherever possible.-->
<img width="1454" height="657" alt="image" src="https://github.com/user-attachments/assets/d48239ba-7586-460e-9f1e-0d84260196d1" />


**If relevant, did you update the documentation?**
<!--Add link to it-->
N/A — this only adds a new entry to the existing tooling data file; no docs pages were changed.

**Summary**
<!-- Explain the motivation for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Adds `rock_solid`, an Elixir library for generating test data from JSON Schema, to the tooling ecosystem listing as requested in #2430. Entry includes name, description, languages (Elixir, Erlang), license, source/homepage links, supported dialects (draft-04 through 2020-12), and compliance notes on unsupported keywords (`$dynamicAnchor`, `unevaluatedProperties`) as provided by the tool's maintainer in the original issue.

Tagged the tooling type as `schema-to-data` rather than `validator`, since the tool generates data from a schema rather than validating data against one

Validated the updated YAML against `data/tooling-data.schema.json` locally using the same Ajv check the `validate-tooling-data.yml` workflow runs — passes with no errors.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No — purely additive, one new entry in an existing data file.

# Checklist
Please ensure the following tasks are completed before submitting this pull request.
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).