### PR TITLE
docs(draft-07): fix broken obsolete link leading to 404 (#2482)

### DIFF
--- a/pages/draft-07/index.md
+++ b/pages/draft-07/index.md
@@ -43,4 +43,4 @@ _These were updated without changing functionality or meta-schemas due to a few 
 - [JSON Schema Release Notes](../draft-07/json-schema-release-notes)
 - [JSON Hyper-Schema Release Notes](../draft-07/json-hyper-schema-release-notes)
 
-Note that the draft-handrews-\*-00 versions of JSON Hyper-Schema and Relative JSON Pointer had confusing bugs, and have been replaced by draft-handrews-\*-01 versions. The -00 versions may be found in the [obsolete](obsolete) directory.
+Note that the draft-handrews-\*-00 versions of JSON Hyper-Schema and Relative JSON Pointer had confusing bugs, and have been replaced by draft-handrews-\*-01 versions. The -00 versions may be found in the [Obsolete Draft 7 Documents](#obsolete-draft-7-documents) section above.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix (documentation)
**Issue Number:**
- Closes #2482
**Screenshots/videos:**
N/A (documentation link fix)
**If relevant, did you update the documentation?**
Yes, updated `pages/draft-07/index.md`.
**Summary**
On the Draft-07 page, under the **Release Notes** section, there was a note stating:
> *"The -00 versions may be found in the [obsolete](obsolete) directory."*
Clicking that link attempted to navigate to `https://json-schema.org/obsolete`, which resulted in a 404 Not Found error. 
Since the `-00` draft documents are already explicitly listed and linked directly above on the same page under the **"Obsolete Draft 7 Documents"** section, this PR updates the link to point to the in-page anchor (`#obsolete-draft-7-documents`).
**Does this PR introduce a breaking change?**
No
# Checklist
Please ensure the following tasks are completed before submitting this pull request.
- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).