### PR TITLE
feat(tooling): update JSON Schema Lint entry (#2487)

### DIFF
--- a/data/tooling-data.yaml
+++ b/data/tooling-data.yaml
@@ -1015,21 +1015,24 @@
   lastUpdated: '2022-08-31'
 
 - name: JSON Schema Lint
-  description: 'JSON Schema Lint'
+  description: 'An in-browser JSON schema linter'
   toolingTypes: ['validator']
   environments: ['Web (Online)']
   dependsOnValidators: ['https://github.com/ajv-validator/ajv']
+  creators:
+    - name: 'Nick Maynard'
+      username: 'nickcmaynard'
+      platform: 'github'
   maintainers:
     - name: 'Nick Maynard'
       username: 'nickcmaynard'
       platform: 'github'
   license: 'MIT'
   source: 'https://github.com/nickcmaynard/jsonschemalint'
-  homepage: 'http://jsonschemalint.com/'
+  homepage: 'https://jsonschemalint.com'
   supportedDialects:
-    draft: ['1', '2', '3', '4', '6', '7']
-  toolingListingNotes: 'Uses JSV for draft-03 and earlier'
-  lastUpdated: '2022-08-31'
+    draft: ['4', '6', '7', '2019-09', '2020-12']
+  lastUpdated: '2026-09-08'
 
 - name: ExtendsClass's JSON Schema Validator
   description: 'JSON Schema Validator and Generator'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Tooling data update

**Issue Number:**
- Closes #2487

**Screenshots/videos:**

N/A (data file update)

**If relevant, did you update the documentation?**

N/A

**Summary**

Updates the tooling entry for **JSON Schema Lint** (`jsonschemalint.com`) in `data/tooling-data.yaml` as requested in #2487 by the author:
- Updated description to `"An in-browser JSON schema linter"`
- Changed `toolingTypes` to `['linter']`
- Added creator `Nick Maynard`
- Updated homepage URL to `https://jsonschemalint.com`
- Updated supported dialects to `['4', '6', '7', '2019-09', '2020-12']`
- Removed obsolete note about `JSV`
- Updated `lastUpdated` date

**Does this PR introduce a breaking change?**

No

# Checklist

Please ensure the following tasks are completed before submitting this pull request.

- [x] Read, understood, and followed the [contributing guidelines](https://github.com/json-schema-org/website/blob/main/CONTRIBUTING.md).